### PR TITLE
Native MIDI: piano roll editor + engine scheduling

### DIFF
--- a/crates/SphereDirectAudioEngine/src/engine.rs
+++ b/crates/SphereDirectAudioEngine/src/engine.rs
@@ -2089,6 +2089,19 @@ where
                             );
                             runtime = next_runtime;
                             runtime.sample_rate = output_sample_rate;
+                            if crate::runtime::midi_engine_debug_enabled() {
+                                let notes: usize =
+                                    runtime.midi_clips.iter().map(|c| c.events.len() / 2).sum();
+                                eprintln!(
+                                    "[DAUx MIDI] snapshot clips={} notes={}",
+                                    runtime.midi_clips.len(),
+                                    notes
+                                );
+                            }
+                            // Position MIDI cursors for the current transport
+                            // position so a load mid-playback stays in sync.
+                            let midi_pos = shared.position_samples.load(Ordering::Relaxed);
+                            runtime.reset_midi_playback(midi_pos);
                         }
                         EngineCommand::SetTestTone { enabled, frequency } => {
                             osc_on = enabled;
@@ -2110,6 +2123,9 @@ where
                             }
                             playing_local = true;
                             shared.playing.store(true, Ordering::Relaxed);
+                            // Position MIDI cursors at the start beat and clear
+                            // any stale active notes so play-from is clean.
+                            runtime.reset_midi_playback(pos);
                         }
                         EngineCommand::StopTransport => {
                             if command_debug_enabled() {
@@ -2117,6 +2133,8 @@ where
                             }
                             playing_local = false;
                             shared.playing.store(false, Ordering::Relaxed);
+                            // Release held notes so nothing is left stuck.
+                            runtime.all_notes_off("stop");
                         }
                         EngineCommand::Seek { position_seconds } => {
                             let sr_local = shared.sample_rate.load(Ordering::Relaxed) as f64;
@@ -2129,6 +2147,8 @@ where
                             }
                             shared.position_samples.store(pos, Ordering::Relaxed);
                             metronome.reset_metronome_schedule(pos, output_sample_rate);
