### PR TITLE
audio: add native Rust facade on SphereDirectAudioEngine

### DIFF
--- a/apps/experimental/native/Cargo.lock
+++ b/apps/experimental/native/Cargo.lock
@@ -61,6 +61,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +519,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +943,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "command-fds"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1014,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1095,6 +1160,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen 0.72.1",
+]
+
+[[package]]
 name = "cosmic-text"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1203,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1241,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1188,6 +1305,16 @@ dependencies = [
 
 [[package]]
 name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ctor"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
@@ -1201,6 +1328,12 @@ name = "ctor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-url"
@@ -1220,7 +1353,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1525,6 +1658,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,6 +1880,7 @@ name = "futureboard_native"
 version = "0.1.0"
 dependencies = [
  "gpui",
+ "sphere-direct-audio-engine",
  "sphere_ui_components",
 ]
 
@@ -2013,7 +2153,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "ashpd 0.11.1",
  "async-task",
- "bindgen",
+ "bindgen 0.71.1",
  "blade-graphics",
  "blade-macros",
  "blade-util",
@@ -2030,7 +2170,7 @@ dependencies = [
  "core-text",
  "core-video",
  "cosmic-text",
- "ctor",
+ "ctor 0.4.3",
  "derive_more",
  "embed-resource",
  "etagere",
@@ -2165,10 +2305,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05cb8912ae17371725132d2b7eec6797a255accc95d58ee5c1134b529810f14b"
 dependencies = [
  "anyhow",
- "bindgen",
+ "bindgen 0.71.1",
  "core-foundation 0.10.0",
  "core-video",
- "ctor",
+ "ctor 0.4.3",
  "foreign-types",
  "metal",
  "objc",
@@ -2758,6 +2898,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2997,6 +3181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3348,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "napi"
+version = "2.16.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
+dependencies = [
+ "bitflags 2.11.1",
+ "ctor 0.2.9",
+ "napi-derive",
+ "napi-sys",
+ "once_cell",
+]
+
+[[package]]
+name = "napi-build"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
+
+[[package]]
+name = "napi-derive"
+version = "2.16.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cbe2585d8ac223f7d34f13701434b9d5f4eb9c332cccce8dee57ea18ab8ab0c"
+dependencies = [
+ "cfg-if",
+ "convert_case 0.6.0",
+ "napi-derive-backend",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "napi-derive-backend"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1639aaa9eeb76e91c6ae66da8ce3e89e921cd3885e99ec85f4abacae72fc91bf"
+dependencies = [
+ "convert_case 0.6.0",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "semver",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "napi-sys"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -3343,6 +3622,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,6 +3777,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4799,6 +5123,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sphere-audio-plugins"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sphere-direct-audio-engine"
+version = "0.1.0"
+dependencies = [
+ "cc",
+ "cpal",
+ "crossbeam-channel",
+ "napi",
+ "napi-build",
+ "napi-derive",
+ "parking_lot",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "sphere-audio-plugins",
+ "symphonia",
+ "windows 0.58.0",
+]
+
+[[package]]
 name = "sphere_ui_components"
 version = "0.1.0"
 dependencies = [
@@ -5044,9 +5395,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
 dependencies = [
  "lazy_static",
+ "symphonia-bundle-flac",
  "symphonia-bundle-mp3",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
  "symphonia-core",
  "symphonia-metadata",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]
@@ -5059,6 +5427,27 @@ dependencies = [
  "log",
  "symphonia-core",
  "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]
@@ -5075,6 +5464,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "symphonia-metadata"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5084,6 +5497,16 @@ dependencies = [
  "lazy_static",
  "log",
  "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -6145,11 +6568,31 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -6190,6 +6633,16 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
@@ -6197,6 +6650,19 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -6237,6 +6703,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -6251,6 +6728,17 @@ name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6323,11 +6811,30 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6346,6 +6853,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -6391,6 +6907,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6452,6 +6983,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6470,6 +7007,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6485,6 +7028,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6518,6 +7067,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6533,6 +7088,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6554,6 +7115,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6569,6 +7136,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/apps/experimental/native/Cargo.toml
+++ b/apps/experimental/native/Cargo.toml
@@ -10,3 +10,6 @@ path = "src/main.rs"
 [dependencies]
 gpui = "0.2.2"
 sphere_ui_components = { path = "../../../crates/SphereUIComponents" }
+# Native audio engine. The crate also exposes an N-API surface for Electron;
+# we only use its `native` facade from here (no NAPI calls in this binary).
+sphere-direct-audio-engine = { path = "../../../crates/SphereDirectAudioEngine" }

--- a/apps/experimental/native/src/audio_state.rs
+++ b/apps/experimental/native/src/audio_state.rs
@@ -1,0 +1,45 @@
+//! Minimal native audio engine integration.
+//!
+//! At this stage the native shell does not actually drive playback — it
+//! only proves that the Rust facade in `sphere_direct_audio_engine::native`
+//! can be instantiated and queried without touching the NAPI surface.
+//!
+//! The `NativeAudioState` is owned by `app::setup` and currently kept
+//! offline (no `start()` call) so we do not open the OS audio device
+//! before the rest of the playback path is wired up.
+
+// The crate is published with `[lib] name = "DAUx"` so the N-API output
+// is `DAUx.node`. Rust consumers import its symbols through that same
+// name — alias it locally for readability.
+use DAUx::{
+    AudioBackend, AudioEngine, EngineConfig, EngineStats, SphereAudioError,
+};
+
+pub struct NativeAudioState {
+    pub config: EngineConfig,
+    pub engine: AudioEngine,
+}
+
+impl NativeAudioState {
+    /// Build the default native audio state. Does not open the device —
+    /// call `start_if_offline` once the rest of the playback pipeline is
+    /// in place.
+    pub fn new() -> Result<Self, SphereAudioError> {
+        let config = EngineConfig {
+            backend: AudioBackend::Auto,
+            ..AudioEngine::default_config()
+        };
+        let engine = AudioEngine::new(config.clone())?;
+        Ok(Self { config, engine })
+    }
+
+    /// Polling snapshot — wired into the status-bar / inspector later.
+    pub fn stats(&self) -> EngineStats {
+        self.engine.stats()
+    }
+
+    /// Engine semver — useful for the About box.
+    pub fn version(&self) -> String {
+        self.engine.version()
+    }
+}

--- a/apps/experimental/native/src/main.rs
+++ b/apps/experimental/native/src/main.rs
@@ -1,9 +1,29 @@
 mod app;
+mod audio_state;
 mod window;
 
 use sphere_ui_components::embedded_assets::EmbeddedAssets;
 
 fn main() {
+    // Instantiate the native audio facade up front so we surface any
+    // construction errors before the GPUI shell takes over. The handle is
+    // dropped at end of `main` for now — the rest of the shell does not
+    // depend on a running stream yet.
+    match audio_state::NativeAudioState::new() {
+        Ok(state) => {
+            eprintln!(
+                "[audio] sphere-direct-audio-engine v{} ready (backend={:?}, sr={}, buf={})",
+                state.version(),
+                state.config.backend,
+                state.config.sample_rate,
+                state.config.buffer_size,
+            );
+        }
+        Err(e) => {
+            eprintln!("[audio] failed to build NativeAudioState: {e}");
+        }
+    }
+
     gpui::Application::new()
         .with_assets(EmbeddedAssets::new())
         .run(app::setup);

--- a/crates/SphereDirectAudioEngine/src/lib.rs
+++ b/crates/SphereDirectAudioEngine/src/lib.rs
@@ -26,10 +26,25 @@ mod dsp;
 pub mod engine;
 pub mod error;
 mod graph;
+pub mod native;
 pub mod recording;
 mod runtime;
 pub mod types;
 mod vst3_processor;
+
+// ── Native Rust facade ───────────────────────────────────────────────────
+//
+// Re-exports so the Rust-Native shell can write:
+//
+//     use sphere_direct_audio_engine::{AudioEngine, EngineConfig, AudioBackend, EngineStats};
+//
+// without reaching into the NAPI-flavored modules. Both this facade and
+// the `SphereDirectAudioEngine` NAPI class wrap the same `EngineInner`.
+pub use crate::error::SphereAudioError;
+pub use crate::native::{
+    AudioBackend, AudioEngine, EngineConfig, EngineStats, DEFAULT_BUFFER_SIZE,
+    DEFAULT_SAMPLE_RATE,
+};
 
 use std::sync::Arc;
 

--- a/crates/SphereDirectAudioEngine/src/native.rs
+++ b/crates/SphereDirectAudioEngine/src/native.rs
@@ -1,0 +1,204 @@
+//! Native Rust facade over [`crate::engine::EngineInner`].
+//!
+//! This module exists so the Rust-Native Futureboard Studio shell
+//! (`apps/experimental/native`) can drive the audio engine without
+//! touching any NAPI types or Node.js runtime. It is a thin wrapper —
+//! the underlying state, audio thread, and DSP code stay the same.
+//!
+//! The existing NAPI surface in [`crate::SphereDirectAudioEngine`] is
+//! untouched. Both entry points share the same `EngineInner` so a
+//! command issued through either surface sees the same realtime state.
+//!
+//! Realtime safety contract is identical to the NAPI path:
+//!   * `start` / `stop` / `open` calls run on the control thread and
+//!     take a parking-lot lock — not realtime safe, but they only run
+//!     from UI events.
+//!   * The native facade adds no allocations on the audio thread.
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use crate::backend::BackendKind;
+use crate::engine::EngineInner;
+use crate::error::SphereAudioError;
+use crate::types::JsDauxConfig;
+
+/// Default sample rate used when the caller does not specify one. Mirrors
+/// the system's "Auto" path — most backends ignore this and pick their
+/// own default anyway.
+pub const DEFAULT_SAMPLE_RATE: u32 = 48_000;
+/// Default buffer size used when the caller does not specify one.
+pub const DEFAULT_BUFFER_SIZE: u32 = 256;
+
+/// Which DAUx audio backend to drive. Mirrors [`BackendKind`] but is
+/// re-exposed under a more Rust-Native-friendly name and limited to the
+/// values the native shell currently cares about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AudioBackend {
+    /// Platform default — WASAPI Shared / CoreAudio / ALSA.
+    #[default]
+    Auto,
+    /// cpal-backed best-effort (same as `Auto` for now; explicit selector).
+    Cpal,
+    /// Windows: WASAPI Exclusive event-driven (lowest latency).
+    WasapiExclusive,
+}
+
+impl AudioBackend {
+    fn to_backend_kind(self) -> BackendKind {
+        match self {
+            AudioBackend::Auto => BackendKind::Auto,
+            AudioBackend::Cpal => BackendKind::Auto,
+            AudioBackend::WasapiExclusive => BackendKind::WasapiExclusive,
+        }
+    }
+
+    fn backend_id(self) -> &'static str {
+        self.to_backend_kind().id()
+    }
+}
+
+/// Configuration for opening the engine's audio stream.
+///
+/// `sample_rate == 0` or `buffer_size == 0` means "use the device default".
+#[derive(Debug, Clone)]
+pub struct EngineConfig {
+    pub sample_rate: u32,
+    pub buffer_size: u32,
+    pub channels: u16,
+    pub backend: AudioBackend,
+}
+
+impl Default for EngineConfig {
+    fn default() -> Self {
+        Self {
+            sample_rate: DEFAULT_SAMPLE_RATE,
+            buffer_size: DEFAULT_BUFFER_SIZE,
+            channels: 2,
+            backend: AudioBackend::Auto,
+        }
+    }
+}
+
+/// Lightweight status snapshot suitable for status-bar polling.
+#[derive(Debug, Clone, Default)]
+pub struct EngineStats {
+    pub running: bool,
+    pub stream_open: bool,
+    pub transport_playing: bool,
+    pub sample_rate: u32,
+    pub buffer_size: u32,
+    pub backend_name: String,
+    pub output_device: Option<String>,
+    pub last_error: Option<String>,
+    pub glitch_count: u64,
+    pub estimated_latency_ms: f64,
+}
+
+/// Native Rust-facing handle to the engine.
+///
+/// Wraps [`EngineInner`] in an `Arc`. Cloning the handle is cheap and
+/// shares the same underlying engine — the audio thread and any other
+/// control surfaces all see the same state.
+#[derive(Clone)]
+pub struct AudioEngine {
+    inner: Arc<EngineInner>,
+    config: EngineConfig,
+}
+
+impl AudioEngine {
+    /// The default native configuration. Equivalent to
+    /// `EngineConfig::default()`; provided as a method so call sites read
+    /// closer to the spec (`AudioEngine::default_config()`).
+    pub fn default_config() -> EngineConfig {
+        EngineConfig::default()
+    }
+
+    /// Build a new engine handle. Does **not** open or start the audio
+    /// stream — call [`AudioEngine::start`] when ready.
+    pub fn new(config: EngineConfig) -> Result<Self, SphereAudioError> {
+        Ok(Self {
+            inner: Arc::new(EngineInner::new()),
+            config,
+        })
+    }
+
+    /// Borrow the configuration the engine was created with. The active
+    /// runtime sample rate / buffer size may differ once a stream is
+    /// open — see [`AudioEngine::stats`].
+    pub fn config(&self) -> &EngineConfig {
+        &self.config
+    }
+
+    /// Engine semver string, e.g. `"0.1.0"`.
+    pub fn version(&self) -> String {
+        self.inner.get_version()
+    }
+
+    /// Open the audio stream and start it. The stream stays paused at the
+    /// transport level — use [`AudioEngine::play`] to advance the
+    /// timeline once playback work is wired up.
+    pub fn start(&mut self) -> Result<(), SphereAudioError> {
+        let daux = JsDauxConfig {
+            backend_id: self.config.backend.backend_id().to_string(),
+            output_device_id: None,
+            sample_rate: if self.config.sample_rate > 0 {
+                Some(self.config.sample_rate)
+            } else {
+                None
+            },
+            buffer_size: if self.config.buffer_size > 0 {
+                Some(self.config.buffer_size)
+            } else {
+                None
+            },
+            mmcss_priority: false,
+            safe_mode: false,
+        };
+        self.inner.open_daux(daux)?;
+        self.inner.start()
+    }
+
+    /// Stop the audio stream (closes the device, frees realtime resources).
+    pub fn stop(&mut self) -> Result<(), SphereAudioError> {
+        self.inner.stop();
+        self.inner.close_device();
+        Ok(())
+    }
+
+    /// Whether the stream is currently active.
+    pub fn is_running(&self) -> bool {
+        self.inner.get_status().running
+    }
+
+    /// Polling snapshot for status bar / diagnostics.
+    pub fn stats(&self) -> EngineStats {
+        let st = self.inner.get_status();
+        let daux = self.inner.get_daux_status();
+        EngineStats {
+            running: st.running,
+            stream_open: st.stream_open,
+            transport_playing: self.inner.shared_playing(),
+            sample_rate: st.sample_rate,
+            buffer_size: st.buffer_size,
+            backend_name: daux.backend_name,
+            output_device: daux.output_device,
+            last_error: st.last_error,
+            glitch_count: daux.glitch_count as u64,
+            estimated_latency_ms: daux.estimated_latency_ms,
+        }
+    }
+}
+
+// ── EngineInner helper accessor ──────────────────────────────────────────
+//
+// We need read access to `SharedState::playing` for the stats snapshot
+// without exposing the entire shared state. A small accessor on
+// `EngineInner` keeps the rest of the engine untouched.
+
+impl EngineInner {
+    /// Whether the transport is advancing. Used by [`AudioEngine::stats`].
+    pub fn shared_playing(&self) -> bool {
+        self.shared.playing.load(Ordering::Relaxed)
+    }
+}


### PR DESCRIPTION
Lets the Rust-Native shell drive the existing audio engine without touching the NAPI surface used by Electron. Both entry points share the same EngineInner so they observe the same realtime state.

- crates/SphereDirectAudioEngine/src/native.rs (new)
  * AudioEngine handle (Arc<EngineInner>), EngineConfig, AudioBackend, EngineStats.
  * start() opens via the existing DAUx path; stop() closes the device.
- src/lib.rs re-exports AudioEngine / EngineConfig / AudioBackend / EngineStats / SphereAudioError so callers write: use DAUx::{AudioEngine, EngineConfig, ...}
- Tiny EngineInner::shared_playing() accessor for the stats snapshot.

apps/experimental/native:
- Depend on sphere-direct-audio-engine (path) and instantiate NativeAudioState at startup. Engine is not started — only constructed and logged — so we don't open the OS device before playback wiring exists.

NAPI: untouched. SphereDirectAudioEngine class and all #[napi] methods remain available; napi_build::setup() only affects the cdylib stage so the rlib consumed by futureboard_native does not pick up Node runtime linkage. No features toggled — keeping existing defaults is safer than gating every #[napi] in this pass.

Validation:
  cargo check --manifest-path crates/SphereDirectAudioEngine/Cargo.toml
  cargo check --manifest-path apps/experimental/native/Cargo.toml
both clean.