+                            // Re-seek MIDI cursors + flush held notes.
+                            runtime.reset_midi_playback(pos);
                         }
                         EngineCommand::SetMetronomeEnabled(enabled) => {
                             let pos = shared.position_samples.load(Ordering::Relaxed);
@@ -2189,6 +2209,14 @@ where
                 let mut frames = 0u64;
                 let base_sample = shared.position_samples.load(Ordering::Relaxed);
                 runtime.begin_meter_block();
+
+                // MIDI scheduling — once per block, path-independent. Advances
+                // each MIDI track's event cursor and emits note on/off for the
+                // block range (debug-logged; instrument routing is Phase 2B).
+                if playing_local && ch > 0 {
+                    let frames_needed = (data.len() / ch) as u64;
+                    runtime.schedule_midi_block(base_sample, frames_needed);
+                }
 
                 if ch >= 2 && playing_local {
                     let frames_needed = data.len() / ch;

--- a/crates/SphereDirectAudioEngine/src/runtime.rs
+++ b/crates/SphereDirectAudioEngine/src/runtime.rs
@@ -12,8 +12,16 @@ use crate::audio_file::{load_audio_file, AudioFileBuffer};
 use serde_json::Value;
 use sphere_audio_plugins::{canonical_plugin_id, should_rebuild_state, AudioPluginDspState};
 
-use crate::types::{EngineClipSnapshot, EngineProjectSnapshot};
+use crate::types::{EngineClipSnapshot, EngineMidiClipSnapshot, EngineProjectSnapshot};
 use crate::vst3_processor::Vst3RuntimeProcessor;
+
+/// `FUTUREBOARD_MIDI_ENGINE_DEBUG=1` enables eprintln traces for MIDI runtime
+/// build + per-block scheduling. Cached on first read so the audio callback
+/// never touches the environment.
+pub fn midi_engine_debug_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("FUTUREBOARD_MIDI_ENGINE_DEBUG").is_some())
+}
 
 #[derive(Debug, Clone)]
 pub struct RuntimeTrack {
@@ -152,12 +160,62 @@ pub struct RuntimeClip {
     pub source: Arc<AudioFileBuffer>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeMidiEventKind {
+    NoteOff,
+    NoteOn,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeMidiEvent {
+    /// Absolute project sample at which the event fires (precomputed from the
+    /// snapshot BPM at build time, mirroring how audio clips resolve to
+    /// samples — keeps scheduling deterministic and lock-free in the callback).
+    pub sample: u64,
+    /// Absolute project beat (kept for debug logging only).
+    pub beat: f64,
+    pub kind: RuntimeMidiEventKind,
+    pub pitch: u8,
+    pub velocity: u8,
+    pub channel: u8,
+    pub note_id: u64,
+}
+
+/// Structural per-clip representation, retained for logging / future reuse.
+#[derive(Debug, Clone)]
+pub struct RuntimeMidiClip {
+    pub id: String,
+    pub track_id: String,
+    pub start_beat: f64,
+    pub end_beat: f64,
+    pub events: Vec<RuntimeMidiEvent>,
+}
+
+/// Per-track merged + sorted event list with a playback cursor and active-note
+/// set. Scheduling reads `events[cursor..]` each block; `cursor` is repositioned
+/// on seek/play. `active` prevents stuck notes across stop/seek.
+#[derive(Debug, Clone, Default)]
+pub struct RuntimeMidiTrack {
+    pub track_id: String,
+    pub events: Vec<RuntimeMidiEvent>,
+    pub cursor: usize,
+    /// Currently-sounding (channel, pitch) pairs since the last NoteOn.
+    pub active: Vec<(u8, u8)>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct RuntimeProject {
     pub sample_rate: u32,
     pub tracks: Vec<RuntimeTrack>,
     pub clips: Vec<RuntimeClip>,
     pub has_solo: bool,
+    /// Samples per beat at the snapshot BPM (constant-tempo; tempo automation
+    /// is a TODO — see midi-phase2-engine-playback.md).
+    pub samples_per_beat: f64,
+    /// Structural MIDI clips (logging / inspection).
+    pub midi_clips: Vec<RuntimeMidiClip>,
+    /// Per-track scheduling state driven by the audio callback.
+    pub midi_tracks: Vec<RuntimeMidiTrack>,
 }
 
 impl RuntimeProject {
@@ -465,11 +523,138 @@ impl RuntimeProject {
             }
         }
 
+        // ── MIDI runtime build (Phase 2) ────────────────────────────────────
+        let samples_per_beat = if snapshot.bpm > 0.0 {
+            output_sample_rate as f64 * 60.0 / snapshot.bpm
+        } else {
+            0.0
+        };
+        let (midi_clips, midi_tracks) =
+            build_midi_runtime(&snapshot.midi_clips, samples_per_beat);
+
+        if midi_engine_debug_enabled() {
+            let total_events: usize = midi_clips.iter().map(|c| c.events.len()).sum();
+            for c in &midi_clips {
+                eprintln!(
+                    "[DAUx MIDI] RuntimeMidiClip id={} track={} notes={} events={} beats={:.3}..{:.3}",
+                    c.id,
+                    c.track_id,
+                    c.events.len() / 2,
+                    c.events.len(),
+                    c.start_beat,
+                    c.end_beat
+                );
+            }
+            eprintln!(
+                "[DAUx MIDI] RuntimeProject midi_clips={} midi_events={} midi_tracks={} samples_per_beat={:.2}",
+                midi_clips.len(),
+                total_events,
+                midi_tracks.len(),
+                samples_per_beat
+            );
+        }
+
         Self {
             sample_rate: output_sample_rate,
             tracks,
             clips,
             has_solo,
+            samples_per_beat,
+            midi_clips,
+            midi_tracks,
+        }
+    }
+
+    /// Reposition every MIDI track's cursor to the first event at/after
+    /// `position_sample` and clear active notes (emitting note-offs so the
+    /// destination never gets a stuck note). Called on seek / play-from.
+    pub fn reset_midi_playback(&mut self, position_sample: u64) {
+        self.all_notes_off("seek/play");
+        for mt in &mut self.midi_tracks {
+            // Binary search: first event with sample >= position.
+            mt.cursor = mt
+                .events
+                .partition_point(|ev| ev.sample < position_sample);
+        }
+        if midi_engine_debug_enabled() {
+            eprintln!(
+                "[DAUx MIDI] reset_midi_playback pos={}sa tracks={}",
+                position_sample,
+                self.midi_tracks.len()
+            );
+        }
+    }
+
+    /// Emit note-off for all active notes on every MIDI track and clear the
+    /// active set. Called on stop/seek to prevent stuck notes.
+    pub fn all_notes_off(&mut self, reason: &str) {
+        let debug = midi_engine_debug_enabled();
+        for mt in &mut self.midi_tracks {
+            if mt.active.is_empty() {
+                continue;
+            }
+            if debug {
+                eprintln!(
+                    "[DAUx MIDI] all notes off track={} active={} reason={}",
+                    mt.track_id,
+                    mt.active.len(),
+                    reason
+                );
+            }
+            // TODO (Phase 2B): forward note-off to the track's instrument insert
+            // (VST3 event input) before clearing.
+            mt.active.clear();
+        }
+    }
+
+    /// Schedule the MIDI events that fall inside `[base_sample, base_sample +
+    /// frames)`. Runs once per audio block from the callback. No heap
+    /// allocation on the steady-state path (event lists are preallocated; the
+    /// active-note Vec is reserved at build time).
+    pub fn schedule_midi_block(&mut self, base_sample: u64, frames: u64) {
+        if self.midi_tracks.is_empty() || frames == 0 {
+            return;
+        }
+        let block_end = base_sample.saturating_add(frames);
+        let debug = midi_engine_debug_enabled();
+        let spb = self.samples_per_beat.max(1.0);
+        for mt in &mut self.midi_tracks {
+            let mut scheduled = 0u32;
+            while mt.cursor < mt.events.len() && mt.events[mt.cursor].sample < block_end {
+                let ev = mt.events[mt.cursor].clone();
+                mt.cursor += 1;
+                if ev.sample < base_sample {
+                    // Stale (e.g. just after a seek landing mid-block) — still
+                    // apply active-note bookkeeping so state stays consistent.
+                    apply_active(&mut mt.active, &ev);
+                    continue;
+                }
+                let offset = (ev.sample - base_sample) as usize;
+                apply_active(&mut mt.active, &ev);
+                // TODO (Phase 2B): route `ev` to the track's instrument insert
+                // (VST3 IEventList) at `offset` samples into the block.
+                if debug {
+                    match ev.kind {
+                        RuntimeMidiEventKind::NoteOn => eprintln!(
+                            "[DAUx MIDI] note_on ch={} pitch={} vel={} offset={}",
+                            ev.channel, ev.pitch, ev.velocity, offset
+                        ),
+                        RuntimeMidiEventKind::NoteOff => eprintln!(
+                            "[DAUx MIDI] note_off ch={} pitch={} offset={}",
+                            ev.channel, ev.pitch, offset
+                        ),
+                    }
+                }
+                scheduled += 1;
+            }
+            if debug && scheduled > 0 {
+                let bs = base_sample as f64 / spb;
+                let be = block_end as f64 / spb;
+                eprintln!(
+                    "[DAUx MIDI] block beat={:.3}..{:.3} track={} events={} active={}",
+                    bs, be, mt.track_id, scheduled, mt.active.len()
+                );
+            }
         }
     }
 
@@ -613,6 +798,109 @@ impl RuntimeProject {
     }
 }
 
+/// Apply a note event to the active-note set (NoteOn inserts, NoteOff removes).
+#[inline]
+fn apply_active(active: &mut Vec<(u8, u8)>, ev: &RuntimeMidiEvent) {
+    let key = (ev.channel, ev.pitch);
+    match ev.kind {
+        RuntimeMidiEventKind::NoteOn => {
+            if !active.contains(&key) {
+                active.push(key);
+            }
+        }
+        RuntimeMidiEventKind::NoteOff => {
+            active.retain(|k| *k != key);
+        }
+    }
+}
+
+/// Convert snapshot MIDI clips into structural [`RuntimeMidiClip`]s and merged
+/// per-track [`RuntimeMidiTrack`] schedules. Note starts are clip-relative and
+/// converted to absolute project beats/samples here (outside the audio
+/// callback). Events are sorted by sample, with NoteOff before NoteOn at the
+/// same sample to avoid retrigger glitches / stuck notes.
+fn build_midi_runtime(
+    snapshot_clips: &[EngineMidiClipSnapshot],
+    samples_per_beat: f64,
+) -> (Vec<RuntimeMidiClip>, Vec<RuntimeMidiTrack>) {
+    let mut clips: Vec<RuntimeMidiClip> = Vec::with_capacity(snapshot_clips.len());
+    let mut by_track: HashMap<String, Vec<RuntimeMidiEvent>> = HashMap::new();
+
+    for clip in snapshot_clips {
+        let mut events: Vec<RuntimeMidiEvent> = Vec::with_capacity(clip.notes.len() * 2);
+        for note in &clip.notes {
+            if note.length_beats <= 0.0 {
+                continue; // skip zero/negative-length notes
+            }
+            let pitch = note.pitch.min(127);
+            let velocity = note.velocity.clamp(1, 127);
+            let channel = note.channel.min(15);
+            let abs_start = clip.start_beat + note.start_beat.max(0.0);
+            let abs_end = abs_start + note.length_beats;
+            let on_sample = (abs_start * samples_per_beat).round().max(0.0) as u64;
+            let off_sample = (abs_end * samples_per_beat).round().max(0.0) as u64;
+            events.push(RuntimeMidiEvent {
+                sample: on_sample,
+                beat: abs_start,
+                kind: RuntimeMidiEventKind::NoteOn,
+                pitch,
+                velocity,
+                channel,
+                note_id: note.id,
+            });
+            events.push(RuntimeMidiEvent {
+                sample: off_sample,
+                beat: abs_end,
+                kind: RuntimeMidiEventKind::NoteOff,
+                pitch,
+                velocity: 0,
+                channel,
+                note_id: note.id,
+            });
+        }
+        // Sort by sample; NoteOff before NoteOn at the same sample.
+        events.sort_by(|a, b| {
+            a.sample
+                .cmp(&b.sample)
+                .then((a.kind as u8).cmp(&(b.kind as u8)))
+        });
+        let end_beat = clip.start_beat + clip.length_beats.max(0.0);
+        by_track
+            .entry(clip.track_id.clone())
+            .or_default()
+            .extend(events.iter().cloned());
+        clips.push(RuntimeMidiClip {
+            id: clip.id.clone(),
+            track_id: clip.track_id.clone(),
+            start_beat: clip.start_beat,
+            end_beat,
+            events,
+        });
+    }
+
+    let mut midi_tracks: Vec<RuntimeMidiTrack> = by_track
+        .into_iter()
+        .map(|(track_id, mut events)| {
+            events.sort_by(|a, b| {
+                a.sample
+                    .cmp(&b.sample)
+                    .then((a.kind as u8).cmp(&(b.kind as u8)))
+            });
+            let mut active = Vec::new();
+            active.reserve(128); // bound growth out of the audio callback
+            RuntimeMidiTrack {
+                track_id,
+                events,
+                cursor: 0,
+                active,
+            }
+        })
+        .collect();
+    midi_tracks.sort_by(|a, b| a.track_id.cmp(&b.track_id));
+
+    (clips, midi_tracks)
+}
+
 fn build_clip_runtime(
     clip: &EngineClipSnapshot,
     source: Arc<AudioFileBuffer>,
@@ -661,4 +949,105 @@ fn f32_store(v: f32) -> u32 {
 #[inline]
 fn f32_load(v: u32) -> f32 {
     f32::from_bits(v)
+}
+
+#[cfg(test)]
+mod midi_tests {
+    use super::*;
+    use crate::types::{EngineMidiClipSnapshot, EngineMidiNoteSnapshot};
+
+    // 120 BPM @ 48 kHz → 24000 samples per beat.
+    const SPB: f64 = 24000.0;
+
+    fn clip_with_one_note() -> EngineMidiClipSnapshot {
+        EngineMidiClipSnapshot {
+            id: "mc1".into(),
+            track_id: "track-1".into(),
+            start_beat: 4.0, // bar 2 in 4/4
+            length_beats: 4.0,
+            notes: vec![EngineMidiNoteSnapshot {
+                id: 1,
+                pitch: 60, // C4
+                start_beat: 0.0,
+                length_beats: 1.0,
+                velocity: 100,
+                channel: 0,
+            }],
+        }
+    }
+
+    fn project_with(clips: Vec<EngineMidiClipSnapshot>) -> RuntimeProject {
+        let (midi_clips, midi_tracks) = build_midi_runtime(&clips, SPB);
+        RuntimeProject {
+            sample_rate: 48_000,
+            samples_per_beat: SPB,
+            midi_clips,
+            midi_tracks,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn note_resolves_to_absolute_samples_with_off_before_on() {
+        let p = project_with(vec![clip_with_one_note()]);
+        let evs = &p.midi_tracks[0].events;
+        assert_eq!(evs.len(), 2);
+        // absolute start beat = 4 + 0 = 4 → 96000 sa; end beat 5 → 120000 sa.
+        let on = evs.iter().find(|e| e.kind == RuntimeMidiEventKind::NoteOn).unwrap();
+        let off = evs.iter().find(|e| e.kind == RuntimeMidiEventKind::NoteOff).unwrap();
+        assert_eq!(on.sample, 96_000);
+        assert_eq!(off.sample, 120_000);
+        assert_eq!(on.pitch, 60);
+        assert_eq!(on.velocity, 100);
+    }
+
+    #[test]
+    fn zero_length_note_is_skipped() {
+        let mut clip = clip_with_one_note();
+        clip.notes[0].length_beats = 0.0;
+        let p = project_with(vec![clip]);
+        assert!(p.midi_tracks.is_empty() || p.midi_tracks[0].events.is_empty());
+    }
+
+    #[test]
+    fn schedule_fires_note_on_then_off_and_tracks_active() {
+        let mut p = project_with(vec![clip_with_one_note()]);
+        p.reset_midi_playback(0);
+        // Block before the note: nothing active.
+        p.schedule_midi_block(0, 512);
+        assert_eq!(p.midi_tracks[0].active.len(), 0);
+        // Block covering the NoteOn (96000).
+        p.schedule_midi_block(96_000, 512);
+        assert_eq!(p.midi_tracks[0].active, vec![(0u8, 60u8)]);
+        // Block covering the NoteOff (120000).
+        p.schedule_midi_block(120_000, 512);
+        assert!(p.midi_tracks[0].active.is_empty());
+    }
+
+    #[test]
+    fn seek_before_note_then_play_fires_it() {
+        let mut p = project_with(vec![clip_with_one_note()]);
+        p.reset_midi_playback(95_000); // just before the NoteOn
+        p.schedule_midi_block(95_000, 2048); // covers 95000..97048 → fires NoteOn
+        assert_eq!(p.midi_tracks[0].active, vec![(0u8, 60u8)]);
+    }
+
+    #[test]
+    fn seek_after_note_does_not_fire_old_note() {
+        let mut p = project_with(vec![clip_with_one_note()]);
+        p.reset_midi_playback(200_000); // well past the note
+        p.schedule_midi_block(200_000, 512);
+        assert!(p.midi_tracks[0].active.is_empty());
+        assert_eq!(p.midi_tracks[0].cursor, p.midi_tracks[0].events.len());
+    }
+
+    #[test]
+    fn all_notes_off_clears_active() {
+        let mut p = project_with(vec![clip_with_one_note()]);
+        p.reset_midi_playback(96_000);
+        p.schedule_midi_block(96_000, 512);
+        assert_eq!(p.midi_tracks[0].active.len(), 1);
+        p.all_notes_off("stop");
+        assert!(p.midi_tracks[0].active.is_empty());
+    }
 }

--- a/crates/SphereDirectAudioEngine/src/types.rs
+++ b/crates/SphereDirectAudioEngine/src/types.rs
@@ -164,7 +164,35 @@ pub struct EngineProjectSnapshot {
     pub sample_rate: u32,
     pub tracks: Vec<EngineTrackSnapshot>,
     pub clips: Vec<EngineClipSnapshot>,
+    /// MIDI clips (Phase 2). Defaulted so older snapshots without the field
+    /// still deserialize. Notes are stored relative to the clip start; the
+    /// runtime converts them to absolute project beats/samples at build time.
+    #[serde(default)]
+    pub midi_clips: Vec<EngineMidiClipSnapshot>,
     pub routing: EngineRoutingSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EngineMidiClipSnapshot {
+    pub id: String,
+    pub track_id: String,
+    pub start_beat: f64,
+    pub length_beats: f64,
+    pub notes: Vec<EngineMidiNoteSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EngineMidiNoteSnapshot {
+    pub id: u64,
+    pub pitch: u8,
+    /// Start beat relative to the clip start.
+    pub start_beat: f64,
+    pub length_beats: f64,
+    pub velocity: u8,
+    #[serde(default)]
+    pub channel: u8,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/SphereUIComponents/src/components/bottom_panel.rs
+++ b/crates/SphereUIComponents/src/components/bottom_panel.rs
@@ -326,6 +326,7 @@ pub fn bottom_panel(
     mixer_scroll_x: f32,
     mixer_viewport_width: f32,
     on_mixer_scroll: std::sync::Arc<dyn Fn(f32, &mut gpui::Window, &mut gpui::App) + 'static>,
+    editor_content: Option<gpui::AnyElement>,
     on_tab_click: impl Fn(&BottomTab, &mut Window, &mut App) + 'static,
     on_resize_start: impl Fn(&gpui::MouseDownEvent, &mut Window, &mut App) + 'static,
     on_resize_move: impl Fn(&gpui::DragMoveEvent<BottomPanelResizeDrag>, &mut Window, &mut App)
@@ -333,6 +334,7 @@ pub fn bottom_panel(
     on_resize_end: impl Fn(&gpui::MouseUpEvent, &mut Window, &mut App) + 'static,
 ) -> impl IntoElement {
     let on_tab_click = std::sync::Arc::new(on_tab_click);
+    let mut editor_content = editor_content;
     div()
         .flex()
         .flex_col()
@@ -416,7 +418,9 @@ pub fn bottom_panel(
                         on_mixer_scroll,
                     )
                     .into_any_element(),
-                    BottomTab::Editor => editor_panel().into_any_element(),
+                    BottomTab::Editor => editor_content
+                        .take()
+                        .unwrap_or_else(|| editor_panel().into_any_element()),
                     BottomTab::EffectEditor => effect_editor_panel().into_any_element(),
                 }),
         )

--- a/crates/SphereUIComponents/src/components/mod.rs
+++ b/crates/SphereUIComponents/src/components/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use mixer_window::external_mixer_debug;
 pub mod panel;
 pub mod project_switcher;
 pub mod project_wizard;
+pub mod piano_roll;
 pub mod plugin_editor_window;
 pub mod plugin_manager;
 pub mod plugin_picker;
@@ -56,6 +57,7 @@ pub use message_box_dialog::{
     MessageBoxResult, MessageBoxWindow, MESSAGE_BOX_WIDTH,
 };
 pub use mixer_panel::mixer_panel;
+pub use piano_roll::PianoRoll;
 pub use mixer_window::{open_mixer_window, MixerSnapshot, MixerWindow};
 pub use panel::right_panel;
 pub use plugin_manager::{

--- a/crates/SphereUIComponents/src/components/piano_roll.rs
+++ b/crates/SphereUIComponents/src/components/piano_roll.rs
@@ -1,0 +1,1413 @@
+//! Native GPUI Piano Roll editor.
+//!
+//! Ported from the WebUI `MidiEditorPanel`. Edits the currently selected MIDI
+//! clip in the shared [`Timeline`] entity. All note mutations go through the
+//! single-source-of-truth helpers on `TimelineState` (see
+//! `timeline_state.rs`) and mark the project dirty so the engine sync /
+//! autosave observe the change.
+//!
+//! Coordinate model (matches WebUI):
+//! - notes are stored in beats relative to the clip start
+//! - the grid maps beats → x with `ppb` (pixels per beat) and a horizontal
+//!   scroll offset; pitch → y with a fixed [`ROW_H`] and a vertical scroll
+//!
+//! Interaction state (tool, selection, zoom, snap, drag) lives on this entity
+//! — never recomputed in render. Note geometry is only built for the visible
+//! pitch/beat range each frame.
+
+use std::cell::Cell;
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use gpui::prelude::FluentBuilder;
+use gpui::{
+    canvas, div, px, Bounds, Context, Entity, FocusHandle, InteractiveElement, IntoElement,
+    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels,
+    Render, ScrollWheelEvent, StatefulInteractiveElement, Styled, Window,
+};
+
+use crate::components::timeline::timeline::Timeline;
+use crate::components::timeline::timeline_state::{MidiNoteState, MIN_NOTE_BEATS};
+use crate::theme::Colors;
+
+// ── Layout constants (CSS px) ───────────────────────────────────────────────
+const ROW_H: f32 = 14.0; // px per semitone
+const PITCH_CNT: i32 = 128;
+const TOTAL_H: f32 = PITCH_CNT as f32 * ROW_H;
+const KEY_W: f32 = 56.0; // piano key lane width
+const VEL_H: f32 = 72.0; // velocity lane height
+const RULER_H: f32 = 18.0; // bar/beat ruler header height
+const RESIZE_ZONE: f32 = 6.0; // px on the right edge that starts a resize
+
+/// Strength tier of a vertical timing gridline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GridLineKind {
+    Bar,
+    Beat,
+    Subdivision,
+}
+
+/// `true` when `beat` is (within tolerance) an integer multiple of `m`.
+#[inline]
+fn is_multiple(beat: f32, m: f32) -> bool {
+    if m <= 0.0 {
+        return false;
+    }
+    let r = (beat / m).round();
+    (beat - r * m).abs() < 1.0e-3
+}
+
+const NOTE_NAMES: [&str; 12] = [
+    "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
+];
+
+fn is_black(pitch: i32) -> bool {
+    matches!(pitch.rem_euclid(12), 1 | 3 | 6 | 8 | 10)
+}
+
+fn note_name(pitch: i32) -> String {
+    format!("{}{}", NOTE_NAMES[pitch.rem_euclid(12) as usize], pitch / 12 - 1)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PianoTool {
+    Draw,
+    Select,
+}
+
+/// Grid resolution in beats-per-step. Mirrors the WebUI dropdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GridRes {
+    Whole,
+    Half,
+    Quarter,
+    Eighth,
+    Sixteenth,
+    ThirtySecond,
+}
+
+impl GridRes {
+    fn beats(self) -> f32 {
+        match self {
+            GridRes::Whole => 4.0,
+            GridRes::Half => 2.0,
+            GridRes::Quarter => 1.0,
+            GridRes::Eighth => 0.5,
+            GridRes::Sixteenth => 0.25,
+            GridRes::ThirtySecond => 0.125,
+        }
+    }
+    fn label(self) -> &'static str {
+        match self {
+            GridRes::Whole => "1",
+            GridRes::Half => "1/2",
+            GridRes::Quarter => "1/4",
+            GridRes::Eighth => "1/8",
+            GridRes::Sixteenth => "1/16",
+            GridRes::ThirtySecond => "1/32",
+        }
+    }
+    fn cycle(self) -> Self {
+        match self {
+            GridRes::Whole => GridRes::Half,
+            GridRes::Half => GridRes::Quarter,
+            GridRes::Quarter => GridRes::Eighth,
+            GridRes::Eighth => GridRes::Sixteenth,
+            GridRes::Sixteenth => GridRes::ThirtySecond,
+            GridRes::ThirtySecond => GridRes::Whole,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum PianoDrag {
+    None,
+    /// Move the selected notes. `prev` snapshots each affected note's original
+    /// (id, start, pitch). `dx_beats` / `dpitch` are the live, snapped deltas.
+    Move {
+        start_x: f32,
+        start_y: f32,
+        prev: Vec<(u64, f32, u8)>,
+        dx_beats: f32,
+        dpitch: i32,
+    },
+    /// Resize a single note from its right edge (also used to drag-extend a
+    /// freshly drawn note). `new_dur` is the live length.
+    Resize {
+        id: u64,
+        start_x: f32,
+        prev_dur: f32,
+        new_dur: f32,
+    },
+    /// Drag a velocity bar.
+    Velocity {
+        id: u64,
+        start_y: f32,
+        orig_vel: u8,
+    },
+}
+
+pub struct PianoRoll {
+    timeline: Entity<Timeline>,
+    tool: PianoTool,
+    ppb: f32,
+    snap_on: bool,
+    grid_res: GridRes,
+    selection: HashSet<u64>,
+    scroll_x: f32,
+    scroll_y: f32,
+    drag: PianoDrag,
+    /// Whether `scroll_y` has been centred on C4 yet (done once after the grid
+    /// height is known).
+    centered: bool,
+    grid_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
+    /// Last clip the editor rendered — used to emit the `open_editor` debug log
+    /// exactly once when the edited clip changes (not every frame).
+    last_editing_clip: Option<String>,
+    focus: FocusHandle,
+}
+
+impl PianoRoll {
+    pub fn new(timeline: Entity<Timeline>, cx: &mut Context<Self>) -> Self {
+        Self {
+            timeline,
+            tool: PianoTool::Draw,
+            ppb: 80.0,
+            snap_on: true,
+            grid_res: GridRes::Sixteenth,
+            selection: HashSet::new(),
+            scroll_x: 0.0,
+            scroll_y: 0.0,
+            drag: PianoDrag::None,
+            centered: false,
+            grid_bounds: Rc::new(Cell::new(None)),
+            last_editing_clip: None,
+            focus: cx.focus_handle(),
+        }
+    }
+
+    // ── Editing target ───────────────────────────────────────────────────
+    /// The selected clip id, but only if it is a MIDI clip.
+    fn editing_clip_id(&self, cx: &Context<Self>) -> Option<String> {
+        let tl = self.timeline.read(cx);
+        let cid = tl.state.selection.selected_clip_ids.first()?.clone();
+        tl.state.midi_clip_notes(&cid).map(|_| cid)
+    }
+
+    fn step_beats(&self) -> f32 {
+        self.grid_res.beats()
+    }
+
+    fn snap_beats(&self, beats: f32) -> f32 {
+        if !self.snap_on {
+            return beats.max(0.0);
+        }
+        let step = self.step_beats();
+        if step <= 0.0 {
+            return beats.max(0.0);
+        }
+        ((beats / step).floor() * step).max(0.0)
+    }
+
+    // ── Coordinate helpers (local px → beat / pitch) ──────────────────────
+    fn x_to_beat(&self, local_x: f32) -> f32 {
+        ((local_x + self.scroll_x) / self.ppb.max(0.0001)).max(0.0)
+    }
+    fn beat_to_x(&self, beat: f32) -> f32 {
+        beat * self.ppb - self.scroll_x
+    }
+    fn y_to_pitch(&self, local_y: f32) -> u8 {
+        let row = ((local_y + self.scroll_y) / ROW_H).floor() as i32;
+        (PITCH_CNT - 1 - row).clamp(0, PITCH_CNT - 1) as u8
+    }
+    fn pitch_to_y(&self, pitch: u8) -> f32 {
+        (PITCH_CNT - 1 - pitch as i32) as f32 * ROW_H - self.scroll_y
+    }
+
+    /// Resolve the local (grid-relative) cursor position from a window-space
+    /// point using the bounds captured during paint. `None` until the first
+    /// frame has laid the grid out.
+    fn grid_local(&self, window_pos: gpui::Point<Pixels>) -> Option<(f32, f32)> {
+        let bounds = self.grid_bounds.get()?;
+        let ox: f32 = bounds.origin.x.into();
+        let oy: f32 = bounds.origin.y.into();
+        let x: f32 = window_pos.x.into();
+        let y: f32 = window_pos.y.into();
+        Some((x - ox, y - oy))
+    }
+
+    fn grid_view_size(&self) -> (f32, f32) {
+        match self.grid_bounds.get() {
+            Some(b) => (f32::from(b.size.width).max(1.0), f32::from(b.size.height).max(1.0)),
+            None => (600.0, 200.0),
+        }
+    }
+
+    fn max_scroll_y(&self) -> f32 {
+        let (_, h) = self.grid_view_size();
+        (TOTAL_H - h).max(0.0)
+    }
+
+    // ── Mutations through the timeline ────────────────────────────────────
+    fn with_timeline<R>(
+        &mut self,
+        cx: &mut Context<Self>,
+        f: impl FnOnce(&mut Timeline, &mut Context<Timeline>) -> R,
+    ) -> R {
+        self.timeline.update(cx, |tl, tcx| {
+            let r = f(tl, tcx);
+            tl.mark_project_changed(tcx);
+            tcx.notify();
+            r
+        })
+    }
+
+    /// Mutate the timeline for a *live* gesture (drag in progress): repaint but
+    /// do NOT mark the project dirty, so we don't rebuild the engine snapshot on
+    /// every mouse-move. The owning gesture marks dirty once on release.
+    fn with_timeline_silent<R>(
+        &mut self,
+        cx: &mut Context<Self>,
+        f: impl FnOnce(&mut Timeline, &mut Context<Timeline>) -> R,
+    ) -> R {
+        self.timeline.update(cx, |tl, tcx| {
+            let r = f(tl, tcx);
+            tcx.notify();
+            r
+        })
+    }
+
+    fn mark_project_dirty(&mut self, cx: &mut Context<Self>) {
+        self.timeline.update(cx, |tl, tcx| tl.mark_project_changed(tcx));
+    }
+
+    // ── Mouse handlers ─────────────────────────────────────────────────────
+    // Notes are interactive elements that handle their own select/move/resize/
+    // delete (and stop propagation), so the grid surface only deals with empty
+    // space: create a note (Draw tool) or clear the selection (Select tool).
+    fn on_grid_down(&mut self, event: &MouseDownEvent, window: &mut Window, cx: &mut Context<Self>) {
+        window.focus(&self.focus);
+        let Some((lx, ly)) = self.grid_local(event.position) else {
+            // Bounds not captured yet (first frame) — ignore to avoid creating
+            // a note at the wrong coordinate.
+            return;
+        };
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        if self.tool == PianoTool::Draw {
+            let pitch = self.y_to_pitch(ly);
+            let start = self.snap_beats(self.x_to_beat(lx));
+            let dur = self.step_beats().max(MIN_NOTE_BEATS);
+            let new_id = self.with_timeline(cx, |tl, _| {
+                tl.state.add_midi_note(&clip_id, pitch, start, dur, 100)
+            });
+            if let Some(id) = new_id {
+                self.selection = HashSet::from([id]);
+                // Drag right to extend the freshly drawn note.
+                self.drag = PianoDrag::Resize {
+                    id,
+                    start_x: event.position.x.into(),
+                    prev_dur: dur,
+                    new_dur: dur,
+                };
+            }
+            cx.notify();
+        } else if !self.selection.is_empty() {
+            self.selection.clear();
+            cx.notify();
+        }
+    }
+
+    /// Note body mouse-down: (multi-)select and begin a move drag.
+    fn note_mouse_down(
+        &mut self,
+        id: u64,
+        event: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.focus(&self.focus);
+        let shift = event.modifiers.shift;
+        let ctrl = event.modifiers.control || event.modifiers.platform;
+        if shift || ctrl {
+            // Toggle this note in/out of the selection — no drag.
+            if self.selection.contains(&id) {
+                self.selection.remove(&id);
+            } else {
+                self.selection.insert(id);
+            }
+            cx.notify();
+            return;
+        }
+        if !self.selection.contains(&id) {
+            self.selection = HashSet::from([id]);
+        }
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let prev = self.snapshot_selection(cx, &clip_id);
+        self.drag = PianoDrag::Move {
+            start_x: event.position.x.into(),
+            start_y: event.position.y.into(),
+            prev,
+            dx_beats: 0.0,
+            dpitch: 0,
+        };
+        cx.notify();
+    }
+
+    /// Right-edge handle mouse-down: begin a resize drag.
+    fn begin_resize_drag(
+        &mut self,
+        id: u64,
+        event: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.focus(&self.focus);
+        self.selection = HashSet::from([id]);
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let prev_dur = self
+            .timeline
+            .read(cx)
+            .state
+            .midi_clip_notes(&clip_id)
+            .and_then(|notes| notes.iter().find(|n| n.id == id))
+            .map(|n| n.duration)
+            .unwrap_or_else(|| self.step_beats());
+        self.drag = PianoDrag::Resize {
+            id,
+            start_x: event.position.x.into(),
+            prev_dur,
+            new_dur: prev_dur,
+        };
+        cx.notify();
+    }
+
+    /// Right-click a note: delete it (or the whole selection if part of one).
+    fn note_right_down(&mut self, id: u64, cx: &mut Context<Self>) {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let ids: Vec<u64> = if self.selection.contains(&id) && self.selection.len() > 1 {
+            self.selection.iter().copied().collect()
+        } else {
+            vec![id]
+        };
+        self.with_timeline(cx, |tl, _| {
+            tl.state.delete_midi_notes(&clip_id, &ids);
+        });
+        self.selection.clear();
+        cx.notify();
+    }
+
+    /// Velocity bar mouse-down: begin a velocity drag.
+    fn begin_velocity_drag(
+        &mut self,
+        id: u64,
+        orig_vel: u8,
+        event: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.focus(&self.focus);
+        self.selection = HashSet::from([id]);
+        self.drag = PianoDrag::Velocity {
+            id,
+            start_y: event.position.y.into(),
+            orig_vel,
+        };
+        cx.notify();
+    }
+
+    fn snapshot_selection(&self, cx: &Context<Self>, clip_id: &str) -> Vec<(u64, f32, u8)> {
+        let tl = self.timeline.read(cx);
+        tl.state
+            .midi_clip_notes(clip_id)
+            .map(|notes| {
+                notes
+                    .iter()
+                    .filter(|n| self.selection.contains(&n.id))
+                    .map(|n| (n.id, n.start, n.pitch))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn on_move(&mut self, event: &MouseMoveEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        if event.pressed_button != Some(MouseButton::Left) {
+            return;
+        }
+        match &mut self.drag {
+            PianoDrag::None => {}
+            PianoDrag::Move {
+                start_x,
+                start_y,
+                dx_beats,
+                dpitch,
+                ..
+            } => {
+                let cur_x: f32 = event.position.x.into();
+                let cur_y: f32 = event.position.y.into();
+                // Store the raw beat delta; snapping is applied per-note against
+                // each note's absolute start in `display_note` / commit.
+                *dx_beats = (cur_x - *start_x) / self.ppb.max(0.0001);
+                *dpitch = -(((cur_y - *start_y) / ROW_H).round() as i32);
+                cx.notify();
+            }
+            PianoDrag::Resize {
+                start_x,
+                prev_dur,
+                new_dur,
+                ..
+            } => {
+                let cur_x: f32 = event.position.x.into();
+                let mut d = (*prev_dur + (cur_x - *start_x) / self.ppb.max(0.0001)).max(MIN_NOTE_BEATS);
+                if self.snap_on {
+                    let step = self.grid_res.beats();
+                    d = ((d / step).round() * step).max(MIN_NOTE_BEATS);
+                }
+                *new_dur = d;
+                cx.notify();
+            }
+            PianoDrag::Velocity {
+                id,
+                start_y,
+                orig_vel,
+            } => {
+                let cur_y: f32 = event.position.y.into();
+                let delta = (*start_y - cur_y).round() as i32;
+                let new_vel = (*orig_vel as i32 + delta).clamp(1, 127) as u8;
+                let id = *id;
+                if let Some(clip_id) = self.editing_clip_id(cx) {
+                    self.with_timeline_silent(cx, |tl, _| {
+                        tl.state.set_midi_note_velocity(&clip_id, id, new_vel);
+                    });
+                }
+            }
+        }
+    }
+
+    fn on_up(&mut self, _event: &MouseUpEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        let drag = std::mem::replace(&mut self.drag, PianoDrag::None);
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        match drag {
+            PianoDrag::None => return,
+            PianoDrag::Move {
+                prev,
+                dx_beats,
+                dpitch,
+                ..
+            } => {
+                if dx_beats.abs() < 0.0001 && dpitch == 0 {
+                    return;
+                }
+                let updates: Vec<(u64, f32, u8)> = prev
+                    .iter()
+                    .map(|(id, start, pitch)| {
+                        let new_start = self.snap_beats(*start + dx_beats);
+                        let new_pitch = (*pitch as i32 + dpitch).clamp(0, 127) as u8;
+                        (*id, new_start, new_pitch)
+                    })
+                    .collect();
+                // Skip a commit (and the dirty flag) if snapping landed every
+                // note back on its original position.
+                let changed = updates.iter().zip(prev.iter()).any(|((_, ns, np), (_, os, op))| {
+                    (ns - os).abs() > 1e-4 || np != op
+                });
+                if !changed {
+                    return;
+                }
+                self.with_timeline(cx, |tl, _| tl.state.move_midi_notes(&clip_id, &updates));
+            }
+            PianoDrag::Resize { id, new_dur, prev_dur, .. } => {
+                if (new_dur - prev_dur).abs() < 0.0001 {
+                    return;
+                }
+                self.with_timeline(cx, |tl, _| tl.state.resize_midi_note(&clip_id, id, new_dur));
+            }
+            PianoDrag::Velocity { .. } => {
+                // Velocity was applied live (silent). Mark dirty once now so
+                // the change is saved / synced.
+                self.mark_project_dirty(cx);
+            }
+        }
+    }
+
+    fn on_key(&mut self, event: &KeyDownEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let key = event.keystroke.key.as_str();
+        let ctrl = event.keystroke.modifiers.control || event.keystroke.modifiers.platform;
+        match key {
+            "delete" | "backspace" if !self.selection.is_empty() => {
+                // Stop the key from bubbling to the layout shortcut dispatcher,
+                // which would otherwise run `edit:delete` and remove the whole
+                // MIDI clip on top of deleting the notes.
+                cx.stop_propagation();
+                let ids: Vec<u64> = self.selection.iter().copied().collect();
+                self.with_timeline(cx, |tl, _| {
+                    tl.state.delete_midi_notes(&clip_id, &ids);
+                });
+                self.selection.clear();
+            }
+            "a" if ctrl => {
+                cx.stop_propagation();
+                let all: Vec<u64> = self
+                    .timeline
+                    .read(cx)
+                    .state
+                    .midi_clip_notes(&clip_id)
+                    .map(|notes| notes.iter().map(|n| n.id).collect())
+                    .unwrap_or_default();
+                self.selection = all.into_iter().collect();
+                cx.notify();
+            }
+            "escape" => {
+                cx.stop_propagation();
+                self.drag = PianoDrag::None;
+                self.selection.clear();
+                cx.notify();
+            }
+            _ => {}
+        }
+    }
+
+    fn quantize_selection(&mut self, cx: &mut Context<Self>) {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let ids: Vec<u64> = self.selection.iter().copied().collect();
+        let step = self.grid_res.beats();
+        self.with_timeline(cx, |tl, _| {
+            tl.state.quantize_midi_notes(&clip_id, &ids, step);
+        });
+    }
+
+    fn delete_selection(&mut self, cx: &mut Context<Self>) {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        if self.selection.is_empty() {
+            return;
+        }
+        let ids: Vec<u64> = self.selection.iter().copied().collect();
+        self.with_timeline(cx, |tl, _| {
+            tl.state.delete_midi_notes(&clip_id, &ids);
+        });
+        self.selection.clear();
+    }
+
+    fn on_wheel(&mut self, event: &ScrollWheelEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        let (dx, dy) = match event.delta {
+            gpui::ScrollDelta::Pixels(p) => (f32::from(p.x), f32::from(p.y)),
+            gpui::ScrollDelta::Lines(p) => (p.x * 36.0, p.y * 36.0),
+        };
+        if event.modifiers.control || event.modifiers.platform {
+            // Zoom horizontal.
+            let factor = (1.0015_f32).powf(-dy);
+            self.ppb = (self.ppb * factor).clamp(20.0, 400.0);
+        } else if event.modifiers.shift {
+            self.scroll_x = (self.scroll_x - dy - dx).max(0.0);
+        } else {
+            self.scroll_y = (self.scroll_y - dy).clamp(0.0, self.max_scroll_y());
+            self.scroll_x = (self.scroll_x - dx).max(0.0);
+        }
+        cx.notify();
+    }
+}
+
+// ── Live display geometry during a drag ─────────────────────────────────────
+struct DisplayNote {
+    id: u64,
+    pitch: u8,
+    start: f32,
+    duration: f32,
+    velocity: u8,
+}
+
+impl PianoRoll {
+    fn display_note(&self, n: &MidiNoteState) -> DisplayNote {
+        let mut start = n.start;
+        let mut pitch = n.pitch;
+        let mut duration = n.duration;
+        match &self.drag {
+            PianoDrag::Move {
+                prev,
+                dx_beats,
+                dpitch,
+                ..
+            } => {
+                if prev.iter().any(|(id, _, _)| *id == n.id) {
+                    // Snap the absolute resulting start (WebUI semantics), not
+                    // the raw delta, so notes always land on the grid.
+                    start = self.snap_beats(n.start + dx_beats);
+                    pitch = (n.pitch as i32 + dpitch).clamp(0, 127) as u8;
+                }
+            }
+            PianoDrag::Resize { id, new_dur, .. } if *id == n.id => {
+                duration = *new_dur;
+            }
+            _ => {}
+        }
+        DisplayNote {
+            id: n.id,
+            pitch,
+            start,
+            duration,
+            velocity: n.velocity,
+        }
+    }
+}
+
+impl Render for PianoRoll {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let clip_id = self.editing_clip_id(cx);
+
+        // Emit the open_editor log once when the edited clip changes (PART C).
+        if clip_id != self.last_editing_clip {
+            if std::env::var_os("FUTUREBOARD_MIDI_DEBUG").is_some() {
+                if let Some(cid) = clip_id.as_deref() {
+                    let tl = self.timeline.read(cx);
+                    let track_id = tl
+                        .state
+                        .tracks
+                        .iter()
+                        .find(|t| t.clips.iter().any(|c| c.id == cid))
+                        .map(|t| t.id.as_str())
+                        .unwrap_or("<none>");
+                    let notes = tl.state.midi_clip_notes(cid).map(|n| n.len()).unwrap_or(0);
+                    eprintln!(
+                        "[Native MIDI] open_editor clip_id={} track_id={} notes={}",
+                        cid, track_id, notes
+                    );
+                }
+            }
+            self.last_editing_clip = clip_id.clone();
+        }
+
+        // Toolbar is always shown; the body shows a hint when no MIDI clip is
+        // selected.
+        let toolbar = self.render_toolbar(cx, clip_id.as_deref());
+
+        let body: gpui::AnyElement = match clip_id {
+            Some(cid) => self.render_body(cx, &cid).into_any_element(),
+            None => div()
+                .flex_1()
+                .flex()
+                .items_center()
+                .justify_center()
+                .text_size(px(11.0))
+                .text_color(Colors::text_muted())
+                .child("Select or double-click a MIDI clip to edit")
+                .into_any_element(),
+        };
+
+        div()
+            .key_context("PianoRoll")
+            .track_focus(&self.focus)
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(Colors::surface_base())
+            .on_key_down(cx.listener(Self::on_key))
+            .on_mouse_move(cx.listener(Self::on_move))
+            .on_mouse_up(MouseButton::Left, cx.listener(Self::on_up))
+            .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_up))
+            .on_scroll_wheel(cx.listener(Self::on_wheel))
+            .child(toolbar)
+            .child(body)
+    }
+}
+
+impl PianoRoll {
+    fn render_toolbar(&self, cx: &mut Context<Self>, clip_id: Option<&str>) -> impl IntoElement {
+        let note_count = clip_id
+            .and_then(|cid| self.timeline.read(cx).state.midi_clip_notes(cid).map(|n| n.len()))
+            .unwrap_or(0);
+        let sel_count = self.selection.len();
+        let tool = self.tool;
+        let snap_on = self.snap_on;
+        let grid_label = self.grid_res.label();
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(6.0))
+            .h(px(30.0))
+            .px(px(8.0))
+            .border_b(px(1.0))
+            .border_color(Colors::panel_border())
+            .bg(Colors::surface_panel())
+            .child(tool_btn(
+                "pr-draw",
+                "Draw",
+                tool == PianoTool::Draw,
+                cx.listener(|this, _, _w, cx| {
+                    this.tool = PianoTool::Draw;
+                    cx.notify();
+                }),
+            ))
+            .child(tool_btn(
+                "pr-select",
+                "Select",
+                tool == PianoTool::Select,
+                cx.listener(|this, _, _w, cx| {
+                    this.tool = PianoTool::Select;
+                    cx.notify();
+                }),
+            ))
+            .child(divider())
+            .child(tool_btn(
+                "pr-snap",
+                "Snap",
+                snap_on,
+                cx.listener(|this, _, _w, cx| {
+                    this.snap_on = !this.snap_on;
+                    cx.notify();
+                }),
+            ))
+            .child(tool_btn(
+                "pr-grid",
+                grid_label,
+                false,
+                cx.listener(|this, _, _w, cx| {
+                    this.grid_res = this.grid_res.cycle();
+                    cx.notify();
+                }),
+            ))
+            .child(divider())
+            .child(tool_btn(
+                "pr-quantize",
+                "Q",
+                false,
+                cx.listener(|this, _, _w, cx| this.quantize_selection(cx)),
+            ))
+            .child(tool_btn(
+                "pr-delete",
+                "Del",
+                false,
+                cx.listener(|this, _, _w, cx| this.delete_selection(cx)),
+            ))
+            .child(div().flex_1())
+            .child(
+                div()
+                    .text_size(px(9.0))
+                    .text_color(Colors::text_muted())
+                    .child(format!("{} notes · {} sel", note_count, sel_count)),
+            )
+    }
+
+    fn render_body(&mut self, cx: &mut Context<Self>, clip_id: &str) -> impl IntoElement {
+        // Centre on C4 once the real grid height is known (i.e. after the first
+        // paint has captured the grid bounds via the canvas callback).
+        if !self.centered && self.grid_bounds.get().is_some() {
+            let (_, h) = self.grid_view_size();
+            if h > 1.0 {
+                let target = (self.pitch_to_y(60) + self.scroll_y) - h / 2.0;
+                self.scroll_y = target.clamp(0.0, self.max_scroll_y());
+                self.centered = true;
+            }
+        }
+
+        let (view_w, view_h) = self.grid_view_size();
+        let track_color = self.track_color_for_clip(cx, clip_id);
+        let bpb = self.timeline.read(cx).state.beats_per_bar().max(1.0);
+
+        // Visible ranges (only build geometry for what's on screen).
+        let first_pitch = (self.y_to_pitch(view_h) as i32 - 1).max(0);
+        let last_pitch = (self.y_to_pitch(0.0) as i32 + 1).min(PITCH_CNT - 1);
+        let start_beat = self.x_to_beat(0.0);
+        let end_beat = self.x_to_beat(view_w);
+
+        // Piano key lane.
+        let keys: Vec<_> = (first_pitch..=last_pitch)
+            .map(|p| {
+                let y = self.pitch_to_y(p as u8);
+                let black = is_black(p);
+                let is_c = p % 12 == 0;
+                div()
+                    .absolute()
+                    .top(px(y))
+                    .left_0()
+                    .w_full()
+                    .h(px(ROW_H))
+                    .bg(if black {
+                        Colors::surface_base()
+                    } else {
+                        Colors::surface_raised()
+                    })
+                    .border_b(px(1.0))
+                    .border_color(Colors::border_subtle())
+                    .flex()
+                    .items_center()
+                    .justify_end()
+                    .pr(px(5.0))
+                    .when(is_c, |this| {
+                        this.child(
+                            div()
+                                .text_size(px(8.0))
+                                .text_color(Colors::text_secondary())
+                                .child(note_name(p)),
+                        )
+                    })
+            })
+            .collect();
+
+        // Note + grid rendering.
+        let grid_lines =
+            self.build_grid_lines(start_beat, end_beat, view_w, view_h, first_pitch, last_pitch, bpb);
+        let ruler = self.build_ruler(start_beat, end_beat, bpb);
+        let vel_grid = self.build_velocity_grid(start_beat, end_beat, bpb);
+        let notes_geo = self.build_note_elements(cx, clip_id, track_color);
+        let vel_bars = self.build_velocity_bars(cx, clip_id, track_color);
+        let grid_cursor = if self.tool == PianoTool::Draw {
+            gpui::CursorStyle::Crosshair
+        } else {
+            gpui::CursorStyle::Arrow
+        };
+
+        // Capture grid bounds so empty-area clicks can be mapped to beat/pitch.
+        let grid_bounds = self.grid_bounds.clone();
+        let grid_canvas = canvas(
+            move |bounds, _w, _cx| {
+                grid_bounds.set(Some(bounds));
+            },
+            |_b, _r, _w, _cx| {},
+        )
+        .absolute()
+        .inset_0();
+
+        div()
+            .flex_1()
+            .min_h_0()
+            .flex()
+            .flex_row()
+            // Left: piano keys.
+            .child(
+                div()
+                    .w(px(KEY_W))
+                    .h_full()
+                    .flex()
+                    .flex_col()
+                    // Corner spacer so the keys line up with the grid (below the
+                    // ruler row on the right).
+                    .child(
+                        div()
+                            .h(px(RULER_H))
+                            .w_full()
+                            .bg(Colors::surface_panel())
+                            .border_b(px(1.0))
+                            .border_r(px(1.0))
+                            .border_color(Colors::panel_border()),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_h_0()
+                            .relative()
+                            .overflow_hidden()
+                            .bg(Colors::surface_panel())
+                            .border_r(px(1.0))
+                            .border_color(Colors::panel_border())
+                            .children(keys),
+                    )
+                    .child(
+                        div()
+                            .h(px(VEL_H))
+                            .w_full()
+                            .border_t(px(1.0))
+                            .border_color(Colors::panel_border())
+                            .bg(Colors::surface_panel())
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .text_size(px(8.0))
+                            .text_color(Colors::text_muted())
+                            .child("VEL"),
+                    ),
+            )
+            // Right: grid + velocity lane.
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .flex()
+                    .flex_col()
+                    // Ruler header — bar/beat labels aligned to the grid below.
+                    .child(
+                        div()
+                            .h(px(RULER_H))
+                            .w_full()
+                            .relative()
+                            .overflow_hidden()
+                            .bg(Colors::surface_panel())
+                            .border_b(px(1.0))
+                            .border_color(Colors::panel_border())
+                            .children(ruler),
+                    )
+                    // Note grid.
+                    .child(
+                        div()
+                            .id("piano-grid")
+                            .flex_1()
+                            .min_h_0()
+                            .relative()
+                            .overflow_hidden()
+                            .bg(Colors::surface_base())
+                            .cursor(grid_cursor)
+                            .child(grid_canvas)
+                            .children(grid_lines)
+                            .children(notes_geo)
+                            .on_mouse_down(MouseButton::Left, cx.listener(Self::on_grid_down)),
+                    )
+                    // Velocity lane.
+                    .child(
+                        div()
+                            .id("piano-vel")
+                            .h(px(VEL_H))
+                            .w_full()
+                            .relative()
+                            .overflow_hidden()
+                            .border_t(px(1.0))
+                            .border_color(Colors::panel_border())
+                            .bg(Colors::surface_panel_alt())
+                            .children(vel_grid)
+                            .children(vel_bars),
+                    ),
+            )
+    }
+
+    fn track_color_for_clip(&self, cx: &Context<Self>, clip_id: &str) -> gpui::Rgba {
+        let tl = self.timeline.read(cx);
+        tl.state
+            .tracks
+            .iter()
+            .find(|t| t.clips.iter().any(|c| c.id == clip_id))
+            .map(|t| t.color)
+            .unwrap_or_else(Colors::accent_primary)
+    }
+
+    /// Compute the visible vertical gridlines with a zoom-aware subdivision
+    /// tier. Returns `(x_px, kind)` for each line in `[start_beat, end_beat]`.
+    ///
+    /// Tiering by `px_per_beat` (`self.ppb`):
+    /// - always: bar lines
+    /// - `ppb >= 10`: beat lines
+    /// - subdivision (snap step) lines only when they're at least ~7 px apart
+    ///   and the view is zoomed in enough — keeps far-zoom views uncluttered.
+    fn visible_grid_lines(
+        &self,
+        start_beat: f32,
+        end_beat: f32,
+        bpb: f32,
+    ) -> Vec<(f32, GridLineKind)> {
+        let ppb = self.ppb.max(0.0001);
+        let bpb = bpb.max(1.0);
+        let show_beats = ppb >= 10.0;
+        let sub_step = self.grid_res.beats().max(1.0 / 32.0);
+        let show_subs = show_beats && sub_step * ppb >= 7.0 && ppb >= 24.0;
+
+        let iter_step = if show_subs {
+            sub_step
+        } else if show_beats {
+            1.0
+        } else {
+            bpb
+        };
+
+        let mut out = Vec::new();
+        let mut beat = (start_beat / iter_step).floor() * iter_step;
+        let mut guard = 0;
+        while beat <= end_beat + iter_step && guard < 8000 {
+            guard += 1;
+            let b = beat;
+            beat += iter_step;
+            if b < -1.0e-3 {
+                continue;
+            }
+            let kind = if is_multiple(b, bpb) {
+                GridLineKind::Bar
+            } else if is_multiple(b, 1.0) {
+                GridLineKind::Beat
+            } else {
+                GridLineKind::Subdivision
+            };
+            let keep = match kind {
+                GridLineKind::Bar => true,
+                GridLineKind::Beat => show_beats,
+                GridLineKind::Subdivision => show_subs,
+            };
+            if keep {
+                out.push((self.beat_to_x(b), kind));
+            }
+        }
+        out
+    }
+
+    fn build_grid_lines(
+        &self,
+        start_beat: f32,
+        end_beat: f32,
+        view_w: f32,
+        _view_h: f32,
+        first_pitch: i32,
+        last_pitch: i32,
+        bpb: f32,
+    ) -> Vec<gpui::AnyElement> {
+        let mut out: Vec<gpui::AnyElement> = Vec::new();
+
+        // ── Pitch row backgrounds: shade black-key rows, highlight C rows ──
+        for p in first_pitch..=last_pitch {
+            let y = self.pitch_to_y(p as u8);
+            if is_black(p) {
+                out.push(
+                    div()
+                        .absolute()
+                        .top(px(y))
+                        .left_0()
+                        .w(px(view_w))
+                        .h(px(ROW_H))
+                        .bg(Colors::with_alpha(Colors::surface_base(), 0.45))
+                        .into_any_element(),
+                );
+            } else if p % 12 == 0 {
+                // C row — a touch brighter so octaves are easy to scan.
+                out.push(
+                    div()
+                        .absolute()
+                        .top(px(y))
+                        .left_0()
+                        .w(px(view_w))
+                        .h(px(ROW_H))
+                        .bg(Colors::with_alpha(Colors::text_primary(), 0.03))
+                        .into_any_element(),
+                );
+            }
+        }
+
+        // ── Vertical timing gridlines (zoom-aware hierarchy) ──
+        for (x, kind) in self.visible_grid_lines(start_beat, end_beat, bpb) {
+            let (alpha, w) = match kind {
+                GridLineKind::Bar => (0.26, 1.0),
+                GridLineKind::Beat => (0.13, 1.0),
+                GridLineKind::Subdivision => (0.06, 1.0),
+            };
+            out.push(
+                div()
+                    .absolute()
+                    .top_0()
+                    .left(px(x))
+                    .w(px(w))
+                    .h_full()
+                    .bg(Colors::with_alpha(Colors::text_primary(), alpha))
+                    .into_any_element(),
+            );
+        }
+
+        // ── Horizontal octave boundary lines (top of each C row) ──
+        for p in first_pitch..=last_pitch {
+            if p % 12 == 0 {
+                let y = self.pitch_to_y(p as u8);
+                out.push(
+                    div()
+                        .absolute()
+                        .top(px(y))
+                        .left_0()
+                        .w(px(view_w))
+                        .h(px(1.0))
+                        .bg(Colors::with_alpha(Colors::text_primary(), 0.12))
+                        .into_any_element(),
+                );
+            }
+        }
+
+        out
+    }
+
+    /// Bar/beat ruler header labels, aligned to the note grid via `beat_to_x`.
+    fn build_ruler(&self, start_beat: f32, end_beat: f32, bpb: f32) -> Vec<gpui::AnyElement> {
+        let ppb = self.ppb.max(0.0001);
+        let bpb = bpb.max(1.0);
+        // Label each beat when zoomed in; otherwise label only bar starts.
+        let label_beats = ppb >= 36.0;
+        let step = if label_beats { 1.0 } else { bpb };
+
+        let mut out: Vec<gpui::AnyElement> = Vec::new();
+        let mut beat = (start_beat / step).floor() * step;
+        let mut guard = 0;
+        while beat <= end_beat + step && guard < 2000 {
+            guard += 1;
+            let b = beat;
+            beat += step;
+            if b < -1.0e-3 {
+                continue;
+            }
+            let x = self.beat_to_x(b);
+            let bar = (b / bpb).floor() as i32 + 1;
+            let on_bar = is_multiple(b, bpb);
+            let text = if label_beats {
+                let beat_in_bar = (b - (bar - 1) as f32 * bpb).floor() as i32 + 1;
+                format!("{}.{}", bar, beat_in_bar)
+            } else {
+                format!("{}", bar)
+            };
+            out.push(
+                div()
+                    .absolute()
+                    .top_0()
+                    .left(px(x + 2.0))
+                    .text_size(px(8.5))
+                    .text_color(if on_bar {
+                        Colors::text_secondary()
+                    } else {
+                        Colors::text_muted()
+                    })
+                    .child(text)
+                    .into_any_element(),
+            );
+            // Tick mark at the bottom of the ruler.
+            out.push(
+                div()
+                    .absolute()
+                    .left(px(x))
+                    .bottom_0()
+                    .w(px(1.0))
+                    .h(px(if on_bar { 6.0 } else { 4.0 }))
+                    .bg(Colors::with_alpha(
+                        Colors::text_primary(),
+                        if on_bar { 0.26 } else { 0.13 },
+                    ))
+                    .into_any_element(),
+            );
+        }
+        out
+    }
+
+    /// Bar/beat vertical lines through the velocity lane (aligned with the grid;
+    /// subdivisions omitted to keep the lane uncluttered).
+    fn build_velocity_grid(&self, start_beat: f32, end_beat: f32, bpb: f32) -> Vec<gpui::AnyElement> {
+        self.visible_grid_lines(start_beat, end_beat, bpb)
+            .into_iter()
+            .filter(|(_, kind)| *kind != GridLineKind::Subdivision)
+            .map(|(x, kind)| {
+                let alpha = if kind == GridLineKind::Bar { 0.20 } else { 0.10 };
+                div()
+                    .absolute()
+                    .top_0()
+                    .left(px(x))
+                    .w(px(1.0))
+                    .h_full()
+                    .bg(Colors::with_alpha(Colors::text_primary(), alpha))
+                    .into_any_element()
+            })
+            .collect()
+    }
+
+    fn build_note_elements(
+        &mut self,
+        cx: &mut Context<Self>,
+        clip_id: &str,
+        track_color: gpui::Rgba,
+    ) -> Vec<gpui::AnyElement> {
+        let (view_w, view_h) = self.grid_view_size();
+        // Collect owned geometry first so the timeline read borrow is released
+        // before we build per-note listeners (which borrow `cx` mutably).
+        let geos: Vec<(u64, f32, f32, f32, bool)> = {
+            let tl = self.timeline.read(cx);
+            let Some(notes) = tl.state.midi_clip_notes(clip_id) else {
+                return Vec::new();
+            };
+            notes
+                .iter()
+                .filter_map(|n| {
+                    let d = self.display_note(n);
+                    let x = self.beat_to_x(d.start);
+                    let w = (d.duration * self.ppb).max(3.0);
+                    let y = self.pitch_to_y(d.pitch);
+                    // Cull off-screen notes.
+                    if x + w < 0.0 || x > view_w || y + ROW_H < 0.0 || y > view_h {
+                        return None;
+                    }
+                    Some((d.id, x, y, w, self.selection.contains(&d.id)))
+                })
+                .collect()
+        };
+
+        geos.into_iter()
+            .map(|(id, x, y, w, selected)| {
+                let mut fill = track_color;
+                fill.a = if selected { 1.0 } else { 0.78 };
+                let border = if selected {
+                    Colors::text_primary()
+                } else {
+                    Colors::with_alpha(track_color, 0.55)
+                };
+                let mut note = div()
+                    .id(("pr-note", id as usize))
+                    .absolute()
+                    .left(px(x))
+                    .top(px(y + 1.0))
+                    .w(px(w))
+                    .h(px(ROW_H - 2.0))
+                    .rounded(px(2.0))
+                    .bg(fill)
+                    .border(px(1.0))
+                    .border_color(border)
+                    .cursor(gpui::CursorStyle::PointingHand)
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, ev: &MouseDownEvent, window, cx| {
+                            cx.stop_propagation();
+                            this.note_mouse_down(id, ev, window, cx);
+                        }),
+                    )
+                    .on_mouse_down(
+                        MouseButton::Right,
+                        cx.listener(move |this, _ev: &MouseDownEvent, _window, cx| {
+                            cx.stop_propagation();
+                            this.note_right_down(id, cx);
+                        }),
+                    );
+                // Right-edge resize handle (only when the note is wide enough to
+                // leave room for a separate move/resize zone).
+                if w >= 12.0 {
+                    note = note.child(
+                        div()
+                            .id(("pr-note-edge", id as usize))
+                            .absolute()
+                            .right_0()
+                            .top_0()
+                            .w(px(RESIZE_ZONE))
+                            .h_full()
+                            .cursor(gpui::CursorStyle::ResizeLeftRight)
+                            .hover(|s| s.bg(Colors::with_alpha(Colors::text_primary(), 0.35)))
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |this, ev: &MouseDownEvent, window, cx| {
+                                    cx.stop_propagation();
+                                    this.begin_resize_drag(id, ev, window, cx);
+                                }),
+                            ),
+                    );
+                }
+                note.into_any_element()
+            })
+            .collect()
+    }
+
+    fn build_velocity_bars(
+        &mut self,
+        cx: &mut Context<Self>,
+        clip_id: &str,
+        track_color: gpui::Rgba,
+    ) -> Vec<gpui::AnyElement> {
+        let (view_w, _) = self.grid_view_size();
+        let geos: Vec<(u64, u8, f32, bool)> = {
+            let tl = self.timeline.read(cx);
+            let Some(notes) = tl.state.midi_clip_notes(clip_id) else {
+                return Vec::new();
+            };
+            notes
+                .iter()
+                .filter_map(|n| {
+                    let d = self.display_note(n);
+                    let x = self.beat_to_x(d.start);
+                    if x < -8.0 || x > view_w {
+                        return None;
+                    }
+                    Some((d.id, d.velocity, x, self.selection.contains(&d.id)))
+                })
+                .collect()
+        };
+
+        geos.into_iter()
+            .map(|(id, vel, x, selected)| {
+                let bar_h = (((vel as f32 - 1.0) / 126.0) * (VEL_H - 8.0)).max(1.0);
+                let mut fill = track_color;
+                fill.a = if selected { 1.0 } else { 0.5 };
+                // Full-height invisible hit column so even low-velocity bars are
+                // easy to grab; the colored bar sits inside it at the bottom.
+                div()
+                    .id(("pr-vel", id as usize))
+                    .absolute()
+                    .left(px(x))
+                    .top_0()
+                    .bottom_0()
+                    .w(px(8.0))
+                    .cursor(gpui::CursorStyle::ResizeUpDown)
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, ev: &MouseDownEvent, window, cx| {
+                            cx.stop_propagation();
+                            this.begin_velocity_drag(id, vel, ev, window, cx);
+                        }),
+                    )
+                    .child(
+                        div()
+                            .absolute()
+                            .left_0()
+                            .bottom(px(2.0))
+                            .w(px(6.0))
+                            .h(px(bar_h))
+                            .rounded_t(px(1.0))
+                            .bg(fill),
+                    )
+                    .into_any_element()
+            })
+            .collect()
+    }
+}
+
+// ── Small toolbar helpers ───────────────────────────────────────────────────
+fn divider() -> impl IntoElement {
+    div()
+        .w(px(1.0))
+        .h(px(16.0))
+        .bg(Colors::with_alpha(Colors::text_primary(), 0.08))
+}
+
+fn tool_btn(
+    id: &'static str,
+    label: &str,
+    active: bool,
+    on_click: impl Fn(&gpui::ClickEvent, &mut Window, &mut gpui::App) + 'static,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .flex()
+        .items_center()
+        .justify_center()
+        .h(px(22.0))
+        .min_w(px(24.0))
+        .px(px(7.0))
+        .rounded(px(4.0))
+        .text_size(px(10.0))
+        .text_color(if active {
+            Colors::text_primary()
+        } else {
+            Colors::text_secondary()
+        })
+        .bg(if active {
+            Colors::surface_hover()
+        } else {
+            Colors::with_alpha(Colors::text_primary(), 0.0)
+        })
+        .border(px(1.0))
+        .border_color(if active {
+            Colors::border_subtle()
+        } else {
+            Colors::with_alpha(Colors::text_primary(), 0.0)
+        })
+        .hover(|s| s.bg(Colors::surface_hover()))
+        .cursor(gpui::CursorStyle::PointingHand)
+        .on_click(move |ev, w, cx| on_click(ev, w, cx))
+        .child(label.to_string())
+}

--- a/crates/SphereUIComponents/src/components/timeline/midi_clip.rs
+++ b/crates/SphereUIComponents/src/components/timeline/midi_clip.rs
@@ -17,6 +17,7 @@ pub fn midi_clip(
     on_context_menu: Option<
         std::sync::Arc<dyn Fn(&(String, f32, f32), &mut gpui::Window, &mut gpui::App) + 'static>,
     >,
+    on_open_editor: Option<std::sync::Arc<dyn Fn(&mut gpui::Window, &mut gpui::App) + 'static>>,
 ) -> impl IntoElement {
     let clip_id = clip.id.clone();
     let drag_clip_id = clip.id.clone();
@@ -107,8 +108,17 @@ pub fn midi_clip(
         .id(("midi-clip", id_num))
         .on_mouse_down(
             gpui::MouseButton::Left,
-            move |_event: &gpui::MouseDownEvent, window, cx| {
+            move |event: &gpui::MouseDownEvent, window, cx| {
+                // Stop the parent lane handler from re-selecting the track and
+                // clearing this clip selection — the piano roll edits the
+                // selected clip, so selection must survive the click.
+                cx.stop_propagation();
                 on_select(&clip_id, window, cx);
+                if event.click_count >= 2 {
+                    if let Some(open) = on_open_editor.as_ref() {
+                        open(window, cx);
+                    }
+                }
             },
         )
         .when_some(on_context_menu, |this, cb| {

--- a/crates/SphereUIComponents/src/components/timeline/timeline.rs
+++ b/crates/SphereUIComponents/src/components/timeline/timeline.rs
@@ -3,7 +3,7 @@ use crate::components::sidebar::{BrowserDragItem, SIDEBAR_WIDTH};
 use crate::components::timeline::floating_tools_bar::floating_tools_bar;
 use crate::components::timeline::timeline_ruler::timeline_ruler;
 use crate::components::timeline::timeline_state::{
-    ClipDragItem, ClipState, ClipType, MidiNoteState, SnapDivision, TimelineState, TimelineTool,
+    ClipDragItem, ClipState, ClipType, SnapDivision, TimelineState, TimelineTool,
     TrackDragItem, TrackType, HEADER_WIDTH, RULER_HEIGHT, TRACK_HEIGHT,
 };
 use crate::components::timeline::track_list::track_list;
@@ -59,8 +59,14 @@ pub struct Timeline {
     clip_drag_target_track_index: Option<usize>,
     pan_last_position: Option<gpui::Point<gpui::Pixels>>,
     on_context_menu: Option<TimelineContextMenuCb>,
+    /// Invoked when the user double-clicks a MIDI clip — `StudioLayout` uses it
+    /// to switch the bottom panel to the piano-roll Editor tab.
+    on_open_editor: Option<TimelineOpenEditorCb>,
     chrome_metrics: TimelineChromeMetrics,
 }
+
+pub type TimelineOpenEditorCb =
+    std::sync::Arc<dyn Fn(&mut gpui::Window, &mut gpui::App) + 'static>;
 
 #[derive(Clone, Debug)]
 pub enum TimelineContextTarget {
@@ -116,6 +122,7 @@ impl Timeline {
             clip_drag_target_track_index: None,
             pan_last_position: None,
             on_context_menu: None,
+            on_open_editor: None,
             chrome_metrics: TimelineChromeMetrics::default(),
         }
     }
@@ -135,6 +142,7 @@ impl Timeline {
             clip_drag_target_track_index: None,
             pan_last_position: None,
             on_context_menu: None,
+            on_open_editor: None,
             chrome_metrics: TimelineChromeMetrics::default(),
         }
     }
@@ -150,6 +158,10 @@ impl Timeline {
         self.on_context_menu = callback;
     }
 
+    pub fn set_open_editor_callback(&mut self, callback: Option<TimelineOpenEditorCb>) {
+        self.on_open_editor = callback;
+    }
+
     pub fn set_add_track_callback(&mut self, callback: Option<TimelineAddTrackCb>) {
         self.on_add_track = callback;
     }
@@ -162,7 +174,7 @@ impl Timeline {
         self.on_media_changed = callback;
     }
 
-    fn mark_project_changed(&self, cx: &mut gpui::App) {
+    pub(crate) fn mark_project_changed(&self, cx: &mut gpui::App) {
         if let Some(callback) = self.on_project_changed.as_ref() {
             callback(cx);
         }
@@ -432,51 +444,64 @@ impl Render for Timeline {
         });
 
         let on_add_clip = cx.listener(|this, (track_id, beat): &(String, f32), _window, cx| {
-            if let Some(t) = this.state.tracks.iter_mut().find(|t| t.id == *track_id) {
-                let name = match t.track_type {
-                    TrackType::Audio => "vocals_harmony_new.wav".to_string(),
-                    _ => "midi_clip_new.mid".to_string(),
-                };
-                let duration = 4.0;
-                let clip_type = match t.track_type {
-                    TrackType::Audio => ClipType::Audio {
-                        file_id: "new-file".to_string(),
-                        source_path: None,
-                    },
-                    _ => ClipType::Midi {
-                        notes: vec![
-                            MidiNoteState {
-                                pitch: 60,
-                                start: 0.0,
-                                duration: 1.0,
+            let track_type = this
+                .state
+                .tracks
+                .iter()
+                .find(|t| t.id == *track_id)
+                .map(|t| t.track_type);
+            let duration = 4.0;
+            match track_type {
+                Some(TrackType::Audio) => {
+                    if let Some(t) = this.state.tracks.iter_mut().find(|t| t.id == *track_id) {
+                        let clip_id = format!("clip-{}-{}", t.clips.len() + 1, beat);
+                        t.clips.push(ClipState {
+                            id: clip_id,
+                            name: "vocals_harmony_new.wav".to_string(),
+                            start_beat: *beat,
+                            duration_beats: duration,
+                            source_duration_seconds: None,
+                            offset_beats: 0.0,
+                            gain: 1.0,
+                            clip_type: ClipType::Audio {
+                                file_id: "new-file".to_string(),
+                                source_path: None,
                             },
-                            MidiNoteState {
-                                pitch: 64,
-                                start: 1.0,
-                                duration: 1.0,
-                            },
-                            MidiNoteState {
-                                pitch: 67,
-                                start: 2.0,
-                                duration: 2.0,
-                            },
-                        ],
-                    },
-                };
-                let clip_id = format!("clip-{}-{}", t.clips.len() + 1, beat);
-                t.clips.push(ClipState {
-                    id: clip_id,
-                    name,
-                    start_beat: *beat,
-                    duration_beats: duration,
-                    source_duration_seconds: None,
-                    offset_beats: 0.0,
-                    gain: 1.0,
-                    clip_type,
-                    muted: false,
-                    audio_import: crate::components::timeline::timeline_state::AudioImportState::default(),
-                });
-                this.mark_project_changed(cx);
+                            muted: false,
+                            audio_import: crate::components::timeline::timeline_state::AudioImportState::default(),
+                        });
+                        this.mark_project_changed(cx);
+                    }
+                }
+                Some(_) => {
+                    // MIDI / Instrument: create an EMPTY clip (user draws notes).
+                    // Demo notes are dev-only, behind FUTUREBOARD_DEMO_MIDI=1.
+                    if let Some(clip_id) =
+                        this.state.create_midi_clip(track_id, *beat, duration)
+                    {
+                        let demo = std::env::var_os("FUTUREBOARD_DEMO_MIDI").is_some();
+                        if demo {
+                            this.state.add_midi_note(&clip_id, 60, 0.0, 1.0, 100);
+                            this.state.add_midi_note(&clip_id, 64, 1.0, 1.0, 100);
+                            this.state.add_midi_note(&clip_id, 67, 2.0, 2.0, 100);
+                        }
+                        if std::env::var_os("FUTUREBOARD_MIDI_DEBUG").is_some() {
+                            let notes = this
+                                .state
+                                .midi_clip_notes(&clip_id)
+                                .map(|n| n.len())
+                                .unwrap_or(0);
+                            eprintln!(
+                                "[Native MIDI] create_midi_clip reason={} clip_id={} notes={}",
+                                if demo { "demo_env" } else { "user_pen_tool" },
+                                clip_id,
+                                notes
+                            );
+                        }
+                        this.mark_project_changed(cx);
+                    }
+                }
+                None => {}
             }
             cx.notify();
         });
@@ -894,6 +919,7 @@ impl Render for Timeline {
                 on_add_clip.clone(),
                 on_track_context_menu.clone(),
                 on_clip_context_menu.clone(),
+                self.on_open_editor.clone(),
             )))
             // 3. Playhead Overlay (frontmost timeline pass)
             // Render after ruler + content so grid/ruler/content never cover it.

--- a/crates/SphereUIComponents/src/components/timeline/timeline_state.rs
+++ b/crates/SphereUIComponents/src/components/timeline/timeline_state.rs
@@ -34,11 +34,51 @@ impl TrackType {
     }
 }
 
+/// `FUTUREBOARD_MIDI_DEBUG=1` enables eprintln traces for MIDI clip/note
+/// mutations (mirrors the plugin/routing debug flags). Cached on first read.
+pub fn midi_debug_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| std::env::var_os("FUTUREBOARD_MIDI_DEBUG").is_some())
+}
+
+/// Smallest allowed note length, in beats (1/32 note). Mirrors the WebUI
+/// `MIN_DUR` guard so a note can never collapse to zero width.
+pub const MIN_NOTE_BEATS: f32 = 1.0 / 32.0;
+
+/// Monotonic source of transient note identities. Note ids are NOT persisted —
+/// they exist only so the piano-roll editor can track selection / drag targets
+/// across edits. Fresh ids are minted on create and on project load.
+fn next_midi_note_id() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct MidiNoteState {
+    /// Transient identity (not serialized). Used by the piano-roll editor to
+    /// track selection and in-flight drag targets.
+    pub id: u64,
     pub pitch: u8,
     pub start: f32,    // beats relative to clip start
     pub duration: f32, // beats
+    /// MIDI velocity in 1..=127.
+    pub velocity: u8,
+}
+
+impl MidiNoteState {
+    /// Construct a note with a freshly minted transient id. `pitch` is clamped
+    /// to 0..=127, `velocity` to 1..=127, and `duration` to at least
+    /// [`MIN_NOTE_BEATS`].
+    pub fn new(pitch: u8, start: f32, duration: f32, velocity: u8) -> Self {
+        Self {
+            id: next_midi_note_id(),
+            pitch: pitch.min(127),
+            start: start.max(0.0),
+            duration: duration.max(MIN_NOTE_BEATS),
+            velocity: velocity.clamp(1, 127),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -636,41 +676,13 @@ impl TimelineState {
                 gain: 1.0,
                 clip_type: ClipType::Midi {
                     notes: vec![
-                        MidiNoteState {
-                            pitch: 60,
-                            start: 0.0,
-                            duration: 1.0,
-                        },
-                        MidiNoteState {
-                            pitch: 64,
-                            start: 1.0,
-                            duration: 1.0,
-                        },
-                        MidiNoteState {
-                            pitch: 67,
-                            start: 2.0,
-                            duration: 1.0,
-                        },
-                        MidiNoteState {
-                            pitch: 72,
-                            start: 3.0,
-                            duration: 2.0,
-                        },
-                        MidiNoteState {
-                            pitch: 67,
-                            start: 5.0,
-                            duration: 1.0,
-                        },
-                        MidiNoteState {
-                            pitch: 64,
-                            start: 6.0,
-                            duration: 1.0,
-                        },
-                        MidiNoteState {
-                            pitch: 60,
-                            start: 7.0,
-                            duration: 1.0,
-                        },
+                        MidiNoteState::new(60, 0.0, 1.0, 100),
+                        MidiNoteState::new(64, 1.0, 1.0, 100),
+                        MidiNoteState::new(67, 2.0, 1.0, 100),
+                        MidiNoteState::new(72, 3.0, 2.0, 110),
+                        MidiNoteState::new(67, 5.0, 1.0, 90),
+                        MidiNoteState::new(64, 6.0, 1.0, 90),
+                        MidiNoteState::new(60, 7.0, 1.0, 80),
                     ],
                 },
                 muted: false,
@@ -1145,6 +1157,178 @@ impl TimelineState {
             armed: false,
             input_monitor: false,
         })
+    }
+
+    // ── MIDI clip / note mutations ────────────────────────────────────────
+    // Single source of truth for piano-roll edits. The piano-roll editor calls
+    // these inside `Timeline::update` and then marks the project dirty so the
+    // engine sync + autosave see the change. Notes are stored relative to the
+    // clip start (matches the WebUI model). Every mutation clamps to valid
+    // ranges so a bad gesture can never produce an out-of-range note.
+
+    /// Create an empty MIDI clip on `track_id` at `start_beat` (snapped by the
+    /// caller if desired). Returns the new clip id, or `None` if the track is
+    /// missing. The clip is selected so the editor can pick it up immediately.
+    pub fn create_midi_clip(&mut self, track_id: &str, start_beat: f32, length_beats: f32) -> Option<String> {
+        if !self.tracks.iter().any(|t| t.id == track_id) {
+            return None;
+        }
+        let clip_id = self.next_clip_id();
+        let name = format!("MIDI {}", clip_id.strip_prefix("clip-").unwrap_or(&clip_id));
+        let new_clip = ClipState {
+            id: clip_id.clone(),
+            name,
+            start_beat: start_beat.max(0.0),
+            duration_beats: length_beats.max(1.0),
+            source_duration_seconds: None,
+            offset_beats: 0.0,
+            gain: 1.0,
+            clip_type: ClipType::Midi { notes: Vec::new() },
+            muted: false,
+            audio_import: AudioImportState::default(),
+        };
+        if let Some(track) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+            track.clips.push(new_clip);
+        }
+        self.selection.selected_track_id = Some(track_id.to_string());
+        self.selection.selected_clip_ids = vec![clip_id.clone()];
+        if midi_debug_enabled() {
+            eprintln!(
+                "[midi] create_midi_clip track={} clip={} start={:.3} len={:.3}",
+                track_id, clip_id, start_beat, length_beats
+            );
+        }
+        Some(clip_id)
+    }
+
+    /// Borrow the notes of a MIDI clip by id.
+    pub fn midi_clip_notes(&self, clip_id: &str) -> Option<&Vec<MidiNoteState>> {
+        for track in &self.tracks {
+            for clip in &track.clips {
+                if clip.id == clip_id {
+                    if let ClipType::Midi { notes } = &clip.clip_type {
+                        return Some(notes);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn midi_clip_notes_mut(&mut self, clip_id: &str) -> Option<&mut Vec<MidiNoteState>> {
+        for track in &mut self.tracks {
+            for clip in &mut track.clips {
+                if clip.id == clip_id {
+                    if let ClipType::Midi { notes } = &mut clip.clip_type {
+                        return Some(notes);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Add a note to a MIDI clip. Returns the new note id.
+    pub fn add_midi_note(
+        &mut self,
+        clip_id: &str,
+        pitch: u8,
+        start: f32,
+        duration: f32,
+        velocity: u8,
+    ) -> Option<u64> {
+        let note = MidiNoteState::new(pitch, start, duration, velocity);
+        let id = note.id;
+        let notes = self.midi_clip_notes_mut(clip_id)?;
+        notes.push(note);
+        if midi_debug_enabled() {
+            eprintln!(
+                "[midi] add_note clip={} id={} pitch={} start={:.3} dur={:.3} vel={}",
+                clip_id, id, pitch.min(127), start.max(0.0), duration.max(MIN_NOTE_BEATS), velocity.clamp(1, 127)
+            );
+        }
+        Some(id)
+    }
+
+    /// Apply absolute start/pitch to a set of notes (move gesture). Each tuple
+    /// is `(note_id, new_start_beats, new_pitch)`.
+    pub fn move_midi_notes(&mut self, clip_id: &str, updates: &[(u64, f32, u8)]) {
+        let Some(notes) = self.midi_clip_notes_mut(clip_id) else {
+            return;
+        };
+        for (id, new_start, new_pitch) in updates {
+            if let Some(note) = notes.iter_mut().find(|n| n.id == *id) {
+                note.start = new_start.max(0.0);
+                note.pitch = (*new_pitch).min(127);
+            }
+        }
+        if midi_debug_enabled() {
+            eprintln!("[midi] move_notes clip={} count={}", clip_id, updates.len());
+        }
+    }
+
+    /// Set a note's length (resize gesture), clamped to [`MIN_NOTE_BEATS`].
+    pub fn resize_midi_note(&mut self, clip_id: &str, id: u64, new_duration: f32) {
+        let Some(notes) = self.midi_clip_notes_mut(clip_id) else {
+            return;
+        };
+        if let Some(note) = notes.iter_mut().find(|n| n.id == id) {
+            note.duration = new_duration.max(MIN_NOTE_BEATS);
+            if midi_debug_enabled() {
+                eprintln!(
+                    "[midi] resize_note clip={} id={} dur={:.3}",
+                    clip_id, id, note.duration
+                );
+            }
+        }
+    }
+
+    /// Delete the given note ids from a MIDI clip. Returns how many were removed.
+    pub fn delete_midi_notes(&mut self, clip_id: &str, ids: &[u64]) -> usize {
+        let Some(notes) = self.midi_clip_notes_mut(clip_id) else {
+            return 0;
+        };
+        let before = notes.len();
+        notes.retain(|n| !ids.contains(&n.id));
+        let removed = before - notes.len();
+        if removed > 0 && midi_debug_enabled() {
+            eprintln!("[midi] delete_notes clip={} removed={}", clip_id, removed);
+        }
+        removed
+    }
+
+    /// Set a note's velocity (1..=127).
+    pub fn set_midi_note_velocity(&mut self, clip_id: &str, id: u64, velocity: u8) {
+        let Some(notes) = self.midi_clip_notes_mut(clip_id) else {
+            return;
+        };
+        if let Some(note) = notes.iter_mut().find(|n| n.id == id) {
+            note.velocity = velocity.clamp(1, 127);
+        }
+    }
+
+    /// Quantize the given note starts (or all notes when `ids` is empty) to the
+    /// supplied grid step in beats. Rounds to the nearest step.
+    pub fn quantize_midi_notes(&mut self, clip_id: &str, ids: &[u64], step_beats: f32) {
+        if step_beats <= 0.0 {
+            return;
+        }
+        let Some(notes) = self.midi_clip_notes_mut(clip_id) else {
+            return;
+        };
+        let mut count = 0;
+        for note in notes.iter_mut() {
+            if ids.is_empty() || ids.contains(&note.id) {
+                note.start = ((note.start / step_beats).round() * step_beats).max(0.0);
+                count += 1;
+            }
+        }
+        if midi_debug_enabled() {
+            eprintln!(
+                "[midi] quantize clip={} count={} step={:.4}",
+                clip_id, count, step_beats
+            );
+        }
     }
 
     pub fn track_color_for_index(&self, index: usize) -> gpui::Rgba {

--- a/crates/SphereUIComponents/src/components/timeline/track_lane.rs
+++ b/crates/SphereUIComponents/src/components/timeline/track_lane.rs
@@ -23,6 +23,7 @@ pub fn track_lane(
     on_clip_context_menu: Option<
         std::sync::Arc<dyn Fn(&(String, f32, f32), &mut gpui::Window, &mut gpui::App) + 'static>,
     >,
+    on_open_editor: Option<std::sync::Arc<dyn Fn(&mut gpui::Window, &mut gpui::App) + 'static>>,
 ) -> impl IntoElement {
     let _s = crate::perf::PerfScope::enter("TrackLane");
     let track_id = track.id.clone();
@@ -63,6 +64,7 @@ pub fn track_lane(
             let track_color = track.color;
             let on_sel_clip = on_select_clip.clone();
             let on_clip_context = on_clip_context_menu.clone();
+            let on_open = on_open_editor.clone();
             Some(match clip.clip_type {
                 ClipType::Audio { .. } => audio_clip(
                     clip,
@@ -80,6 +82,7 @@ pub fn track_lane(
                     state,
                     on_sel_clip,
                     on_clip_context,
+                    on_open,
                 )
                 .into_any_element(),
             })

--- a/crates/SphereUIComponents/src/components/timeline/track_list.rs
+++ b/crates/SphereUIComponents/src/components/timeline/track_list.rs
@@ -25,6 +25,7 @@ pub fn track_list(
     on_clip_context_menu: Option<
         std::sync::Arc<dyn Fn(&(String, f32, f32), &mut gpui::Window, &mut gpui::App) + 'static>,
     >,
+    on_open_editor: Option<std::sync::Arc<dyn Fn(&mut gpui::Window, &mut gpui::App) + 'static>>,
 ) -> impl IntoElement {
     let _s = crate::perf::PerfScope::enter("TrackList");
     let grid_width = state.viewport.viewport_width.max(1.0);
@@ -106,6 +107,7 @@ pub fn track_list(
                         on_add_clip.clone(),
                         on_track_context_menu.clone(),
                         on_clip_context_menu.clone(),
+                        on_open_editor.clone(),
                     )),
             )
             .children(

--- a/crates/SphereUIComponents/src/layout.rs
+++ b/crates/SphereUIComponents/src/layout.rs
@@ -50,8 +50,9 @@ use crate::overlay::{project_title_anchor, titlebar_label_anchor, OverlayAnchor}
 use crate::theme::{self, Colors};
 
 use DAUx::types::{
-    EngineClipAudioProcess, EngineClipSnapshot, EngineInsertSnapshot, EngineProjectSnapshot,
-    EngineRoutingSnapshot, EngineSendSnapshot, EngineTrackSnapshot,
+    EngineClipAudioProcess, EngineClipSnapshot, EngineInsertSnapshot, EngineMidiClipSnapshot,
+    EngineMidiNoteSnapshot, EngineProjectSnapshot, EngineRoutingSnapshot, EngineSendSnapshot,
+    EngineTrackSnapshot,
 };
 
 /// Flip to `true` to seed the studio with demo tracks/clips at startup.
@@ -137,6 +138,9 @@ pub struct StudioLayout {
     active_bottom_tab: components::BottomTab,
     bottom_panel_state: BottomPanelState,
     timeline: Entity<components::timeline::Timeline>,
+    /// Piano-roll editor shown in the bottom panel's Editor tab. Holds a handle
+    /// to the timeline so note edits mutate the single project source of truth.
+    piano_roll: Entity<components::piano_roll::PianoRoll>,
     file_browser: FileBrowserState,
     /// Stable scroll handle for the browser tree. Lives on the layout
     /// (not in `FileBrowserState`) so the state stays free of gpui types
@@ -466,6 +470,11 @@ impl StudioLayout {
         let _ = timeline.update(cx, |t, _cx| {
             t.state.transport.metronome_enabled = metronome_enabled;
         });
+
+        let piano_roll = {
+            let timeline = timeline.clone();
+            cx.new(|cx| components::piano_roll::PianoRoll::new(timeline, cx))
+        };
         if let Some(engine) = audio_engine.clone() {
             let seek_engine = engine.clone();
             let param_engine = engine.clone();
@@ -526,6 +535,19 @@ impl StudioLayout {
                 })));
             });
         }
+        {
+            let target = cx.entity().clone();
+            let _ = timeline.update(cx, |timeline, _cx| {
+                timeline.set_open_editor_callback(Some(Arc::new(move |_window, cx| {
+                    let _ = target.update(cx, |this, cx| {
+                        this.active_bottom_tab = components::BottomTab::Editor;
+                        this.panels.mixer_docked = true;
+                        cx.notify();
+                    });
+                })));
+            });
+        }
+
         let initial_audio_stats = audio_engine.as_ref().map(|engine| engine.stats());
         let initial_audio_running = initial_audio_stats
             .as_ref()
@@ -549,6 +571,7 @@ impl StudioLayout {
             active_bottom_tab: components::BottomTab::Mixer,
             bottom_panel_state: BottomPanelState::default(),
             timeline,
+            piano_roll,
             file_browser: FileBrowserState::default(),
             browser_scroll: UniformListScrollHandle::new(),
             menu_bar: MenuBarUiState::default(),
@@ -4728,6 +4751,7 @@ impl Render for StudioLayout {
                         mixer_scroll_x,
                         mixer_viewport_width,
                         on_mixer_scroll,
+                        Some(self.piano_roll.clone().into_any_element()),
                         on_tab_click,
                         on_resize_start,
                         on_resize_move,
@@ -4903,6 +4927,41 @@ fn build_engine_project_snapshot(state: &TimelineState, sample_rate: u32) -> Eng
         })
         .collect();
 
+    // MIDI clips (Phase 2): notes stay clip-relative; the engine resolves them
+    // to absolute beats/samples. Muted clips are skipped, matching audio clips.
+    let midi_clips = state
+        .tracks
+        .iter()
+        .flat_map(|track| {
+            let track_id = track.id.clone();
+            track.clips.iter().filter_map(move |clip| {
+                if clip.muted {
+                    return None;
+                }
+                let ClipType::Midi { notes } = &clip.clip_type else {
+                    return None;
+                };
+                Some(EngineMidiClipSnapshot {
+                    id: clip.id.clone(),
+                    track_id: track_id.clone(),
+                    start_beat: clip.start_beat.max(0.0) as f64,
+                    length_beats: clip.duration_beats.max(0.0) as f64,
+                    notes: notes
+                        .iter()
+                        .map(|n| EngineMidiNoteSnapshot {
+                            id: n.id,
+                            pitch: n.pitch.min(127),
+                            start_beat: n.start.max(0.0) as f64,
+                            length_beats: n.duration.max(0.0) as f64,
+                            velocity: n.velocity.clamp(1, 127),
+                            channel: 0,
+                        })
+                        .collect(),
+                })
+            })
+        })
+        .collect();
+
     EngineProjectSnapshot {
         project_id: "futureboard-native".to_string(),
         project_root: None,
@@ -4911,6 +4970,7 @@ fn build_engine_project_snapshot(state: &TimelineState, sample_rate: u32) -> Eng
         sample_rate: sample_rate.max(1),
         tracks,
         clips,
+        midi_clips,
         routing: EngineRoutingSnapshot {
             master_output_device: None,
             sample_rate: sample_rate.max(1),
@@ -4931,13 +4991,16 @@ fn log_engine_sync_snapshot(snapshot: &EngineProjectSnapshot, dirty: bool, reaso
         })
         .count();
     let insert_count: usize = snapshot.tracks.iter().map(|t| t.inserts.len()).sum();
+    let midi_note_count: usize = snapshot.midi_clips.iter().map(|c| c.notes.len()).sum();
     eprintln!(
-        "[engine-sync] reason={} tracks={} clips={} clips_with_path={} inserts={} dirty={}",
+        "[engine-sync] reason={} tracks={} clips={} clips_with_path={} inserts={} midi_clips={} midi_notes={} dirty={}",
         reason,
         snapshot.tracks.len(),
         snapshot.clips.len(),
         clips_with_path,
         insert_count,
+        snapshot.midi_clips.len(),
+        midi_note_count,
         dirty
     );
     for track in &snapshot.tracks {

--- a/crates/SphereUIComponents/src/project/mod.rs
+++ b/crates/SphereUIComponents/src/project/mod.rs
@@ -332,7 +332,7 @@ impl From<&TimelineState> for FutureboardProject {
                                         pitch: n.pitch,
                                         start_beats: n.start,
                                         duration_beats: n.duration,
-                                        velocity: 100,
+                                        velocity: n.velocity,
                                     })
                                     .collect(),
                             },
@@ -483,11 +483,12 @@ pub fn apply_to_timeline(project: &FutureboardProject, tl: &mut TimelineState) {
                         ClipSource::Midi { notes } => ClipType::Midi {
                             notes: notes
                                 .iter()
-                                .map(|n| MidiNoteState {
-                                    pitch: n.pitch,
-                                    start: n.start_beats,
-                                    duration: n.duration_beats,
-                                })
+                                .map(|n| MidiNoteState::new(
+                                    n.pitch,
+                                    n.start_beats,
+                                    n.duration_beats,
+                                    n.velocity,
+                                ))
                                 .collect(),
                         },
                         ClipSource::Empty => ClipType::Midi { notes: Vec::new() },

--- a/tasks/native/midi-phase2-engine-playback.md
+++ b/tasks/native/midi-phase2-engine-playback.md
@@ -1,0 +1,72 @@
+# MIDI Phase 2 — DAUx Engine MIDI Playback / Scheduling
+
+## PART A — findings (WebUI / existing engine reference)
+
+### WebUI / WASM MIDI playback
+The WebUI (`apps/web`) does **not** have a real MIDI instrument playback path.
+Transport (`apps/web/src/engine/Transport.ts`) drives a `ClipScheduler` and a
+`MetronomeScheduler` over WebAudio. `ClipScheduler` bulk-schedules **audio**
+clips on `play()`; there is no MIDI note scheduler, no instrument host, and the
+`MidiEditorPanel` only edits clip note data — it never sounds. So WebUI is a
+reference for the **MIDI clip/note model** (pitch / start-beat / length-beat /
+velocity, notes stored relative to clip start) but **not** for engine playback.
+
+### Existing native engine (DAUx = `sphere-direct-audio-engine`)
+- `EngineProjectSnapshot` (types.rs) carried only audio `clips`; MIDI was absent.
+- `RuntimeProject::build` (runtime.rs) converts snapshot → runtime on the
+  control/worker thread (decodes audio, builds VST3 processors). Audio clips
+  resolve **beats → samples at build time** using the snapshot BPM
+  (`build_clip_runtime`): `start_sample = round(start_beat / bps * sr)`.
+- The audio callback (engine.rs) owns a local `RuntimeProject`, advances
+  `shared.position_samples` by `frames` each block, and renders via
+  `render_project_block_interleaved(runtime, base_sample, ...)`.
+- Transport commands (`StartTransport`/`StopTransport`/`Seek`) are handled
+  inside the callback command drain.
+- VST3 C-ABI bridge (`vst3_processor.rs`) exposes audio process + param changes
+  **only** — there is **no event/IEventList input** function.
+
+### Timing units / assumptions Native mirrors
+- Constant tempo. `samples_per_beat = sample_rate * 60 / bpm`.
+- Notes are clip-relative; absolute beat = `clip.start_beat + note.start_beat`.
+- To match audio clips (and stay lock-free in the callback) MIDI events are
+  **resolved to absolute project samples at build time**, not re-derived from
+  beats every block.
+- Block-accurate scheduling (events placed at a sample offset within the block)
+  — sample-accurate within one block is the offset granularity.
+
+## What was implemented (Phase 2A — scheduler + routing scaffold)
+
+- **Snapshot** (types.rs): `EngineMidiClipSnapshot` / `EngineMidiNoteSnapshot`;
+  `EngineProjectSnapshot.midi_clips` (serde `default`). UI fills it in
+  `build_engine_project_snapshot` (layout.rs) — note edits now change the
+  snapshot signature, so a committed edit triggers a rebuild (no live-drag spam;
+  Phase 1 already commits once on release).
+- **Runtime** (runtime.rs): `RuntimeMidiEvent` (precomputed `sample` + `beat`),
+  `RuntimeMidiClip`, `RuntimeMidiTrack` (merged sorted events + `cursor` +
+  `active` notes). `build_midi_runtime` clamps pitch/velocity/channel, skips
+  length ≤ 0, sorts by sample with **NoteOff before NoteOn** at the same sample.
+- **Callback** (engine.rs): `schedule_midi_block(base_sample, frames)` runs once
+  per block, advances the cursor, emits note on/off (debug-logged) with a
+  within-block sample offset, and tracks active notes. `reset_midi_playback`
+  (binary-search cursor + flush) on Seek / StartTransport / LoadProject;
+  `all_notes_off` on StopTransport. No allocation on the steady path; `active`
+  is reserved (128) at build.
+- **Debug**: `FUTUREBOARD_MIDI_ENGINE_DEBUG=1` (engine) +
+  `FUTUREBOARD_MIDI_DEBUG=1` (UI, Phase 1). Logs snapshot/runtime counts, block
+  beat range, per-event note on/off, all-notes-off.
+- **Tests**: `runtime.rs#midi_tests` (6) prove absolute-sample resolution,
+  off-before-on, zero-length skip, on/off firing + active tracking, seek-before
+  fires, seek-after does not, all-notes-off clears.
+
+## TODO (Phase 2B and beyond)
+- **VST3 instrument event input**: the C++ bridge has no IEventList input. Add a
+  minimal C-ABI (`sphere_daux_vst3_send_note_on/off` filling `processData.
+  inputEvents` for the next process call), then route `RuntimeMidiEvent` →
+  instrument insert at `schedule_midi_block`'s marked hook. Audio effects keep
+  working (additive API).
+- **Instrument track routing**: MIDI track / instrument insert → audio out.
+- **Tempo automation**: scheduling is constant-BPM; events are sample-resolved
+  at build time. Tempo changes currently require a project rebuild.
+- **Loop**: re-arm cursors / flush at loop boundaries when transport loop lands.
+- Optional built-in test synth so notes are audible before a VST3 instrument is
+  loaded.


### PR DESCRIPTION
Phase 1 — GPUI Piano Roll editor in the bottom Editor tab: draw/select/ move/resize/delete notes, velocity lane, snap/quantize, per-note cursors + hover, bar/beat ruler header and zoom-aware gridline hierarchy. Model gains transient note id + velocity (velocity round-trips through save/load).

Phase 2A — MIDI flows to DAUx: EngineMidiClipSnapshot/Note + midi_clips in the project snapshot; runtime resolves notes to absolute samples at build time and schedules block-accurate note on/off with per-track cursors, active-note tracking, and all-notes-off on stop/seek. Debug via FUTUREBOARD_MIDI_DEBUG / FUTUREBOARD_MIDI_ENGINE_DEBUG. 6 scheduling unit tests. VST3 instrument event input is Phase 2B (bridge lacks IEventList).

Pen-tool MIDI clips are now empty (no mock midi_clip_new.mid); demo notes only behind FUTUREBOARD_DEMO_MIDI=1.