### PR TITLE
MIDI editor: note mute, clipboard, CC lanes, undo coverage, CC engine playback

### DIFF
--- a/crates/SphereDirectAudioEngine/src/runtime.rs
+++ b/crates/SphereDirectAudioEngine/src/runtime.rs
@@ -169,6 +169,9 @@ pub struct RuntimeClip {
 pub enum RuntimeMidiEventKind {
     NoteOff,
     NoteOn,
+    /// MIDI controller change (CC / pitch-bend / aftertouch). Uses
+    /// `cc_number` / `cc_value` rather than `pitch` / `velocity`.
+    ControlChange,
 }
 
 #[derive(Debug, Clone)]
@@ -184,6 +187,11 @@ pub struct RuntimeMidiEvent {
     pub velocity: u8,
     pub channel: u8,
     pub note_id: u64,
+    /// For `ControlChange`: VST3 controller number (`0..=127` CC, `128`
+    /// aftertouch, `129` pitch bend). Unused for note events.
+    pub cc_number: u16,
+    /// For `ControlChange`: normalized value `0.0..=1.0`. Unused for notes.
+    pub cc_value: f32,
 }
 
 /// Structural per-clip representation, retained for logging / future reuse.
@@ -659,6 +667,12 @@ impl RuntimeProject {
                             RuntimeMidiEventKind::NoteOff => {
                                 Vst3MidiEvent::note_off(offset, ev.channel, ev.pitch, 0.0)
                             }
+                            RuntimeMidiEventKind::ControlChange => Vst3MidiEvent::control_change(
+                                offset,
+                                ev.channel,
+                                ev.cc_number,
+                                ev.cc_value,
+                            ),
                         };
                         self.tracks[ti].midi_block_events.push(midi_ev);
                     } else if vst3_debug {
@@ -677,6 +691,10 @@ impl RuntimeProject {
                         RuntimeMidiEventKind::NoteOff => eprintln!(
                             "[DAUx MIDI] note_off ch={} pitch={} offset={}",
                             ev.channel, ev.pitch, offset
+                        ),
+                        RuntimeMidiEventKind::ControlChange => eprintln!(
+                            "[DAUx MIDI] cc ch={} ctrl={} value={:.3} offset={}",
+                            ev.channel, ev.cc_number, ev.cc_value, offset
                         ),
                     }
                 }
@@ -966,6 +984,8 @@ fn apply_active(active: &mut Vec<(u8, u8)>, ev: &RuntimeMidiEvent) {
         RuntimeMidiEventKind::NoteOff => {
             active.retain(|k| *k != key);
         }
+        // Controller changes carry no sounding-note state.
+        RuntimeMidiEventKind::ControlChange => {}
     }
 }
 
@@ -1002,6 +1022,8 @@ fn build_midi_runtime(
                 velocity,
                 channel,
                 note_id: note.id,
+                cc_number: 0,
+                cc_value: 0.0,
             });
             events.push(RuntimeMidiEvent {
                 sample: off_sample,
@@ -1011,7 +1033,28 @@ fn build_midi_runtime(
                 velocity: 0,
                 channel,
                 note_id: note.id,
+                cc_number: 0,
+                cc_value: 0.0,
             });
+        }
+        // Controller points → ControlChange events (block-level value).
+        for lane in &clip.controllers {
+            let channel = lane.channel.min(15);
+            for point in &lane.points {
+                let abs_beat = clip.start_beat + point.beat.max(0.0);
+                let sample = (abs_beat * samples_per_beat).round().max(0.0) as u64;
+                events.push(RuntimeMidiEvent {
+                    sample,
+                    beat: abs_beat,
+                    kind: RuntimeMidiEventKind::ControlChange,
+                    pitch: 0,
+                    velocity: 0,
+                    channel,
+                    note_id: 0,
+                    cc_number: lane.controller,
+                    cc_value: point.value.clamp(0.0, 1.0),
+                });
+            }
         }
         // Sort by sample; NoteOff before NoteOn at the same sample.
         events.sort_by(|a, b| {
@@ -1108,7 +1151,10 @@ fn f32_load(v: u32) -> f32 {
 #[cfg(test)]
 mod midi_tests {
     use super::*;
-    use crate::types::{EngineMidiClipSnapshot, EngineMidiNoteSnapshot};
+    use crate::types::{
+        EngineMidiClipSnapshot, EngineMidiControllerLane, EngineMidiControllerPoint,
+        EngineMidiNoteSnapshot,
+    };
 
     // 120 BPM @ 48 kHz → 24000 samples per beat.
     const SPB: f64 = 24000.0;
@@ -1127,6 +1173,7 @@ mod midi_tests {
                 velocity: 100,
                 channel: 0,
             }],
+            controllers: Vec::new(),
         }
     }
 
@@ -1209,5 +1256,57 @@ mod midi_tests {
         assert_eq!(p.midi_tracks[0].active.len(), 1);
         p.all_notes_off("stop");
         assert!(p.midi_tracks[0].active.is_empty());
+    }
+
+    #[test]
+    fn controller_points_resolve_to_control_change_events() {
+        let mut clip = clip_with_one_note();
+        clip.controllers = vec![EngineMidiControllerLane {
+            controller: 11,
+            channel: 0,
+            points: vec![
+                EngineMidiControllerPoint {
+                    beat: 0.0,
+                    value: 0.25,
+                },
+                EngineMidiControllerPoint {
+                    beat: 2.0,
+                    value: 0.75,
+                },
+            ],
+        }];
+        let p = project_with(vec![clip]);
+        let cc: Vec<&RuntimeMidiEvent> = p.midi_tracks[0]
+            .events
+            .iter()
+            .filter(|e| e.kind == RuntimeMidiEventKind::ControlChange)
+            .collect();
+        assert_eq!(cc.len(), 2);
+        // First point: abs beat 4.0 → 96000 sa, cc 11, value 0.25.
+        assert_eq!(cc[0].cc_number, 11);
+        assert_eq!(cc[0].sample, 96_000);
+        assert!((cc[0].cc_value - 0.25).abs() < 1e-6);
+        // Second point: abs beat 6.0 → 144000 sa, value 0.75.
+        assert_eq!(cc[1].sample, 144_000);
+        assert!((cc[1].cc_value - 0.75).abs() < 1e-6);
+    }
+
+    #[test]
+    fn control_change_does_not_affect_active_notes() {
+        let mut clip = clip_with_one_note();
+        clip.controllers = vec![EngineMidiControllerLane {
+            controller: 1,
+            channel: 0,
+            points: vec![EngineMidiControllerPoint {
+                beat: 0.0,
+                value: 0.5,
+            }],
+        }];
+        let mut p = project_with(vec![clip]);
+        p.reset_midi_playback(0);
+        // Block covering the CC at abs beat 4.0 (96000) but the note also starts
+        // there — active set should track only the note, not the CC.
+        p.schedule_midi_block(96_000, 512);
+        assert_eq!(p.midi_tracks[0].active, vec![(0u8, 60u8)]);
     }
 }

--- a/crates/SphereDirectAudioEngine/src/types.rs
+++ b/crates/SphereDirectAudioEngine/src/types.rs
@@ -180,6 +180,29 @@ pub struct EngineMidiClipSnapshot {
     pub start_beat: f64,
     pub length_beats: f64,
     pub notes: Vec<EngineMidiNoteSnapshot>,
+    /// MIDI controller (CC / pitch-bend / aftertouch) lanes for this clip.
+    #[serde(default)]
+    pub controllers: Vec<EngineMidiControllerLane>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EngineMidiControllerPoint {
+    /// Beat relative to the clip start.
+    pub beat: f64,
+    /// Normalized controller value, `0.0..=1.0`.
+    pub value: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EngineMidiControllerLane {
+    /// VST3 controller number: `0..=127` = MIDI CC, `128` = aftertouch,
+    /// `129` = pitch bend. Matches `Steinberg::Vst::ControllerNumbers`.
+    pub controller: u16,
+    #[serde(default)]
+    pub channel: u8,
+    pub points: Vec<EngineMidiControllerPoint>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/SphereDirectAudioEngine/src/vst3_processor.rs
+++ b/crates/SphereDirectAudioEngine/src/vst3_processor.rs
@@ -14,6 +14,11 @@ pub fn vst3_midi_debug_enabled() -> bool {
 pub enum Vst3MidiEventKind {
     NoteOff = 0,
     NoteOn = 1,
+    /// MIDI controller change. `pitch` carries the VST3 controller number
+    /// (`0..=127` CC, `128` aftertouch, `129` pitch bend) and `velocity` the
+    /// normalized value `0.0..=1.0`. The C++ bridge maps it to a parameter
+    /// change via `IMidiMapping`.
+    ControlChange = 2,
 }
 
 /// C-compatible MIDI event for `sphere_daux_vst3_process_stereo_block_with_midi`.
@@ -47,6 +52,19 @@ impl Vst3MidiEvent {
             channel,
             pitch,
             velocity,
+        }
+    }
+
+    /// A controller change. `controller` is the VST3 controller number; values
+    /// `0..=129` fit in the `pitch` byte. `value` is normalized `0.0..=1.0`.
+    #[inline]
+    pub fn control_change(sample_offset: u32, channel: u8, controller: u16, value: f32) -> Self {
+        Self {
+            sample_offset,
+            kind: Vst3MidiEventKind::ControlChange as u8,
+            channel,
+            pitch: controller as u8,
+            velocity: value,
         }
     }
 }

--- a/crates/SphereDirectAudioEngine/vst3bridge/include/sphere_daux_vst3_processor.h
+++ b/crates/SphereDirectAudioEngine/vst3bridge/include/sphere_daux_vst3_processor.h
@@ -36,8 +36,13 @@ SPHERE_DAUX_VST3_API int sphere_daux_vst3_process_stereo_block(
     float* out_r,
     int frames);
 
-/// MIDI note event for batched delivery via processData.inputEvents.
-/// kind: 0 = NoteOff, 1 = NoteOn. velocity is normalized [0.0, 1.0].
+/// MIDI event for batched delivery via processData.
+/// kind: 0 = NoteOff, 1 = NoteOn, 2 = ControlChange.
+/// For notes: `pitch` is the MIDI key, `velocity` is normalized [0.0, 1.0].
+/// For ControlChange: `pitch` is the VST3 controller number (0..127 = MIDI CC,
+/// 128 = aftertouch, 129 = pitch bend) and `velocity` is the normalized value
+/// [0.0, 1.0]. CC events are routed to parameter changes via IMidiMapping and
+/// are ignored when the plugin exposes no mapping.
 typedef struct SphereDauxVst3MidiEvent {
     unsigned int sample_offset;
     unsigned char kind;

--- a/crates/SphereDirectAudioEngine/vst3bridge/src/vst3_processor.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/vst3_processor.cpp
@@ -31,6 +31,7 @@
 #include "pluginterfaces/vst/ivstcomponent.h"
 #include "pluginterfaces/vst/ivsteditcontroller.h"
 #include "pluginterfaces/vst/ivstevents.h"
+#include "pluginterfaces/vst/ivstmidicontrollers.h"
 #include "pluginterfaces/vst/ivstparameterchanges.h"
 #include "pluginterfaces/vst/ivstprocesscontext.h"
 #include "public.sdk/source/vst/hosting/hostclasses.h"
@@ -389,6 +390,9 @@ struct SphereDauxVst3Processor {
   Steinberg::IPtr<Steinberg::Vst::IComponent>       component;
   Steinberg::IPtr<Steinberg::Vst::IAudioProcessor>  processor;
   Steinberg::IPtr<Steinberg::Vst::IEditController>  controller;
+  /// MIDI controller → parameter mapping (queried from `controller`). Null when
+  /// the plugin exposes no IMidiMapping; CC events are then ignored.
+  Steinberg::IPtr<Steinberg::Vst::IMidiMapping>     midi_mapping;
   Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> component_connection;
   Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> controller_connection;
   bool controller_is_component{false};
@@ -623,6 +627,12 @@ struct SphereDauxVst3Processor {
         std::fprintf(stderr,
                      "[DAUx VST3] setComponentHandler not accepted (result=%d) — "
                      "GUI edits may not reach processor\n", (int)ch_res);
+
+      // MIDI controller → parameter mapping (optional). Used to route CC /
+      // pitch-bend / aftertouch input to parameter changes during process().
+      midi_mapping = Steinberg::FUnknownPtr<Steinberg::Vst::IMidiMapping>(controller);
+      std::fprintf(stderr, "[DAUx VST3] IMidiMapping %s\n",
+                   midi_mapping ? "available" : "not exposed");
     }
 
     return true;
@@ -657,36 +667,62 @@ struct SphereDauxVst3Processor {
 
   // ── Thread-safe parameter enqueue (called from audio thread OR GUI thread) ──
 
-  /// Drain pending parameters and optionally fill inputEvents for this block.
+  /// Drain pending parameters, route MIDI CC to parameter changes, and fill
+  /// inputEvents with note on/off for this block.
   void prepare_process_io(const SphereDauxVst3MidiEvent* midi_events,
                           int midi_event_count) {
+    // Parameter changes come from two sources this block: GUI/host edits queued
+    // in `pending_buf`, and CC events mapped via IMidiMapping below.
+    param_changes_obj.reset();
     {
       std::lock_guard<std::mutex> lock(pending_mutex);
-      if (pending_count > 0) {
-        param_changes_obj.reset();
-        for (int i = 0; i < pending_count; ++i) {
-          Steinberg::int32 idx = 0;
-          auto* q = param_changes_obj.addParameterData(pending_buf[i].id, idx);
-          if (q) {
-            Steinberg::int32 dummy = 0;
-            q->addPoint(0, pending_buf[i].value, dummy);
-          }
+      for (int i = 0; i < pending_count; ++i) {
+        Steinberg::int32 idx = 0;
+        auto* q = param_changes_obj.addParameterData(pending_buf[i].id, idx);
+        if (q) {
+          Steinberg::int32 dummy = 0;
+          q->addPoint(0, pending_buf[i].value, dummy);
         }
-        pending_count = 0;
-        process_data.inputParameterChanges = &param_changes_obj;
-      } else {
-        process_data.inputParameterChanges = nullptr;
       }
+      pending_count = 0;
     }
 
     input_events_obj.reset();
-    if (event_input_bus_count > 0 && midi_events && midi_event_count > 0) {
+    int cc_mapped = 0;
+    if (midi_events && midi_event_count > 0) {
       const int n = std::min(midi_event_count, SimpleEventList::kMaxEvents);
       for (int i = 0; i < n; ++i) {
         const auto& m = midi_events[i];
         const auto ch = static_cast<Steinberg::int16>(m.channel & 0x0F);
-        const auto pitch = static_cast<Steinberg::int16>(m.pitch & 0x7F);
         const auto offset = static_cast<Steinberg::int32>(m.sample_offset);
+        if (m.kind == 2) {
+          // ControlChange → parameter change via IMidiMapping. `pitch` carries
+          // the VST3 controller number (not masked to 7 bits: 128/129 are
+          // aftertouch / pitch bend). The block-level value wins (our
+          // SimpleParamValueQueue holds a single point).
+          if (!midi_mapping) {
+            continue;
+          }
+          const auto ctrl = static_cast<Steinberg::Vst::CtrlNumber>(m.pitch);
+          Steinberg::Vst::ParamID pid = 0;
+          if (midi_mapping->getMidiControllerAssignment(0, ch, ctrl, pid) ==
+              Steinberg::kResultOk) {
+            Steinberg::int32 idx = 0;
+            auto* q = param_changes_obj.addParameterData(pid, idx);
+            if (q) {
+              Steinberg::int32 dummy = 0;
+              q->addPoint(offset,
+                          static_cast<Steinberg::Vst::ParamValue>(m.velocity),
+                          dummy);
+              ++cc_mapped;
+            }
+          }
+          continue;
+        }
+        if (event_input_bus_count <= 0) {
+          continue;
+        }
+        const auto pitch = static_cast<Steinberg::int16>(m.pitch & 0x7F);
         if (m.kind == 1) {
           input_events_obj.push_note_on(offset, ch, pitch, m.velocity);
         } else {
@@ -694,13 +730,11 @@ struct SphereDauxVst3Processor {
         }
       }
       input_events_obj.sort_by_sample_offset();
-      process_data.inputEvents = &input_events_obj;
 
       if (daux_vst3_midi_debug()) {
         std::fprintf(stderr,
-                     "[VST3 MIDI] block events=%d eventInputBuses=%d\n",
-                     input_events_obj.count,
-                     event_input_bus_count);
+                     "[VST3 MIDI] block notes=%d cc=%d eventInputBuses=%d\n",
+                     input_events_obj.count, cc_mapped, event_input_bus_count);
         for (int i = 0; i < input_events_obj.count; ++i) {
           const auto& e = input_events_obj.events[i];
           if (e.type == Steinberg::Vst::Event::kNoteOnEvent) {
@@ -717,9 +751,12 @@ struct SphereDauxVst3Processor {
           }
         }
       }
-    } else {
-      process_data.inputEvents = nullptr;
     }
+
+    process_data.inputParameterChanges =
+        (param_changes_obj.count > 0) ? &param_changes_obj : nullptr;
+    process_data.inputEvents =
+        (input_events_obj.count > 0) ? &input_events_obj : nullptr;
   }
 
   /// Add or update a parameter change in the pending queue.

--- a/crates/SphereUIComponents/src/components/edit/edit_commands.rs
+++ b/crates/SphereUIComponents/src/components/edit/edit_commands.rs
@@ -1,6 +1,8 @@
 //! Undo/redo edit commands — all timeline mutations go through here.
 
-use crate::components::timeline::timeline_state::{ClipState, MidiNoteState, TimelineState};
+use crate::components::timeline::timeline_state::{
+    ClipState, MidiControllerKind, MidiControllerPoint, MidiNoteState, TimelineState,
+};
 
 /// Snapshot of a clip plus its owning track for undo/redo.
 #[derive(Debug, Clone)]
@@ -40,9 +42,38 @@ pub enum EditCommand {
         clip_id: String,
         note: MidiNoteState,
     },
+    /// Batch note insert (paste / duplicate) — one undo entry for the group.
+    CreateMidiNotes {
+        clip_id: String,
+        notes: Vec<MidiNoteState>,
+    },
     DeleteMidiNotes {
         clip_id: String,
         notes: Vec<MidiNoteState>,
+    },
+    /// Set the muted flag on a set of notes. `prev` snapshots each note's
+    /// original muted state so undo restores it exactly.
+    SetMidiNotesMuted {
+        clip_id: String,
+        prev: Vec<(u64, bool)>,
+        muted: bool,
+    },
+    /// In-place transform of a fixed set of notes (move / resize / velocity /
+    /// quantize / transpose / nudge). The note set is unchanged — only field
+    /// values differ — so `prev`/`next` carry full per-id snapshots and
+    /// execute/undo simply overwrite matching notes by id.
+    EditMidiNotes {
+        clip_id: String,
+        prev: Vec<MidiNoteState>,
+        next: Vec<MidiNoteState>,
+    },
+    /// Replace a controller lane's points (draw / erase gesture). One entry per
+    /// gesture; `prev`/`next` are full point snapshots of the lane.
+    SetControllerPoints {
+        clip_id: String,
+        kind: MidiControllerKind,
+        prev: Vec<MidiControllerPoint>,
+        next: Vec<MidiControllerPoint>,
     },
 }
 
@@ -53,7 +84,17 @@ impl EditCommand {
             EditCommand::DeleteClip { .. } => "Delete Clip",
             EditCommand::BatchDeleteClips { .. } => "Delete Clips",
             EditCommand::CreateMidiNote { .. } => "Create MIDI Note",
+            EditCommand::CreateMidiNotes { .. } => "Add MIDI Notes",
             EditCommand::DeleteMidiNotes { .. } => "Delete MIDI Notes",
+            EditCommand::SetMidiNotesMuted { muted, .. } => {
+                if *muted {
+                    "Mute Notes"
+                } else {
+                    "Unmute Notes"
+                }
+            }
+            EditCommand::EditMidiNotes { .. } => "Edit MIDI Notes",
+            EditCommand::SetControllerPoints { .. } => "Edit CC Lane",
         }
     }
 
@@ -84,9 +125,38 @@ impl EditCommand {
                 // always contained. Applies to redo too.
                 state.expand_clip_to_contain_notes(clip_id);
             }
+            EditCommand::CreateMidiNotes { clip_id, notes } => {
+                if let Some(existing) = state.midi_clip_notes_mut(clip_id) {
+                    for note in notes {
+                        if !existing.iter().any(|n| n.id == note.id) {
+                            existing.push(note.clone());
+                        }
+                    }
+                }
+                state.expand_clip_to_contain_notes(clip_id);
+            }
             EditCommand::DeleteMidiNotes { clip_id, notes } => {
                 let ids: Vec<u64> = notes.iter().map(|n| n.id).collect();
                 state.delete_midi_notes(clip_id, &ids);
+            }
+            EditCommand::SetMidiNotesMuted {
+                clip_id,
+                prev,
+                muted,
+            } => {
+                let ids: Vec<u64> = prev.iter().map(|(id, _)| *id).collect();
+                state.set_midi_notes_muted(clip_id, &ids, *muted);
+            }
+            EditCommand::EditMidiNotes { clip_id, next, .. } => {
+                state.overwrite_midi_notes(clip_id, next);
+            }
+            EditCommand::SetControllerPoints {
+                clip_id,
+                kind,
+                next,
+                ..
+            } => {
+                state.set_controller_lane_points(clip_id, *kind, next.clone());
             }
         }
     }
@@ -107,6 +177,10 @@ impl EditCommand {
             EditCommand::CreateMidiNote { clip_id, note } => {
                 state.delete_midi_notes(clip_id, &[note.id]);
             }
+            EditCommand::CreateMidiNotes { clip_id, notes } => {
+                let ids: Vec<u64> = notes.iter().map(|n| n.id).collect();
+                state.delete_midi_notes(clip_id, &ids);
+            }
             EditCommand::DeleteMidiNotes { clip_id, notes } => {
                 if let Some(existing) = state.midi_clip_notes_mut(clip_id) {
                     for note in notes {
@@ -115,6 +189,26 @@ impl EditCommand {
                         }
                     }
                 }
+            }
+            EditCommand::SetMidiNotesMuted { clip_id, prev, .. } => {
+                if let Some(existing) = state.midi_clip_notes_mut(clip_id) {
+                    for (id, was) in prev {
+                        if let Some(note) = existing.iter_mut().find(|n| n.id == *id) {
+                            note.muted = *was;
+                        }
+                    }
+                }
+            }
+            EditCommand::EditMidiNotes { clip_id, prev, .. } => {
+                state.overwrite_midi_notes(clip_id, prev);
+            }
+            EditCommand::SetControllerPoints {
+                clip_id,
+                kind,
+                prev,
+                ..
+            } => {
+                state.set_controller_lane_points(clip_id, *kind, prev.clone());
             }
         }
     }

--- a/crates/SphereUIComponents/src/components/piano_roll.rs
+++ b/crates/SphereUIComponents/src/components/piano_roll.rs
@@ -29,7 +29,8 @@ use gpui::{
 use crate::components::edit::{normalize_range, EditCommand};
 use crate::components::timeline::timeline::Timeline;
 use crate::components::timeline::timeline_state::{
-    midi_debug_enabled, MidiNoteState, MIN_NOTE_BEATS,
+    midi_debug_enabled, MidiControllerKind, MidiControllerPoint, MidiNoteState, TimelineState,
+    MIN_NOTE_BEATS,
 };
 use crate::theme::Colors;
 
@@ -39,10 +40,30 @@ const PITCH_CNT: i32 = 128;
 const TOTAL_H: f32 = PITCH_CNT as f32 * ROW_H;
 const KEY_W: f32 = 56.0; // piano key lane width
 const VEL_H: f32 = 72.0; // velocity lane height
+const CC_H: f32 = 80.0; // controller (CC) lane height
 const RULER_H: f32 = 18.0; // bar/beat ruler header height
 const RESIZE_ZONE: f32 = 6.0; // px on the right edge that starts a resize
 /// Pixels of movement before an empty-grid press becomes a marquee drag.
 const MARQUEE_DRAG_THRESHOLD: f32 = 4.0;
+
+/// A copied note, stored with timing relative to the earliest note in the
+/// selection so paste/duplicate can re-anchor the group at a new beat.
+#[derive(Clone)]
+struct ClipboardNote {
+    pitch: u8,
+    rel_start: f32,
+    duration: f32,
+    velocity: u8,
+    muted: bool,
+}
+
+thread_local! {
+    /// Process-global MIDI note clipboard. Lives outside any single editor so
+    /// copy in the docked piano roll can paste in the floating one (both run on
+    /// the GPUI main thread). Holds relative timing — not real notes.
+    static MIDI_NOTE_CLIPBOARD: std::cell::RefCell<Vec<ClipboardNote>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
 
 /// Strength tier of a vertical timing gridline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -209,6 +230,16 @@ enum PianoDrag {
         current_y: f32,
         erased: HashSet<u64>,
     },
+    /// Paint (left) or erase (right) on the active CC lane. The lane's pre-drag
+    /// points are snapshotted in `cc_edit_prev`; one undo entry on release.
+    CcPaint {
+        erase: bool,
+    },
+    /// Drag an existing CC point (by id) to a new beat/value. Pre-drag points
+    /// are snapshotted in `cc_edit_prev`; one undo entry on release.
+    CcMove {
+        id: u64,
+    },
 }
 
 pub struct PianoRoll {
@@ -232,6 +263,12 @@ pub struct PianoRoll {
     /// Last clip id we ran [`Self::fit_piano_roll_to_notes`] for.
     fitted_clip_id: Option<String>,
     grid_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
+    /// The controller lane currently shown/edited in the CC strip.
+    active_cc: MidiControllerKind,
+    /// Bounds of the CC strip, captured at paint for cursor → beat/value mapping.
+    cc_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
+    /// Lane points snapshotted when a CC paint/erase gesture begins (undo prev).
+    cc_edit_prev: Option<Vec<MidiControllerPoint>>,
     /// Last clip the editor rendered — used to emit the `open_editor` debug log
     /// exactly once when the edited clip changes (not every frame).
     last_editing_clip: Option<String>,
@@ -256,6 +293,9 @@ impl PianoRoll {
             erase_preview_ids: HashSet::new(),
             fitted_clip_id: None,
             grid_bounds: Rc::new(Cell::new(None)),
+            active_cc: MidiControllerKind::CC(1),
+            cc_bounds: Rc::new(Cell::new(None)),
+            cc_edit_prev: None,
             last_editing_clip: None,
             focus: cx.focus_handle(),
         }
@@ -600,28 +640,70 @@ impl PianoRoll {
     }
 
     // ── Mutations through the timeline ────────────────────────────────────
-    fn with_timeline<R>(
+    /// Full snapshots of the given note ids in a clip (undo prev/next state).
+    fn snapshot_notes(&self, cx: &Context<Self>, clip_id: &str, ids: &[u64]) -> Vec<MidiNoteState> {
+        self.timeline
+            .read(cx)
+            .state
+            .midi_clip_notes(clip_id)
+            .map(|notes| {
+                notes
+                    .iter()
+                    .filter(|n| ids.contains(&n.id))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Apply an in-place note transform (move / resize / quantize / transpose /
+    /// nudge / bulk velocity) and record it as one undoable `EditMidiNotes`
+    /// command. Captures full prev/next snapshots of `ids`; a no-op
+    /// (`prev == next`) is dropped without dirtying the project.
+    fn commit_note_transform<F>(&mut self, cx: &mut Context<Self>, ids: &[u64], mutate: F)
+    where
+        F: FnOnce(&mut TimelineState, &str),
+    {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        if ids.is_empty() {
+            return;
+        }
+        let prev = self.snapshot_notes(cx, &clip_id, ids);
+        self.timeline.update(cx, |tl, tcx| {
+            mutate(&mut tl.state, &clip_id);
+            tcx.notify();
+        });
+        let next = self.snapshot_notes(cx, &clip_id, ids);
+        self.push_note_edit(cx, clip_id, prev, next);
+    }
+
+    /// Record an `EditMidiNotes` command for an already-applied transform,
+    /// skipping no-ops. Logs the commit for the floating-editor debug sink.
+    fn push_note_edit(
         &mut self,
         cx: &mut Context<Self>,
-        f: impl FnOnce(&mut Timeline, &mut Context<Timeline>) -> R,
-    ) -> R {
-        let clip_id = self.editing_clip_id(cx);
-        let log_commit = self.midi_editor_sink;
+        clip_id: String,
+        prev: Vec<MidiNoteState>,
+        next: Vec<MidiNoteState>,
+    ) {
+        if prev == next {
+            return;
+        }
         self.timeline.update(cx, |tl, tcx| {
-            let r = f(tl, tcx);
-            tl.mark_project_changed(tcx);
-            if log_commit {
-                let notes = clip_id
-                    .as_ref()
-                    .and_then(|cid| tl.state.midi_clip_notes(cid).map(|n| n.len()))
-                    .unwrap_or(0);
-                crate::components::midi_editor_window::midi_editor_debug(&format!(
-                    "edit commit notes={notes} engine_dirty=true"
-                ));
-            }
-            tcx.notify();
-            r
-        })
+            tl.record_executed_command(
+                EditCommand::EditMidiNotes {
+                    clip_id,
+                    prev,
+                    next,
+                },
+                tcx,
+            );
+        });
+        if self.midi_editor_sink {
+            crate::components::midi_editor_window::midi_editor_debug("edit command committed");
+        }
     }
 
     /// Mutate the timeline for a *live* gesture (drag in progress): repaint but
@@ -637,26 +719,6 @@ impl PianoRoll {
             tcx.notify();
             r
         })
-    }
-
-    fn mark_project_dirty(&mut self, cx: &mut Context<Self>) {
-        if self.midi_editor_sink {
-            let notes = self
-                .editing_clip_id(cx)
-                .and_then(|cid| {
-                    self.timeline
-                        .read(cx)
-                        .state
-                        .midi_clip_notes(&cid)
-                        .map(|n| n.len())
-                })
-                .unwrap_or(0);
-            crate::components::midi_editor_window::midi_editor_debug(&format!(
-                "edit commit notes={notes} engine_dirty=true"
-            ));
-        }
-        self.timeline
-            .update(cx, |tl, tcx| tl.mark_project_changed(tcx));
     }
 
     fn run_edit_command(&mut self, cmd: EditCommand, cx: &mut Context<Self>) {
@@ -884,6 +946,21 @@ impl PianoRoll {
     }
 
     fn on_move(&mut self, event: &MouseMoveEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        match self.drag {
+            PianoDrag::CcPaint { erase } => {
+                if let Some((lx, ly)) = self.cc_local(event.position) {
+                    self.cc_paint_at(lx, ly, erase, cx);
+                }
+                return;
+            }
+            PianoDrag::CcMove { id } => {
+                if let Some((lx, ly)) = self.cc_local(event.position) {
+                    self.cc_move_to(id, lx, ly, cx);
+                }
+                return;
+            }
+            _ => {}
+        }
         if event.pressed_button == Some(MouseButton::Right) {
             let Some((lx, ly)) = self.grid_local(event.position) else {
                 return;
@@ -996,6 +1073,7 @@ impl PianoRoll {
             }
             PianoDrag::MarqueeSelect { .. } => {}
             PianoDrag::DrawNote { .. } | PianoDrag::EraseNotes { .. } => {}
+            PianoDrag::CcPaint { .. } | PianoDrag::CcMove { .. } => {}
         }
     }
 
@@ -1060,6 +1138,11 @@ impl PianoRoll {
     }
 
     fn on_up(&mut self, _event: &MouseUpEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        if matches!(self.drag, PianoDrag::CcPaint { .. } | PianoDrag::CcMove { .. }) {
+            self.drag = PianoDrag::None;
+            self.commit_cc_edit(cx);
+            return;
+        }
         if matches!(self.drag, PianoDrag::MarqueeSelect { .. }) {
             self.commit_marquee_select(cx);
             return;
@@ -1104,7 +1187,10 @@ impl PianoRoll {
                 if !changed {
                     return;
                 }
-                self.with_timeline(cx, |tl, _| tl.state.move_midi_notes(&clip_id, &updates));
+                let ids: Vec<u64> = updates.iter().map(|(id, _, _)| *id).collect();
+                self.commit_note_transform(cx, &ids, move |state, cid| {
+                    state.move_midi_notes(cid, &updates)
+                });
             }
             PianoDrag::Resize {
                 id,
@@ -1115,15 +1201,27 @@ impl PianoRoll {
                 if (new_dur - prev_dur).abs() < 0.0001 {
                     return;
                 }
-                self.with_timeline(cx, |tl, _| tl.state.resize_midi_note(&clip_id, id, new_dur));
+                self.commit_note_transform(cx, &[id], move |state, cid| {
+                    state.resize_midi_note(cid, id, new_dur)
+                });
             }
-            PianoDrag::Velocity { .. } => {
-                // Velocity was applied live (silent). Mark dirty once now so
-                // the change is saved / synced.
-                self.mark_project_dirty(cx);
+            PianoDrag::Velocity { id, orig_vel, .. } => {
+                // Velocity was applied live (silent). Reconstruct the pre-drag
+                // state from `orig_vel` and record one undoable edit.
+                let next = self.snapshot_notes(cx, &clip_id, &[id]);
+                let prev: Vec<MidiNoteState> = next
+                    .iter()
+                    .map(|n| {
+                        let mut p = n.clone();
+                        p.velocity = orig_vel;
+                        p
+                    })
+                    .collect();
+                self.push_note_edit(cx, clip_id, prev, next);
             }
             PianoDrag::MarqueeSelect { .. } => {}
             PianoDrag::DrawNote { .. } | PianoDrag::EraseNotes { .. } => {}
+            PianoDrag::CcPaint { .. } | PianoDrag::CcMove { .. } => {}
         }
     }
 
@@ -1150,6 +1248,22 @@ impl PianoRoll {
                 self.selection = all.into_iter().collect();
                 cx.notify();
             }
+            "c" if ctrl => {
+                cx.stop_propagation();
+                self.copy_selection(cx);
+            }
+            "v" if ctrl => {
+                cx.stop_propagation();
+                self.paste_clipboard(cx);
+            }
+            "d" if ctrl => {
+                cx.stop_propagation();
+                self.duplicate_selection(cx);
+            }
+            "m" if !ctrl => {
+                cx.stop_propagation();
+                self.toggle_mute_selection(cx);
+            }
             "escape" => {
                 cx.stop_propagation();
                 if matches!(self.drag, PianoDrag::MarqueeSelect { .. }) {
@@ -1173,10 +1287,21 @@ impl PianoRoll {
         let Some(clip_id) = self.editing_clip_id(cx) else {
             return;
         };
-        let ids: Vec<u64> = self.selection.iter().copied().collect();
+        // Empty selection means quantize every note in the clip.
+        let mut ids: Vec<u64> = self.selection.iter().copied().collect();
+        if ids.is_empty() {
+            ids = self
+                .timeline
+                .read(cx)
+                .state
+                .midi_clip_notes(&clip_id)
+                .map(|notes| notes.iter().map(|n| n.id).collect())
+                .unwrap_or_default();
+        }
         let step = self.grid_res.beats();
-        self.with_timeline(cx, |tl, _| {
-            tl.state.quantize_midi_notes(&clip_id, &ids, step);
+        let target_ids = ids.clone();
+        self.commit_note_transform(cx, &ids, move |state, cid| {
+            state.quantize_midi_notes(cid, &target_ids, step);
         });
     }
 
@@ -1206,6 +1331,175 @@ impl PianoRoll {
         }
         self.run_edit_command(EditCommand::DeleteMidiNotes { clip_id, notes }, cx);
         self.selection.clear();
+    }
+
+    /// Toggle mute on the selection. When the selection is mixed, the gesture
+    /// mutes everything (the common DAW behaviour); when all are already muted
+    /// it unmutes. Routed through an undoable command.
+    fn toggle_mute_selection(&mut self, cx: &mut Context<Self>) {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        if self.selection.is_empty() {
+            return;
+        }
+        let prev: Vec<(u64, bool)> = self
+            .timeline
+            .read(cx)
+            .state
+            .midi_clip_notes(&clip_id)
+            .map(|notes| {
+                notes
+                    .iter()
+                    .filter(|n| self.selection.contains(&n.id))
+                    .map(|n| (n.id, n.muted))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if prev.is_empty() {
+            return;
+        }
+        // Unmute only when every selected note is already muted.
+        let muted = !prev.iter().all(|(_, m)| *m);
+        self.run_edit_command(
+            EditCommand::SetMidiNotesMuted {
+                clip_id,
+                prev,
+                muted,
+            },
+            cx,
+        );
+    }
+
+    /// Copy the current selection into the process-global note clipboard,
+    /// storing timing relative to the earliest selected note.
+    fn copy_selection(&mut self, cx: &mut Context<Self>) {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let notes: Vec<MidiNoteState> = self
+            .timeline
+            .read(cx)
+            .state
+            .midi_clip_notes(&clip_id)
+            .map(|notes| {
+                notes
+                    .iter()
+                    .filter(|n| self.selection.contains(&n.id))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        if notes.is_empty() {
+            return;
+        }
+        let min_start = notes.iter().map(|n| n.start).fold(f32::INFINITY, f32::min);
+        let clip: Vec<ClipboardNote> = notes
+            .iter()
+            .map(|n| ClipboardNote {
+                pitch: n.pitch,
+                rel_start: (n.start - min_start).max(0.0),
+                duration: n.duration,
+                velocity: n.velocity,
+                muted: n.muted,
+            })
+            .collect();
+        MIDI_NOTE_CLIPBOARD.with(|cb| *cb.borrow_mut() = clip);
+        if midi_debug_enabled() {
+            eprintln!("[midi] copy notes={}", notes.len());
+        }
+    }
+
+    /// Build notes from the clipboard anchored so the earliest note lands at
+    /// `anchor_beat` (clip-local). Returns an empty vec when the clipboard is
+    /// empty. New notes get fresh transient ids.
+    fn clipboard_notes_at(&self, anchor_beat: f32) -> Vec<MidiNoteState> {
+        MIDI_NOTE_CLIPBOARD.with(|cb| {
+            cb.borrow()
+                .iter()
+                .map(|c| {
+                    let mut note = MidiNoteState::new(
+                        c.pitch,
+                        (anchor_beat + c.rel_start).max(0.0),
+                        c.duration,
+                        c.velocity,
+                    );
+                    note.muted = c.muted;
+                    note
+                })
+                .collect()
+        })
+    }
+
+    /// Paste the clipboard at the playhead (clip-local), falling back to clip
+    /// beat 0 when the playhead is outside the clip. The pasted notes become the
+    /// new selection.
+    fn paste_clipboard(&mut self, cx: &mut Context<Self>) {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let (clip_start, _clip_len) = self.clip_meta(cx, &clip_id);
+        let playhead = self.timeline.read(cx).state.transport.playhead_beats;
+        let anchor = self.snap_beats((playhead - clip_start).max(0.0));
+        let notes = self.clipboard_notes_at(anchor);
+        if notes.is_empty() {
+            return;
+        }
+        let new_ids: Vec<u64> = notes.iter().map(|n| n.id).collect();
+        self.run_edit_command(EditCommand::CreateMidiNotes { clip_id, notes }, cx);
+        self.selection = new_ids.into_iter().collect();
+        if midi_debug_enabled() {
+            eprintln!("[midi] paste anchor={:.3} count={}", anchor, self.selection.len());
+        }
+        cx.notify();
+    }
+
+    /// Duplicate the selection in place, offset forward by the selection's beat
+    /// span so the copies sit immediately after the originals. Selects the new
+    /// notes. Does not use the clipboard.
+    fn duplicate_selection(&mut self, cx: &mut Context<Self>) {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let src: Vec<MidiNoteState> = self
+            .timeline
+            .read(cx)
+            .state
+            .midi_clip_notes(&clip_id)
+            .map(|notes| {
+                notes
+                    .iter()
+                    .filter(|n| self.selection.contains(&n.id))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        if src.is_empty() {
+            return;
+        }
+        let min_start = src.iter().map(|n| n.start).fold(f32::INFINITY, f32::min);
+        let max_end = src
+            .iter()
+            .map(|n| n.start + n.duration)
+            .fold(0.0_f32, f32::max);
+        // Offset by the span, snapped so duplicates stay grid-aligned.
+        let offset = self.snap_beats(max_end - min_start).max(self.step_beats());
+        let notes: Vec<MidiNoteState> = src
+            .iter()
+            .map(|n| {
+                let mut note =
+                    MidiNoteState::new(n.pitch, n.start + offset, n.duration, n.velocity);
+                note.muted = n.muted;
+                note
+            })
+            .collect();
+        let new_ids: Vec<u64> = notes.iter().map(|n| n.id).collect();
+        self.run_edit_command(EditCommand::CreateMidiNotes { clip_id, notes }, cx);
+        self.selection = new_ids.into_iter().collect();
+        if midi_debug_enabled() {
+            eprintln!("[midi] duplicate offset={:.3} count={}", offset, self.selection.len());
+        }
+        cx.notify();
     }
 
     fn note_inspector_snapshot(&self, cx: &Context<Self>, clip_id: &str) -> NoteInspectorSnapshot {
@@ -1252,8 +1546,9 @@ impl PianoRoll {
         if !will_change {
             return;
         }
-        self.with_timeline(cx, |tl, _| {
-            tl.state.transpose_midi_notes(&clip_id, &ids, semitones);
+        let target_ids = ids.clone();
+        self.commit_note_transform(cx, &ids, move |state, cid| {
+            state.transpose_midi_notes(cid, &target_ids, semitones);
         });
     }
 
@@ -1285,8 +1580,9 @@ impl PianoRoll {
         if updates.is_empty() {
             return;
         }
-        self.with_timeline(cx, |tl, _| {
-            tl.state.move_midi_notes(&clip_id, &updates);
+        let ids: Vec<u64> = updates.iter().map(|(id, _, _)| *id).collect();
+        self.commit_note_transform(cx, &ids, move |state, cid| {
+            state.move_midi_notes(cid, &updates);
         });
     }
 
@@ -1317,9 +1613,10 @@ impl PianoRoll {
         if updates.is_empty() {
             return;
         }
-        self.with_timeline(cx, |tl, _| {
+        let ids: Vec<u64> = updates.iter().map(|(id, _)| *id).collect();
+        self.commit_note_transform(cx, &ids, move |state, cid| {
             for (id, duration) in updates {
-                tl.state.set_midi_note_length(&clip_id, id, duration);
+                state.set_midi_note_length(cid, id, duration);
             }
         });
     }
@@ -1351,9 +1648,10 @@ impl PianoRoll {
         if updates.is_empty() {
             return;
         }
-        self.with_timeline(cx, |tl, _| {
+        let ids: Vec<u64> = updates.iter().map(|(id, _)| *id).collect();
+        self.commit_note_transform(cx, &ids, move |state, cid| {
             for (id, velocity) in updates {
-                tl.state.set_midi_note_velocity(&clip_id, id, velocity);
+                state.set_midi_note_velocity(cid, id, velocity);
             }
         });
     }
@@ -1689,6 +1987,7 @@ impl PianoRoll {
         let tool = self.tool;
         let snap_on = self.snap_on;
         let grid_label = self.grid_res.label();
+        let cc_label = cc_kind_label(self.active_cc);
 
         div()
             .flex()
@@ -1749,6 +2048,29 @@ impl PianoRoll {
                 "Del",
                 false,
                 cx.listener(|this, _, _w, cx| this.delete_selection(cx)),
+            ))
+            .child(divider())
+            .child(tool_btn(
+                "pr-mute",
+                "Mute",
+                false,
+                cx.listener(|this, _, _w, cx| this.toggle_mute_selection(cx)),
+            ))
+            .child(tool_btn(
+                "pr-dup",
+                "Dup",
+                false,
+                cx.listener(|this, _, _w, cx| this.duplicate_selection(cx)),
+            ))
+            .child(divider())
+            .child(tool_btn(
+                "pr-cc",
+                &cc_label,
+                false,
+                cx.listener(|this, _, _w, cx| {
+                    this.active_cc = cc_cycle(this.active_cc);
+                    cx.notify();
+                }),
             ))
             .child(divider())
             .child(tool_btn(
@@ -1884,6 +2206,10 @@ impl PianoRoll {
         let erase_overlay = self.build_erase_overlay();
         let vel_bars = self.build_velocity_bars(cx, clip_id, track_color);
         let note_inspector = self.render_note_inspector(cx, clip_id);
+        let cc_label = cc_kind_label(self.active_cc);
+        let cc_lane = self
+            .render_cc_lane(cx, clip_id, start_beat, end_beat, bpb)
+            .into_any_element();
         let grid_cursor = if self.tool == PianoTool::Draw {
             gpui::CursorStyle::Crosshair
         } else {
@@ -1948,6 +2274,21 @@ impl PianoRoll {
                             .text_size(px(8.0))
                             .text_color(Colors::text_muted())
                             .child("VEL"),
+                    )
+                    // CC lane label (aligned to the CC strip on the right).
+                    .child(
+                        div()
+                            .h(px(CC_H))
+                            .w_full()
+                            .border_t(px(1.0))
+                            .border_color(Colors::panel_border())
+                            .bg(Colors::surface_panel())
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .text_size(px(9.0))
+                            .text_color(Colors::text_secondary())
+                            .child(cc_label),
                     ),
             )
             // Right: grid + velocity lane.
@@ -2006,7 +2347,9 @@ impl PianoRoll {
                             .bg(Colors::surface_panel_alt())
                             .children(vel_grid)
                             .children(vel_bars),
-                    ),
+                    )
+                    // CC controller lane.
+                    .child(cc_lane),
             )
             .child(note_inspector)
     }
@@ -2110,6 +2453,16 @@ impl PianoRoll {
                 ])
                 .into_any_element(),
             );
+            let mute_label = if note.muted { "Unmute" } else { "Mute" };
+            content.push(
+                note_button_row(vec![note_action_button(
+                    "pr-note-mute",
+                    mute_label,
+                    cx.listener(|this, _, _w, cx| this.toggle_mute_selection(cx)),
+                )
+                .into_any_element()])
+                .into_any_element(),
+            );
         } else {
             content.push(note_value_row("Selected", count.to_string()).into_any_element());
             content.push(note_value_row("Pitch", snapshot.pitch_label()).into_any_element());
@@ -2163,6 +2516,23 @@ impl PianoRoll {
                         "pr-notes-delete",
                         "Delete",
                         cx.listener(|this, _, _w, cx| this.delete_selection(cx)),
+                    )
+                    .into_any_element(),
+                ])
+                .into_any_element(),
+            );
+            content.push(
+                note_button_row(vec![
+                    note_action_button(
+                        "pr-notes-mute",
+                        "Mute",
+                        cx.listener(|this, _, _w, cx| this.toggle_mute_selection(cx)),
+                    )
+                    .into_any_element(),
+                    note_action_button(
+                        "pr-notes-duplicate",
+                        "Duplicate",
+                        cx.listener(|this, _, _w, cx| this.duplicate_selection(cx)),
                     )
                     .into_any_element(),
                 ])
@@ -2508,7 +2878,7 @@ impl PianoRoll {
         let (view_w, view_h) = self.grid_view_size();
         // Collect owned geometry first so the timeline read borrow is released
         // before we build per-note listeners (which borrow `cx` mutably).
-        let geos: Vec<(u64, f32, f32, f32, bool, bool)> = {
+        let geos: Vec<(u64, f32, f32, f32, bool, bool, bool)> = {
             let tl = self.timeline.read(cx);
             let Some(notes) = tl.state.midi_clip_notes(clip_id) else {
                 return Vec::new();
@@ -2531,16 +2901,21 @@ impl PianoRoll {
                         w,
                         self.selection.contains(&d.id),
                         self.erase_preview_ids.contains(&d.id),
+                        n.muted,
                     ))
                 })
                 .collect()
         };
 
         geos.into_iter()
-            .map(|(id, x, y, w, selected, erase_target)| {
+            .map(|(id, x, y, w, selected, erase_target, muted)| {
                 let mut fill = track_color;
                 fill.a = if erase_target {
                     0.45
+                } else if muted {
+                    // Muted notes read as hollow/dim so they stand apart from
+                    // active notes without leaving the grid.
+                    0.18
                 } else if selected {
                     1.0
                 } else {
@@ -2550,6 +2925,8 @@ impl PianoRoll {
                     Colors::status_error()
                 } else if selected {
                     Colors::text_primary()
+                } else if muted {
+                    Colors::with_alpha(Colors::text_muted(), 0.7)
                 } else {
                     Colors::with_alpha(track_color, 0.55)
                 };
@@ -2667,6 +3044,295 @@ impl PianoRoll {
                     .into_any_element()
             })
             .collect()
+    }
+}
+
+// ── CC controller lane ───────────────────────────────────────────────────────
+const CC_PRESETS: [MidiControllerKind; 7] = [
+    MidiControllerKind::CC(1),
+    MidiControllerKind::CC(7),
+    MidiControllerKind::CC(10),
+    MidiControllerKind::CC(11),
+    MidiControllerKind::CC(64),
+    MidiControllerKind::PitchBend,
+    MidiControllerKind::ChannelPressure,
+];
+
+fn cc_kind_label(kind: MidiControllerKind) -> String {
+    match kind {
+        MidiControllerKind::CC(n) => format!("CC{n}"),
+        MidiControllerKind::PitchBend => "Bend".to_string(),
+        MidiControllerKind::ChannelPressure => "Press".to_string(),
+        MidiControllerKind::PolyPressure => "Poly".to_string(),
+    }
+}
+
+fn cc_cycle(kind: MidiControllerKind) -> MidiControllerKind {
+    let idx = CC_PRESETS.iter().position(|k| *k == kind);
+    match idx {
+        Some(i) => CC_PRESETS[(i + 1) % CC_PRESETS.len()],
+        None => CC_PRESETS[0],
+    }
+}
+
+impl PianoRoll {
+    fn cc_view_size(&self) -> (f32, f32) {
+        match self.cc_bounds.get() {
+            Some(b) => (
+                f32::from(b.size.width).max(1.0),
+                f32::from(b.size.height).max(1.0),
+            ),
+            None => (600.0, CC_H),
+        }
+    }
+
+    fn cc_local(&self, window_pos: gpui::Point<Pixels>) -> Option<(f32, f32)> {
+        let b = self.cc_bounds.get()?;
+        let ox: f32 = b.origin.x.into();
+        let oy: f32 = b.origin.y.into();
+        let x: f32 = window_pos.x.into();
+        let y: f32 = window_pos.y.into();
+        Some((x - ox, y - oy))
+    }
+
+    /// Begin a CC paint (`erase = false`) or erase (`erase = true`) gesture:
+    /// ensure the active lane, snapshot its points for undo, and apply the first
+    /// edit at the cursor.
+    fn begin_cc_paint(
+        &mut self,
+        erase: bool,
+        lx: f32,
+        ly: f32,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.focus(&self.focus);
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let kind = self.active_cc;
+        self.timeline.update(cx, |tl, _| {
+            tl.state.ensure_controller_lane(&clip_id, kind);
+        });
+        self.cc_edit_prev = Some(
+            self.timeline
+                .read(cx)
+                .state
+                .controller_points_snapshot(&clip_id, kind),
+        );
+        self.drag = PianoDrag::CcPaint { erase };
+        self.cc_paint_at(lx, ly, erase, cx);
+        cx.notify();
+    }
+
+    /// Apply one CC edit at a local strip coordinate (live, not yet committed).
+    fn cc_paint_at(&mut self, lx: f32, ly: f32, erase: bool, cx: &mut Context<Self>) {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let kind = self.active_cc;
+        let beat = self.snap_beats(self.x_to_beat(lx));
+        let (_, cc_h) = self.cc_view_size();
+        let value = (1.0 - (ly / cc_h.max(1.0))).clamp(0.0, 1.0);
+        let tol = (self.step_beats() * 0.5).max(1.0e-3);
+        self.timeline.update(cx, |tl, tcx| {
+            if erase {
+                tl.state.delete_controller_points_near(&clip_id, kind, beat, tol);
+            } else {
+                tl.state.put_controller_point(&clip_id, kind, beat, value);
+            }
+            tcx.notify();
+        });
+    }
+
+    /// Hit-test the active lane's points; return the id of one within ~6 px of
+    /// the local strip coordinate.
+    fn cc_point_at(&self, cx: &Context<Self>, clip_id: &str, lx: f32, ly: f32) -> Option<u64> {
+        let (_, cc_h) = self.cc_view_size();
+        let kind = self.active_cc;
+        let tl = self.timeline.read(cx);
+        let points = tl.state.controller_lane_points(clip_id, kind)?;
+        const R: f32 = 6.0;
+        points.iter().find_map(|p| {
+            let x = self.beat_to_x(p.beat);
+            let y = (1.0 - p.value) * (cc_h - 6.0) + 3.0;
+            ((lx - x).abs() <= R && (ly - y).abs() <= R).then_some(p.id)
+        })
+    }
+
+    /// Begin dragging an existing CC point; snapshot the lane for undo.
+    fn begin_cc_move(&mut self, id: u64, window: &mut Window, cx: &mut Context<Self>) {
+        window.focus(&self.focus);
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let kind = self.active_cc;
+        self.cc_edit_prev = Some(
+            self.timeline
+                .read(cx)
+                .state
+                .controller_points_snapshot(&clip_id, kind),
+        );
+        self.drag = PianoDrag::CcMove { id };
+        cx.notify();
+    }
+
+    /// Move the dragged CC point to the cursor (beat snapped, value continuous).
+    fn cc_move_to(&mut self, id: u64, lx: f32, ly: f32, cx: &mut Context<Self>) {
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let kind = self.active_cc;
+        let beat = self.snap_beats(self.x_to_beat(lx));
+        let (_, cc_h) = self.cc_view_size();
+        let value = (1.0 - (ly / cc_h.max(1.0))).clamp(0.0, 1.0);
+        self.timeline.update(cx, |tl, tcx| {
+            tl.state.set_controller_point(&clip_id, kind, id, beat, value);
+            tcx.notify();
+        });
+    }
+
+    /// Commit a finished CC gesture as one undoable command (skips no-ops).
+    fn commit_cc_edit(&mut self, cx: &mut Context<Self>) {
+        let Some(prev) = self.cc_edit_prev.take() else {
+            return;
+        };
+        let Some(clip_id) = self.editing_clip_id(cx) else {
+            return;
+        };
+        let kind = self.active_cc;
+        let next = self
+            .timeline
+            .read(cx)
+            .state
+            .controller_points_snapshot(&clip_id, kind);
+        if prev == next {
+            return;
+        }
+        self.timeline.update(cx, |tl, tcx| {
+            tl.record_executed_command(
+                EditCommand::SetControllerPoints {
+                    clip_id,
+                    kind,
+                    prev,
+                    next,
+                },
+                tcx,
+            );
+        });
+        if self.midi_editor_sink {
+            crate::components::midi_editor_window::midi_editor_debug("edit command committed");
+        }
+    }
+
+    fn build_cc_points(&self, cx: &Context<Self>, clip_id: &str) -> Vec<gpui::AnyElement> {
+        let (view_w, cc_h) = self.cc_view_size();
+        let kind = self.active_cc;
+        let pts: Vec<(f32, f32)> = self
+            .timeline
+            .read(cx)
+            .state
+            .controller_lane_points(clip_id, kind)
+            .map(|ps| ps.iter().map(|p| (p.beat, p.value)).collect())
+            .unwrap_or_default();
+        let accent = Colors::accent_primary();
+        pts.into_iter()
+            .filter_map(|(beat, value)| {
+                let x = self.beat_to_x(beat);
+                if x < -6.0 || x > view_w + 6.0 {
+                    return None;
+                }
+                let y = (1.0 - value) * (cc_h - 6.0) + 3.0;
+                Some(
+                    div()
+                        .absolute()
+                        .left(px(x - 3.0))
+                        .top_0()
+                        .w(px(6.0))
+                        .h_full()
+                        // Stem from the point down to the lane floor.
+                        .child(
+                            div()
+                                .absolute()
+                                .left(px(2.0))
+                                .top(px(y))
+                                .w(px(2.0))
+                                .bottom(px(0.0))
+                                .bg(Colors::with_alpha(accent, 0.35)),
+                        )
+                        // Point dot.
+                        .child(
+                            div()
+                                .absolute()
+                                .left(px(0.0))
+                                .top(px(y - 3.0))
+                                .w(px(6.0))
+                                .h(px(6.0))
+                                .rounded(px(3.0))
+                                .bg(accent),
+                        )
+                        .into_any_element(),
+                )
+            })
+            .collect()
+    }
+
+    /// The CC strip (right column) plus its captured bounds + interaction.
+    fn render_cc_lane(
+        &mut self,
+        cx: &mut Context<Self>,
+        clip_id: &str,
+        start_beat: f32,
+        end_beat: f32,
+        bpb: f32,
+    ) -> impl IntoElement {
+        let grid = self.build_velocity_grid(start_beat, end_beat, bpb);
+        let points = self.build_cc_points(cx, clip_id);
+        let cc_bounds = self.cc_bounds.clone();
+        let canvas = canvas(
+            move |bounds, _w, _cx| cc_bounds.set(Some(bounds)),
+            |_b, _r, _w, _cx| {},
+        )
+        .absolute()
+        .inset_0();
+        div()
+            .id("piano-cc")
+            .h(px(CC_H))
+            .w_full()
+            .relative()
+            .overflow_hidden()
+            .border_t(px(1.0))
+            .border_color(Colors::panel_border())
+            .bg(Colors::surface_panel_alt())
+            .cursor(gpui::CursorStyle::Crosshair)
+            .child(canvas)
+            .children(grid)
+            .children(points)
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, ev: &MouseDownEvent, window, cx| {
+                    cx.stop_propagation();
+                    if let Some((lx, ly)) = this.cc_local(ev.position) {
+                        // Grab an existing point to move it; otherwise paint.
+                        if let Some(cid) = this.editing_clip_id(cx) {
+                            if let Some(id) = this.cc_point_at(cx, &cid, lx, ly) {
+                                this.begin_cc_move(id, window, cx);
+                                return;
+                            }
+                        }
+                        this.begin_cc_paint(false, lx, ly, window, cx);
+                    }
+                }),
+            )
+            .on_mouse_down(
+                MouseButton::Right,
+                cx.listener(|this, ev: &MouseDownEvent, window, cx| {
+                    cx.stop_propagation();
+                    if let Some((lx, ly)) = this.cc_local(ev.position) {
+                        this.begin_cc_paint(true, lx, ly, window, cx);
+                    }
+                }),
+            )
     }
 }
 

--- a/crates/SphereUIComponents/src/components/timeline/midi_clip.rs
+++ b/crates/SphereUIComponents/src/components/timeline/midi_clip.rs
@@ -43,7 +43,7 @@ pub fn midi_clip(
     // Draw notes inside notes preview area (clip-relative beats, clip bounds).
     let mut note_elements = Vec::new();
     let clip_len = clip.duration_beats;
-    if let ClipType::Midi { notes } = &clip.clip_type {
+    if let ClipType::Midi { notes, .. } = &clip.clip_type {
         let in_bounds: Vec<_> = notes
             .iter()
             .filter(|n| n.start < clip_len && n.start + n.duration > 0.0)

--- a/crates/SphereUIComponents/src/components/timeline/timeline.rs
+++ b/crates/SphereUIComponents/src/components/timeline/timeline.rs
@@ -191,6 +191,15 @@ impl Timeline {
         cx.notify();
     }
 
+    /// Record a command whose effect has already been applied to the state
+    /// (e.g. a gesture that mutated `state` live). Pushes it onto the undo
+    /// stack without re-executing, then marks the project changed.
+    pub fn record_executed_command(&mut self, cmd: EditCommand, cx: &mut gpui::Context<Self>) {
+        self.edit_history.push(cmd);
+        self.mark_project_changed(cx);
+        cx.notify();
+    }
+
     pub fn undo_edit(&mut self, cx: &mut gpui::Context<Self>) -> bool {
         if self.edit_history.undo(&mut self.state) {
             self.mark_project_changed(cx);

--- a/crates/SphereUIComponents/src/components/timeline/timeline_state.rs
+++ b/crates/SphereUIComponents/src/components/timeline/timeline_state.rs
@@ -103,12 +103,14 @@ pub struct MidiNoteState {
     pub duration: f32, // beats
     /// MIDI velocity in 1..=127.
     pub velocity: u8,
+    /// Muted notes remain in clip data but emit no runtime note event.
+    pub muted: bool,
 }
 
 impl MidiNoteState {
     /// Construct a note with a freshly minted transient id. `pitch` is clamped
     /// to 0..=127, `velocity` to 1..=127, and `duration` to at least
-    /// [`MIN_NOTE_BEATS`].
+    /// [`MIN_NOTE_BEATS`]. The note is created unmuted.
     pub fn new(pitch: u8, start: f32, duration: f32, velocity: u8) -> Self {
         Self {
             id: next_midi_note_id(),
@@ -116,8 +118,64 @@ impl MidiNoteState {
             start: start.max(0.0),
             duration: duration.max(MIN_NOTE_BEATS),
             velocity: velocity.clamp(1, 127),
+            muted: false,
         }
     }
+}
+
+/// Source of transient identities for controller points (not serialized;
+/// minted fresh on create and on project load, like [`next_midi_note_id`]).
+fn next_controller_point_id() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Which MIDI controller stream a lane edits. CC carries its 0..=127 number;
+/// the others are single global streams per channel. `PolyPressure` is modeled
+/// for completeness but deferred — it needs per-note association the editor does
+/// not yet provide.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MidiControllerKind {
+    CC(u8),
+    PitchBend,
+    ChannelPressure,
+    PolyPressure,
+}
+
+/// A single point in a controller lane. `value` is normalized `0.0..=1.0` in
+/// state; the UI maps it to the controller's display range (e.g. 0..127 for CC).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MidiControllerPoint {
+    /// Transient identity (not serialized) for editor selection / drag targets.
+    pub id: u64,
+    /// Beats relative to the clip start.
+    pub beat: f32,
+    /// Normalized `0.0..=1.0`.
+    pub value: f32,
+}
+
+impl MidiControllerPoint {
+    /// Construct a point with a freshly minted transient id. `beat` clamps to
+    /// `>= 0`, `value` to `0.0..=1.0`.
+    pub fn new(beat: f32, value: f32) -> Self {
+        Self {
+            id: next_controller_point_id(),
+            beat: beat.max(0.0),
+            value: value.clamp(0.0, 1.0),
+        }
+    }
+}
+
+/// One controller lane inside a MIDI clip. Points travel with the clip in
+/// clip-local beats. (Lane create / edit helpers land with the lane editor UI.)
+#[derive(Debug, Clone, PartialEq)]
+pub struct MidiControllerLane {
+    pub kind: MidiControllerKind,
+    pub points: Vec<MidiControllerPoint>,
+    pub visible: bool,
+    pub height: f32,
+    pub collapsed: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -130,6 +188,8 @@ pub enum ClipType {
     },
     Midi {
         notes: Vec<MidiNoteState>,
+        /// MIDI controller (CC / pitch-bend / pressure) lanes for this clip.
+        controller_lanes: Vec<MidiControllerLane>,
     },
 }
 
@@ -1180,6 +1240,7 @@ impl TimelineState {
                         MidiNoteState::new(64, 6.0, 1.0, 90),
                         MidiNoteState::new(60, 7.0, 1.0, 80),
                     ],
+                    controller_lanes: Vec::new(),
                 },
                 muted: false,
                 audio_import: AudioImportState::default(),
@@ -1822,7 +1883,7 @@ impl TimelineState {
     /// Expand `clip.duration_beats` so every note fits inside the clip, with
     /// optional grid padding. Does not shrink. Returns `true` if length changed.
     pub fn ensure_midi_clip_contains_notes(clip: &mut ClipState, snap_beats: f32) -> bool {
-        let ClipType::Midi { notes } = &clip.clip_type else {
+        let ClipType::Midi { notes, .. } = &clip.clip_type else {
             return false;
         };
         let max_note_end = notes
@@ -1895,7 +1956,7 @@ impl TimelineState {
         for track in &self.tracks {
             for clip in &track.clips {
                 if clip.id == clip_id {
-                    if let ClipType::Midi { notes } = &clip.clip_type {
+                    if let ClipType::Midi { notes, .. } = &clip.clip_type {
                         return Some(notes);
                     }
                 }
@@ -1908,7 +1969,7 @@ impl TimelineState {
         for track in &mut self.tracks {
             for clip in &mut track.clips {
                 if clip.id == clip_id {
-                    if let ClipType::Midi { notes } = &mut clip.clip_type {
+                    if let ClipType::Midi { notes, .. } = &mut clip.clip_type {
                         return Some(notes);
                     }
                 }
@@ -1986,7 +2047,10 @@ impl TimelineState {
             source_duration_seconds: None,
             offset_beats: 0.0,
             gain: 1.0,
-            clip_type: ClipType::Midi { notes: Vec::new() },
+            clip_type: ClipType::Midi {
+                notes: Vec::new(),
+                controller_lanes: Vec::new(),
+            },
             muted: false,
             audio_import: AudioImportState::default(),
         })
@@ -2150,6 +2214,206 @@ impl TimelineState {
         for note in notes.iter_mut() {
             if ids.contains(&note.id) && note.velocity != velocity {
                 note.velocity = velocity;
+                changed += 1;
+            }
+        }
+        changed
+    }
+
+    /// Overwrite the mutable fields of existing notes from full snapshots,
+    /// matched by id. Used by the `EditMidiNotes` undo command — the note set is
+    /// not changed, only field values. Auto-expands the clip afterwards.
+    pub fn overwrite_midi_notes(&mut self, clip_id: &str, states: &[MidiNoteState]) {
+        if let Some(notes) = self.midi_clip_notes_mut(clip_id) {
+            for s in states {
+                if let Some(note) = notes.iter_mut().find(|n| n.id == s.id) {
+                    note.pitch = s.pitch;
+                    note.start = s.start;
+                    note.duration = s.duration;
+                    note.velocity = s.velocity;
+                    note.muted = s.muted;
+                }
+            }
+        }
+        self.expand_clip_to_contain_notes(clip_id);
+    }
+
+    // ── MIDI controller lanes ─────────────────────────────────────────────
+    pub fn midi_clip_controller_lanes(
+        &self,
+        clip_id: &str,
+    ) -> Option<&Vec<MidiControllerLane>> {
+        for track in &self.tracks {
+            for clip in &track.clips {
+                if clip.id == clip_id {
+                    if let ClipType::Midi {
+                        controller_lanes, ..
+                    } = &clip.clip_type
+                    {
+                        return Some(controller_lanes);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn controller_lanes_mut(&mut self, clip_id: &str) -> Option<&mut Vec<MidiControllerLane>> {
+        for track in &mut self.tracks {
+            for clip in &mut track.clips {
+                if clip.id == clip_id {
+                    if let ClipType::Midi {
+                        controller_lanes, ..
+                    } = &mut clip.clip_type
+                    {
+                        return Some(controller_lanes);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Points of a specific controller lane, if the lane exists.
+    pub fn controller_lane_points(
+        &self,
+        clip_id: &str,
+        kind: MidiControllerKind,
+    ) -> Option<&Vec<MidiControllerPoint>> {
+        self.midi_clip_controller_lanes(clip_id)?
+            .iter()
+            .find(|l| l.kind == kind)
+            .map(|l| &l.points)
+    }
+
+    /// Clone of a lane's points (for undo prev/next snapshots).
+    pub fn controller_points_snapshot(
+        &self,
+        clip_id: &str,
+        kind: MidiControllerKind,
+    ) -> Vec<MidiControllerPoint> {
+        self.controller_lane_points(clip_id, kind)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Ensure a visible lane of `kind` exists. Returns true if newly created.
+    pub fn ensure_controller_lane(&mut self, clip_id: &str, kind: MidiControllerKind) -> bool {
+        let Some(lanes) = self.controller_lanes_mut(clip_id) else {
+            return false;
+        };
+        if lanes.iter().any(|l| l.kind == kind) {
+            return false;
+        }
+        lanes.push(MidiControllerLane {
+            kind,
+            points: Vec::new(),
+            visible: true,
+            height: 80.0,
+            collapsed: false,
+        });
+        true
+    }
+
+    fn sort_lane_points(points: &mut [MidiControllerPoint]) {
+        points.sort_by(|a, b| {
+            a.beat
+                .partial_cmp(&b.beat)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
+
+    /// Overwrite a lane's points wholesale (used by undo). Creates the lane if
+    /// missing so undo can restore points into a removed lane.
+    pub fn set_controller_lane_points(
+        &mut self,
+        clip_id: &str,
+        kind: MidiControllerKind,
+        mut points: Vec<MidiControllerPoint>,
+    ) {
+        self.ensure_controller_lane(clip_id, kind);
+        Self::sort_lane_points(&mut points);
+        if let Some(lanes) = self.controller_lanes_mut(clip_id) {
+            if let Some(lane) = lanes.iter_mut().find(|l| l.kind == kind) {
+                lane.points = points;
+            }
+        }
+    }
+
+    /// Add or update a point at `beat` (merging within ~1e-3 beats). `value`
+    /// clamps to `0.0..=1.0`. Creates the lane if missing.
+    pub fn put_controller_point(
+        &mut self,
+        clip_id: &str,
+        kind: MidiControllerKind,
+        beat: f32,
+        value: f32,
+    ) {
+        self.ensure_controller_lane(clip_id, kind);
+        let beat = beat.max(0.0);
+        let value = value.clamp(0.0, 1.0);
+        if let Some(lanes) = self.controller_lanes_mut(clip_id) {
+            if let Some(lane) = lanes.iter_mut().find(|l| l.kind == kind) {
+                if let Some(p) = lane.points.iter_mut().find(|p| (p.beat - beat).abs() < 1.0e-3) {
+                    p.value = value;
+                } else {
+                    lane.points.push(MidiControllerPoint::new(beat, value));
+                    Self::sort_lane_points(&mut lane.points);
+                }
+            }
+        }
+    }
+
+    /// Move an existing point (by id) to a new beat/value, re-sorting the lane.
+    /// `beat` clamps to `>= 0`, `value` to `0.0..=1.0`. Returns true if found.
+    pub fn set_controller_point(
+        &mut self,
+        clip_id: &str,
+        kind: MidiControllerKind,
+        id: u64,
+        beat: f32,
+        value: f32,
+    ) -> bool {
+        if let Some(lanes) = self.controller_lanes_mut(clip_id) {
+            if let Some(lane) = lanes.iter_mut().find(|l| l.kind == kind) {
+                if let Some(p) = lane.points.iter_mut().find(|p| p.id == id) {
+                    p.beat = beat.max(0.0);
+                    p.value = value.clamp(0.0, 1.0);
+                    Self::sort_lane_points(&mut lane.points);
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Delete points within `tol` beats of `beat`. Returns how many were removed.
+    pub fn delete_controller_points_near(
+        &mut self,
+        clip_id: &str,
+        kind: MidiControllerKind,
+        beat: f32,
+        tol: f32,
+    ) -> usize {
+        if let Some(lanes) = self.controller_lanes_mut(clip_id) {
+            if let Some(lane) = lanes.iter_mut().find(|l| l.kind == kind) {
+                let before = lane.points.len();
+                lane.points.retain(|p| (p.beat - beat).abs() > tol);
+                return before - lane.points.len();
+            }
+        }
+        0
+    }
+
+    /// Set the muted flag on the given note ids. Returns the number changed.
+    pub fn set_midi_notes_muted(&mut self, clip_id: &str, ids: &[u64], muted: bool) -> usize {
+        let Some(notes) = self.midi_clip_notes_mut(clip_id) else {
+            return 0;
+        };
+        let mut changed = 0;
+        for note in notes.iter_mut() {
+            if ids.contains(&note.id) && note.muted != muted {
+                note.muted = muted;
                 changed += 1;
             }
         }
@@ -2668,7 +2932,7 @@ impl TimelineState {
         for track in &mut self.tracks {
             if let Some(clip) = track.clips.iter_mut().find(|clip| clip.id == clip_id) {
                 let min_len = match &clip.clip_type {
-                    ClipType::Midi { notes } => {
+                    ClipType::Midi { notes, .. } => {
                         let last_note_end = notes
                             .iter()
                             .map(|note| note.start.max(0.0) + note.duration.max(MIN_NOTE_BEATS))
@@ -3323,7 +3587,7 @@ impl TimelineState {
         let is_midi = matches!(clip.clip_type, ClipType::Midi { .. });
         let min_len = if is_midi { MIN_MIDI_CLIP_BEATS } else { 0.25 };
         // Clip-local end of the furthest note — the floor for any MIDI shrink.
-        let last_note_end = if let ClipType::Midi { notes } = &clip.clip_type {
+        let last_note_end = if let ClipType::Midi { notes, .. } = &clip.clip_type {
             notes
                 .iter()
                 .map(|n| n.start.max(0.0) + n.duration.max(MIN_NOTE_BEATS))
@@ -3345,14 +3609,14 @@ impl TimelineState {
                 // Keep the right edge fixed; clamp the new start to [0, right-min].
                 let mut new_start = snapped.min(old_right - min_len).max(0.0);
                 // Trimming from the left must not push the earliest note < 0.
-                if let ClipType::Midi { notes } = &clip.clip_type {
+                if let ClipType::Midi { notes, .. } = &clip.clip_type {
                     if let Some(min_local) = notes.iter().map(|n| n.start).reduce(f32::min) {
                         let max_start = (old_start + min_local).max(0.0);
                         new_start = new_start.min(max_start);
                     }
                 }
                 let delta = old_start - new_start;
-                if let ClipType::Midi { notes } = &mut clip.clip_type {
+                if let ClipType::Midi { notes, .. } = &mut clip.clip_type {
                     for note in notes.iter_mut() {
                         note.start = (note.start + delta).max(0.0);
                     }
@@ -3592,5 +3856,172 @@ impl TimelineState {
         eprintln!("[audio-import] bpm={:.3}", self.bpm);
         eprintln!("[audio-import] duration_beats={:.6}", duration_beats);
         eprintln!("[audio-import] bars_4_4={:.6}", bars_4_4);
+    }
+}
+
+#[cfg(test)]
+mod midi_edit_tests {
+    use super::*;
+    use crate::components::edit::EditCommand;
+
+    /// Build an empty state with one MIDI clip and return `(state, clip_id)`.
+    fn state_with_midi_clip() -> (TimelineState, String) {
+        let mut state = TimelineState::default();
+        let track_id = state.create_track(CreateTrackOptions {
+            track_type: TrackType::Midi,
+            name: "Test".into(),
+            color: gpui::Rgba {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+            volume: 1.0,
+            pan: 0.0,
+            armed: false,
+            input_monitor: false,
+        });
+        let clip = state
+            .build_midi_clip(&track_id, 0.0, 4.0)
+            .expect("clip builds");
+        let clip_id = clip.id.clone();
+        EditCommand::CreateClip { track_id, clip }.execute(&mut state);
+        (state, clip_id)
+    }
+
+    fn note(state: &TimelineState, clip_id: &str, id: u64) -> MidiNoteState {
+        state
+            .midi_clip_notes(clip_id)
+            .unwrap()
+            .iter()
+            .find(|n| n.id == id)
+            .cloned()
+            .unwrap()
+    }
+
+    #[test]
+    fn edit_midi_notes_velocity_roundtrips() {
+        let (mut state, clip_id) = state_with_midi_clip();
+        let id = state.add_midi_note(&clip_id, 60, 0.0, 1.0, 100).unwrap();
+
+        let prev = state.midi_clip_notes(&clip_id).unwrap().clone();
+        state.set_midi_notes_velocity_bulk(&clip_id, &[id], 40);
+        let next = state.midi_clip_notes(&clip_id).unwrap().clone();
+        assert_eq!(note(&state, &clip_id, id).velocity, 40);
+
+        let cmd = EditCommand::EditMidiNotes {
+            clip_id: clip_id.clone(),
+            prev,
+            next,
+        };
+        cmd.undo(&mut state);
+        assert_eq!(note(&state, &clip_id, id).velocity, 100, "undo restores");
+        cmd.execute(&mut state);
+        assert_eq!(note(&state, &clip_id, id).velocity, 40, "redo reapplies");
+    }
+
+    #[test]
+    fn edit_midi_notes_move_roundtrips() {
+        let (mut state, clip_id) = state_with_midi_clip();
+        let id = state.add_midi_note(&clip_id, 60, 0.0, 1.0, 100).unwrap();
+
+        let prev = state.midi_clip_notes(&clip_id).unwrap().clone();
+        state.move_midi_notes(&clip_id, &[(id, 2.0, 67)]);
+        let next = state.midi_clip_notes(&clip_id).unwrap().clone();
+
+        let cmd = EditCommand::EditMidiNotes {
+            clip_id: clip_id.clone(),
+            prev,
+            next,
+        };
+        cmd.undo(&mut state);
+        let n = note(&state, &clip_id, id);
+        assert_eq!((n.start, n.pitch), (0.0, 60), "undo restores start+pitch");
+        cmd.execute(&mut state);
+        let n = note(&state, &clip_id, id);
+        assert_eq!((n.start, n.pitch), (2.0, 67), "redo reapplies");
+    }
+
+    #[test]
+    fn controller_point_edit_and_undo_roundtrip() {
+        let (mut state, clip_id) = state_with_midi_clip();
+        let kind = MidiControllerKind::CC(1);
+        let prev = state.controller_points_snapshot(&clip_id, kind);
+        state.put_controller_point(&clip_id, kind, 1.0, 0.5);
+        state.put_controller_point(&clip_id, kind, 2.0, 0.75);
+        let next = state.controller_points_snapshot(&clip_id, kind);
+        assert_eq!(next.len(), 2);
+
+        let cmd = EditCommand::SetControllerPoints {
+            clip_id: clip_id.clone(),
+            kind,
+            prev,
+            next,
+        };
+        cmd.undo(&mut state);
+        assert_eq!(
+            state.controller_points_snapshot(&clip_id, kind).len(),
+            0,
+            "undo clears the lane"
+        );
+        cmd.execute(&mut state);
+        assert_eq!(
+            state.controller_points_snapshot(&clip_id, kind).len(),
+            2,
+            "redo restores points"
+        );
+    }
+
+    #[test]
+    fn put_controller_point_merges_within_epsilon() {
+        let (mut state, clip_id) = state_with_midi_clip();
+        let kind = MidiControllerKind::CC(7);
+        state.put_controller_point(&clip_id, kind, 1.0, 0.2);
+        state.put_controller_point(&clip_id, kind, 1.0, 0.9);
+        let pts = state.controller_points_snapshot(&clip_id, kind);
+        assert_eq!(pts.len(), 1, "same-beat edit updates in place");
+        assert_eq!(pts[0].value, 0.9);
+    }
+
+    #[test]
+    fn set_controller_point_moves_in_place() {
+        let (mut state, clip_id) = state_with_midi_clip();
+        let kind = MidiControllerKind::CC(1);
+        state.put_controller_point(&clip_id, kind, 1.0, 0.5);
+        let id = state.controller_points_snapshot(&clip_id, kind)[0].id;
+        assert!(state.set_controller_point(&clip_id, kind, id, 3.0, 0.25));
+        let snapshot = state.controller_points_snapshot(&clip_id, kind);
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].beat, 3.0);
+        assert_eq!(snapshot[0].value, 0.25);
+        assert_eq!(snapshot[0].id, id, "id is preserved across a move");
+    }
+
+    #[test]
+    fn delete_controller_points_near_removes_in_tolerance() {
+        let (mut state, clip_id) = state_with_midi_clip();
+        let kind = MidiControllerKind::CC(11);
+        state.put_controller_point(&clip_id, kind, 1.0, 0.5);
+        state.put_controller_point(&clip_id, kind, 3.0, 0.5);
+        let removed = state.delete_controller_points_near(&clip_id, kind, 1.05, 0.25);
+        assert_eq!(removed, 1);
+        assert_eq!(state.controller_points_snapshot(&clip_id, kind).len(), 1);
+    }
+
+    #[test]
+    fn set_midi_notes_muted_roundtrips() {
+        let (mut state, clip_id) = state_with_midi_clip();
+        let id = state.add_midi_note(&clip_id, 60, 0.0, 1.0, 100).unwrap();
+        assert!(!note(&state, &clip_id, id).muted);
+
+        let cmd = EditCommand::SetMidiNotesMuted {
+            clip_id: clip_id.clone(),
+            prev: vec![(id, false)],
+            muted: true,
+        };
+        cmd.execute(&mut state);
+        assert!(note(&state, &clip_id, id).muted, "execute mutes");
+        cmd.undo(&mut state);
+        assert!(!note(&state, &clip_id, id).muted, "undo unmutes");
     }
 }

--- a/crates/SphereUIComponents/src/layout/engine_snapshot.rs
+++ b/crates/SphereUIComponents/src/layout/engine_snapshot.rs
@@ -1,13 +1,25 @@
 use crate::components::plugin_picker::STUB_PLUGIN_ID;
 use crate::components::timeline::timeline_state::{
-    self, ClipType, TimelineState, TrackState, TrackType,
+    self, ClipType, MidiControllerKind, TimelineState, TrackState, TrackType,
 };
 
 use DAUx::types::{
     EngineClipAudioProcess, EngineClipSnapshot, EngineInsertSnapshot, EngineMidiClipSnapshot,
-    EngineMidiNoteSnapshot, EngineProjectSnapshot, EngineRoutingSnapshot, EngineSendSnapshot,
-    EngineTrackSnapshot,
+    EngineMidiControllerLane, EngineMidiControllerPoint, EngineMidiNoteSnapshot,
+    EngineProjectSnapshot, EngineRoutingSnapshot, EngineSendSnapshot, EngineTrackSnapshot,
 };
+
+/// Map a controller lane kind to its VST3 controller number, or `None` for
+/// kinds with no global controller mapping (poly pressure is per-note and not
+/// yet routed to the engine).
+fn vst3_controller_number(kind: MidiControllerKind) -> Option<u16> {
+    match kind {
+        MidiControllerKind::CC(n) => Some(n as u16),
+        MidiControllerKind::ChannelPressure => Some(128), // kAfterTouch
+        MidiControllerKind::PitchBend => Some(129),       // kPitchBend
+        MidiControllerKind::PolyPressure => None,
+    }
+}
 
 /// Build the DAUx insert descriptors for one track's mixer insert chain
 /// (Phase 2b). Only real, instantiable VST3 plugins are emitted as
@@ -182,9 +194,18 @@ pub(super) fn build_engine_project_snapshot(
                 if clip.muted {
                     return None;
                 }
-                let ClipType::Midi { notes } = &clip.clip_type else {
+                let ClipType::Midi {
+                    notes,
+                    controller_lanes,
+                } = &clip.clip_type
+                else {
                     return None;
                 };
+                let channel = track
+                    .routing
+                    .midi_channel
+                    .map(|ch| ch.saturating_sub(1).min(15))
+                    .unwrap_or(0);
                 Some(EngineMidiClipSnapshot {
                     id: clip.id.clone(),
                     track_id: track_id.clone(),
@@ -192,17 +213,34 @@ pub(super) fn build_engine_project_snapshot(
                     length_beats: clip.duration_beats.max(0.0) as f64,
                     notes: notes
                         .iter()
+                        // Muted notes stay in the clip but emit no runtime event.
+                        .filter(|n| !n.muted)
                         .map(|n| EngineMidiNoteSnapshot {
                             id: n.id,
                             pitch: n.pitch.min(127),
                             start_beat: n.start.max(0.0) as f64,
                             length_beats: n.duration.max(0.0) as f64,
                             velocity: n.velocity.clamp(1, 127),
-                            channel: track
-                                .routing
-                                .midi_channel
-                                .map(|ch| ch.saturating_sub(1).min(15))
-                                .unwrap_or(0),
+                            channel,
+                        })
+                        .collect(),
+                    controllers: controller_lanes
+                        .iter()
+                        .filter(|lane| !lane.points.is_empty())
+                        .filter_map(|lane| {
+                            let controller = vst3_controller_number(lane.kind)?;
+                            Some(EngineMidiControllerLane {
+                                controller,
+                                channel,
+                                points: lane
+                                    .points
+                                    .iter()
+                                    .map(|p| EngineMidiControllerPoint {
+                                        beat: p.beat.max(0.0) as f64,
+                                        value: p.value.clamp(0.0, 1.0),
+                                    })
+                                    .collect(),
+                            })
                         })
                         .collect(),
                 })
@@ -279,6 +317,86 @@ pub(super) fn log_engine_sync_snapshot(
             clip.media_path.as_deref().unwrap_or("<none>"),
             clip.start_beat,
             clip.duration_beats
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::edit::EditCommand;
+    use crate::components::timeline::timeline_state::{CreateTrackOptions, MidiControllerKind};
+
+    fn instrument_state_with_clip() -> (TimelineState, String) {
+        let mut state = TimelineState::default();
+        state.tracks.clear();
+        let track_id = state.create_track(CreateTrackOptions {
+            track_type: TrackType::Instrument,
+            name: "Inst".to_string(),
+            color: gpui::Rgba {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+            volume: 1.0,
+            pan: 0.0,
+            armed: false,
+            input_monitor: false,
+        });
+        let clip = state.build_midi_clip(&track_id, 0.0, 4.0).expect("clip");
+        let clip_id = clip.id.clone();
+        EditCommand::CreateClip { track_id, clip }.execute(&mut state);
+        (state, clip_id)
+    }
+
+    #[test]
+    fn muted_notes_excluded_from_engine_snapshot() {
+        let (mut state, clip_id) = instrument_state_with_clip();
+        let muted = state.add_midi_note(&clip_id, 60, 0.0, 1.0, 100).unwrap();
+        let _audible = state.add_midi_note(&clip_id, 64, 1.0, 1.0, 100).unwrap();
+        state.set_midi_notes_muted(&clip_id, &[muted], true);
+
+        let snap = build_engine_project_snapshot(&state, 48_000);
+        let total: usize = snap.midi_clips.iter().map(|c| c.notes.len()).sum();
+        assert_eq!(total, 1, "muted note must not reach the engine snapshot");
+    }
+
+    #[test]
+    fn cc_lane_reaches_engine_snapshot_with_resolved_controller() {
+        let (mut state, clip_id) = instrument_state_with_clip();
+        state.put_controller_point(&clip_id, MidiControllerKind::CC(11), 0.0, 0.25);
+        state.put_controller_point(&clip_id, MidiControllerKind::CC(11), 2.0, 0.75);
+        // Pitch bend resolves to VST3 controller 129.
+        state.put_controller_point(&clip_id, MidiControllerKind::PitchBend, 1.0, 0.5);
+
+        let snap = build_engine_project_snapshot(&state, 48_000);
+        let clip = snap
+            .midi_clips
+            .iter()
+            .find(|c| c.id == clip_id)
+            .expect("midi clip in snapshot");
+        let cc11 = clip
+            .controllers
+            .iter()
+            .find(|l| l.controller == 11)
+            .expect("CC11 lane");
+        assert_eq!(cc11.points.len(), 2);
+        assert!(clip.controllers.iter().any(|l| l.controller == 129));
+    }
+
+    #[test]
+    fn empty_and_poly_pressure_lanes_are_omitted() {
+        let (mut state, clip_id) = instrument_state_with_clip();
+        // Ensure an empty lane and a poly-pressure lane (no global mapping).
+        state.ensure_controller_lane(&clip_id, MidiControllerKind::CC(7));
+        state.put_controller_point(&clip_id, MidiControllerKind::PolyPressure, 0.0, 0.5);
+
+        let snap = build_engine_project_snapshot(&state, 48_000);
+        let clip = snap.midi_clips.iter().find(|c| c.id == clip_id).unwrap();
+        assert!(
+            clip.controllers.is_empty(),
+            "empty CC7 lane and unmapped poly-pressure lane must be omitted"
         );
     }
 }

--- a/crates/SphereUIComponents/src/layout/helpers.rs
+++ b/crates/SphereUIComponents/src/layout/helpers.rs
@@ -129,7 +129,7 @@ pub(super) fn find_clip_summary<'a>(
                     source_path,
                     ..
                 } => ("Audio", source_path.as_deref(), None),
-                crate::components::timeline::timeline_state::ClipType::Midi { notes } => {
+                crate::components::timeline::timeline_state::ClipType::Midi { notes, .. } => {
                     ("MIDI", None, Some(notes.len()))
                 }
             };

--- a/crates/SphereUIComponents/src/project/format.rs
+++ b/crates/SphereUIComponents/src/project/format.rs
@@ -1,17 +1,20 @@
 use super::{
     AutomationLane, AutomationPoint, AutomationTargetDesc, ClipSource, FutureboardProject,
-    InputMonitorMode, MidiNote, PluginFormat, PluginStateBlob, ProjectAsset, ProjectClip,
-    ProjectInsert, ProjectMixer, ProjectPluginInstance, ProjectSend, ProjectTrack,
-    ProjectTrackAudioFormat, ProjectTrackInputRouting, ProjectTrackMidiInputRouting,
-    ProjectTrackOutputRouting, ProjectTrackType, TrackRouting,
+    InputMonitorMode, MidiControllerKind, MidiControllerLane, MidiControllerPoint, MidiNote,
+    PluginFormat, PluginStateBlob, ProjectAsset, ProjectClip, ProjectInsert, ProjectMixer,
+    ProjectPluginInstance, ProjectSend, ProjectTrack, ProjectTrackAudioFormat,
+    ProjectTrackInputRouting, ProjectTrackMidiInputRouting, ProjectTrackOutputRouting,
+    ProjectTrackType, TrackRouting,
 };
 use std::io::{self, Cursor, Read};
 use std::path::PathBuf;
 
 pub const PROJECT_MAGIC: &[u8; 8] = b"FBSTUD1\0";
-/// On-disk format version. v3 adds persisted track routing fields. v1/v2 files
-/// still load with stable per-track routing defaults.
-pub const PROJECT_VERSION: u32 = 3;
+/// On-disk format version. v5 adds MIDI controller (CC) lanes per MIDI clip.
+/// v4 adds a per-MIDI-note muted flag. v3 adds persisted track routing fields.
+/// Older files still load: v1/v2 use stable per-track routing defaults,
+/// v1/v2/v3 notes default to unmuted, and pre-v5 MIDI clips have no CC lanes.
+pub const PROJECT_VERSION: u32 = 5;
 
 #[derive(Debug)]
 pub enum ProjectError {
@@ -341,6 +344,33 @@ fn encode_midi_note(w: &mut FbWriter, n: &MidiNote) {
     w.write_f32(n.start_beats);
     w.write_f32(n.duration_beats);
     w.write_u8(n.velocity);
+    w.write_bool(n.muted); // v4
+}
+
+/// v5: controller kind tag. CC carries its number; the rest are tag-only.
+fn encode_controller_kind(w: &mut FbWriter, kind: MidiControllerKind) {
+    match kind {
+        MidiControllerKind::CC(n) => {
+            w.write_u8(0);
+            w.write_u8(n);
+        }
+        MidiControllerKind::PitchBend => w.write_u8(1),
+        MidiControllerKind::ChannelPressure => w.write_u8(2),
+        MidiControllerKind::PolyPressure => w.write_u8(3),
+    }
+}
+
+/// v5: a controller lane and its points.
+fn encode_controller_lane(w: &mut FbWriter, lane: &MidiControllerLane) {
+    encode_controller_kind(w, lane.kind);
+    w.write_bool(lane.visible);
+    w.write_f32(lane.height);
+    w.write_bool(lane.collapsed);
+    w.write_u32(lane.points.len() as u32);
+    for p in &lane.points {
+        w.write_f32(p.beat);
+        w.write_f32(p.value);
+    }
 }
 
 fn encode_clip(w: &mut FbWriter, c: &ProjectClip) {
@@ -361,11 +391,19 @@ fn encode_clip(w: &mut FbWriter, c: &ProjectClip) {
             w.write_str(asset_id);
             w.write_opt_path(source_path);
         }
-        ClipSource::Midi { notes } => {
+        ClipSource::Midi {
+            notes,
+            controller_lanes,
+        } => {
             w.write_u8(2);
             w.write_u32(notes.len() as u32);
             for n in notes {
                 encode_midi_note(w, n);
+            }
+            // v5: controller lanes follow the notes.
+            w.write_u32(controller_lanes.len() as u32);
+            for lane in controller_lanes {
+                encode_controller_lane(w, lane);
             }
         }
     }
@@ -656,16 +694,54 @@ fn decode_automation_lane(r: &mut FbReader, version: u32) -> Result<AutomationLa
     })
 }
 
-fn decode_midi_note(r: &mut FbReader) -> Result<MidiNote, ProjectError> {
+fn decode_midi_note(r: &mut FbReader, version: u32) -> Result<MidiNote, ProjectError> {
     Ok(MidiNote {
         pitch: r.read_u8()?,
         start_beats: r.read_f32()?,
         duration_beats: r.read_f32()?,
         velocity: r.read_u8()?,
+        // v4 added the muted flag; older files default to unmuted.
+        muted: if version >= 4 { r.read_bool()? } else { false },
     })
 }
 
-fn decode_clip(r: &mut FbReader) -> Result<ProjectClip, ProjectError> {
+fn decode_controller_kind(r: &mut FbReader) -> Result<MidiControllerKind, ProjectError> {
+    Ok(match r.read_u8()? {
+        0 => MidiControllerKind::CC(r.read_u8()?),
+        1 => MidiControllerKind::PitchBend,
+        2 => MidiControllerKind::ChannelPressure,
+        3 => MidiControllerKind::PolyPressure,
+        t => {
+            return Err(ProjectError::Corrupted(format!(
+                "unknown controller kind tag {t}"
+            )))
+        }
+    })
+}
+
+fn decode_controller_lane(r: &mut FbReader) -> Result<MidiControllerLane, ProjectError> {
+    let kind = decode_controller_kind(r)?;
+    let visible = r.read_bool()?;
+    let height = r.read_f32()?;
+    let collapsed = r.read_bool()?;
+    let count = r.read_u32()? as usize;
+    let mut points = Vec::with_capacity(count);
+    for _ in 0..count {
+        points.push(MidiControllerPoint {
+            beat: r.read_f32()?,
+            value: r.read_f32()?,
+        });
+    }
+    Ok(MidiControllerLane {
+        kind,
+        points,
+        visible,
+        height,
+        collapsed,
+    })
+}
+
+fn decode_clip(r: &mut FbReader, version: u32) -> Result<ProjectClip, ProjectError> {
     let id = r.read_str()?;
     let name = r.read_str()?;
     let start_beat = r.read_f64()?;
@@ -683,9 +759,23 @@ fn decode_clip(r: &mut FbReader) -> Result<ProjectClip, ProjectError> {
             let count = r.read_u32()? as usize;
             let mut notes = Vec::with_capacity(count);
             for _ in 0..count {
-                notes.push(decode_midi_note(r)?);
+                notes.push(decode_midi_note(r, version)?);
             }
-            ClipSource::Midi { notes }
+            // v5: controller lanes follow the notes; older files have none.
+            let controller_lanes = if version >= 5 {
+                let lane_count = r.read_u32()? as usize;
+                let mut lanes = Vec::with_capacity(lane_count);
+                for _ in 0..lane_count {
+                    lanes.push(decode_controller_lane(r)?);
+                }
+                lanes
+            } else {
+                Vec::new()
+            };
+            ClipSource::Midi {
+                notes,
+                controller_lanes,
+            }
         }
         t => {
             return Err(ProjectError::Corrupted(format!(
@@ -863,7 +953,7 @@ fn decode_track(r: &mut FbReader, version: u32) -> Result<ProjectTrack, ProjectE
     let clip_count = r.read_u32()? as usize;
     let mut clips = Vec::with_capacity(clip_count);
     for _ in 0..clip_count {
-        clips.push(decode_clip(r)?);
+        clips.push(decode_clip(r, version)?);
     }
 
     Ok(ProjectTrack {
@@ -979,4 +1069,99 @@ pub fn decode_project(data: &[u8]) -> Result<FutureboardProject, ProjectError> {
     }
 
     decode_body(body, version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn note(pitch: u8, muted: bool) -> MidiNote {
+        MidiNote {
+            pitch,
+            start_beats: 1.5,
+            duration_beats: 0.5,
+            velocity: 90,
+            muted,
+        }
+    }
+
+    #[test]
+    fn midi_note_muted_roundtrips_v4() {
+        let mut w = FbWriter::new();
+        encode_midi_note(&mut w, &note(60, true));
+        encode_midi_note(&mut w, &note(64, false));
+        let bytes = w.into_bytes();
+
+        let mut r = FbReader::new(&bytes);
+        let a = decode_midi_note(&mut r, PROJECT_VERSION).unwrap();
+        let b = decode_midi_note(&mut r, PROJECT_VERSION).unwrap();
+        assert_eq!(a.pitch, 60);
+        assert!(a.muted);
+        assert_eq!(b.pitch, 64);
+        assert!(!b.muted);
+    }
+
+    #[test]
+    fn pre_v4_notes_decode_unmuted() {
+        // v3 and earlier wrote no muted byte: pitch, start, dur, velocity only.
+        let mut w = FbWriter::new();
+        w.write_u8(72);
+        w.write_f32(0.0);
+        w.write_f32(1.0);
+        w.write_u8(100);
+        let bytes = w.into_bytes();
+
+        let mut r = FbReader::new(&bytes);
+        let n = decode_midi_note(&mut r, 3).unwrap();
+        assert_eq!(n.pitch, 72);
+        assert!(!n.muted, "older files must default to unmuted");
+    }
+
+    #[test]
+    fn controller_lane_roundtrips() {
+        let lane = MidiControllerLane {
+            kind: MidiControllerKind::CC(11),
+            points: vec![
+                MidiControllerPoint {
+                    beat: 0.0,
+                    value: 0.0,
+                },
+                MidiControllerPoint {
+                    beat: 2.5,
+                    value: 1.0,
+                },
+            ],
+            visible: true,
+            height: 72.0,
+            collapsed: false,
+        };
+        let mut w = FbWriter::new();
+        encode_controller_lane(&mut w, &lane);
+        let bytes = w.into_bytes();
+
+        let mut r = FbReader::new(&bytes);
+        let got = decode_controller_lane(&mut r).unwrap();
+        assert_eq!(got.kind, MidiControllerKind::CC(11));
+        assert_eq!(got.points.len(), 2);
+        assert_eq!(got.points[1].beat, 2.5);
+        assert_eq!(got.points[1].value, 1.0);
+        assert_eq!(got.height, 72.0);
+        assert!(got.visible);
+    }
+
+    #[test]
+    fn controller_kind_tags_roundtrip() {
+        for kind in [
+            MidiControllerKind::CC(64),
+            MidiControllerKind::PitchBend,
+            MidiControllerKind::ChannelPressure,
+            MidiControllerKind::PolyPressure,
+        ] {
+            let mut w = FbWriter::new();
+            encode_controller_kind(&mut w, kind);
+            let bytes = w.into_bytes();
+            let mut r = FbReader::new(&bytes);
+            assert_eq!(decode_controller_kind(&mut r).unwrap(), kind);
+        }
+    }
 }

--- a/crates/SphereUIComponents/src/project/mod.rs
+++ b/crates/SphereUIComponents/src/project/mod.rs
@@ -62,6 +62,7 @@ pub enum ClipSource {
     },
     Midi {
         notes: Vec<MidiNote>,
+        controller_lanes: Vec<MidiControllerLane>,
     },
     Empty,
 }
@@ -72,6 +73,55 @@ pub struct MidiNote {
     pub start_beats: f32,
     pub duration_beats: f32,
     pub velocity: u8,
+    pub muted: bool,
+}
+
+/// Serialized MIDI controller stream selector. Mirrors
+/// [`timeline_state::MidiControllerKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MidiControllerKind {
+    CC(u8),
+    PitchBend,
+    ChannelPressure,
+    PolyPressure,
+}
+
+#[derive(Debug, Clone)]
+pub struct MidiControllerPoint {
+    pub beat: f32,
+    /// Normalized `0.0..=1.0`.
+    pub value: f32,
+}
+
+#[derive(Debug, Clone)]
+pub struct MidiControllerLane {
+    pub kind: MidiControllerKind,
+    pub points: Vec<MidiControllerPoint>,
+    pub visible: bool,
+    pub height: f32,
+    pub collapsed: bool,
+}
+
+use crate::components::timeline::timeline_state::MidiControllerKind as TlControllerKind;
+
+/// Map a live controller kind to its serialized form.
+fn controller_kind_to_project(k: TlControllerKind) -> MidiControllerKind {
+    match k {
+        TlControllerKind::CC(n) => MidiControllerKind::CC(n),
+        TlControllerKind::PitchBend => MidiControllerKind::PitchBend,
+        TlControllerKind::ChannelPressure => MidiControllerKind::ChannelPressure,
+        TlControllerKind::PolyPressure => MidiControllerKind::PolyPressure,
+    }
+}
+
+/// Map a serialized controller kind back to the live form.
+fn controller_kind_from_project(k: MidiControllerKind) -> TlControllerKind {
+    match k {
+        MidiControllerKind::CC(n) => TlControllerKind::CC(n),
+        MidiControllerKind::PitchBend => TlControllerKind::PitchBend,
+        MidiControllerKind::ChannelPressure => TlControllerKind::ChannelPressure,
+        MidiControllerKind::PolyPressure => TlControllerKind::PolyPressure,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -405,7 +455,10 @@ impl From<&TimelineState> for FutureboardProject {
                                 asset_id: file_id.clone(),
                                 source_path: source_path.as_deref().map(PathBuf::from),
                             },
-                            ClipType::Midi { notes } => ClipSource::Midi {
+                            ClipType::Midi {
+                                notes,
+                                controller_lanes,
+                            } => ClipSource::Midi {
                                 notes: notes
                                     .iter()
                                     .map(|n| MidiNote {
@@ -413,6 +466,24 @@ impl From<&TimelineState> for FutureboardProject {
                                         start_beats: n.start,
                                         duration_beats: n.duration,
                                         velocity: n.velocity,
+                                        muted: n.muted,
+                                    })
+                                    .collect(),
+                                controller_lanes: controller_lanes
+                                    .iter()
+                                    .map(|lane| MidiControllerLane {
+                                        kind: controller_kind_to_project(lane.kind),
+                                        points: lane
+                                            .points
+                                            .iter()
+                                            .map(|p| MidiControllerPoint {
+                                                beat: p.beat,
+                                                value: p.value,
+                                            })
+                                            .collect(),
+                                        visible: lane.visible,
+                                        height: lane.height,
+                                        collapsed: lane.collapsed,
                                     })
                                     .collect(),
                             },
@@ -528,8 +599,9 @@ impl From<&TimelineState> for FutureboardProject {
 /// Apply a loaded `FutureboardProject` back onto an existing `TimelineState`.
 pub fn apply_to_timeline(project: &FutureboardProject, tl: &mut TimelineState) {
     use crate::components::timeline::timeline_state::{
-        AutomationLaneState, AutomationPoint as TlAutoPoint, ClipState, MidiNoteState,
-        SendSlotState, TrackState,
+        AutomationLaneState, AutomationPoint as TlAutoPoint, ClipState,
+        MidiControllerLane as TlControllerLane, MidiControllerPoint as TlControllerPoint,
+        MidiNoteState, SendSlotState, TrackState,
     };
 
     tl.bpm = project.settings.bpm as f32;
@@ -565,18 +637,42 @@ pub fn apply_to_timeline(project: &FutureboardProject, tl: &mut TimelineState) {
                                 .as_ref()
                                 .map(|p| p.to_string_lossy().into_owned()),
                         },
-                        ClipSource::Midi { notes } => ClipType::Midi {
+                        ClipSource::Midi {
+                            notes,
+                            controller_lanes,
+                        } => ClipType::Midi {
                             notes: notes
                                 .iter()
-                                .map(|n| MidiNoteState::new(
-                                    n.pitch,
-                                    n.start_beats,
-                                    n.duration_beats,
-                                    n.velocity,
-                                ))
+                                .map(|n| {
+                                    let mut note = MidiNoteState::new(
+                                        n.pitch,
+                                        n.start_beats,
+                                        n.duration_beats,
+                                        n.velocity,
+                                    );
+                                    note.muted = n.muted;
+                                    note
+                                })
+                                .collect(),
+                            controller_lanes: controller_lanes
+                                .iter()
+                                .map(|lane| TlControllerLane {
+                                    kind: controller_kind_from_project(lane.kind),
+                                    points: lane
+                                        .points
+                                        .iter()
+                                        .map(|p| TlControllerPoint::new(p.beat, p.value))
+                                        .collect(),
+                                    visible: lane.visible,
+                                    height: lane.height,
+                                    collapsed: lane.collapsed,
+                                })
                                 .collect(),
                         },
-                        ClipSource::Empty => ClipType::Midi { notes: Vec::new() },
+                        ClipSource::Empty => ClipType::Midi {
+                            notes: Vec::new(),
+                            controller_lanes: Vec::new(),
+                        },
                     };
                     ClipState {
                         id: pc.id.clone(),

--- a/tasks/native/midi-editor-checklist.md
+++ b/tasks/native/midi-editor-checklist.md
@@ -6,7 +6,7 @@ Planning status: checklist only. No implementation code is implied.
 
 - [ ] Define stable persisted MIDI note IDs.
 - [ ] Decide runtime compact note handle strategy.
-- [ ] Store note pitch, start, duration, velocity, muted state.
+- [x] Store note pitch, start, duration, velocity, muted state.
 - [ ] Decide whether selected state is persisted or transient only.
 - [ ] Clamp pitch to `0..=127`.
 - [ ] Clamp velocity to `1..=127`.
@@ -15,19 +15,19 @@ Planning status: checklist only. No implementation code is implied.
 - [ ] Sort notes by `(start_beat, pitch, id)`.
 - [ ] Auto-expand MIDI clip when note edits exceed clip end.
 - [ ] Preserve notes when trimming clips.
-- [ ] Add MIDI controller lane model.
-- [ ] Add CC, pitch bend, channel pressure kinds.
-- [ ] Add lane visible/collapsed/height state.
+- [x] Add MIDI controller lane model.
+- [x] Add CC, pitch bend, channel pressure kinds.
+- [x] Add lane visible/collapsed/height state.
 - [ ] Add migration path from current note model.
 
 ## Project Save/Load
 
 - [ ] Serialize notes with stable IDs.
 - [ ] Deserialize notes with validation and clamping.
-- [ ] Serialize note muted state.
-- [ ] Serialize MIDI controller lanes.
-- [ ] Serialize controller points.
-- [ ] Preserve empty visible controller lanes if chosen as project state.
+- [x] Serialize note muted state.
+- [x] Serialize MIDI controller lanes.
+- [x] Serialize controller points.
+- [x] Preserve empty visible controller lanes if chosen as project state.
 - [ ] Migrate old projects with transient note IDs.
 - [ ] Roundtrip MIDI clips without data loss.
 - [ ] Warn on invalid/out-of-range data instead of panicking.
@@ -55,7 +55,7 @@ Planning status: checklist only. No implementation code is implied.
 - [ ] Render playhead synced to transport.
 - [ ] Render loop region awareness.
 - [ ] Render selected notes distinctly.
-- [ ] Render muted notes distinctly.
+- [x] Render muted notes distinctly.
 - [ ] Render note labels only when readable.
 - [ ] Cull notes outside visible beat/pitch range.
 - [ ] Avoid DOM/element spam for dense clips.
@@ -71,14 +71,14 @@ Planning status: checklist only. No implementation code is implied.
 - [ ] Move notes vertically by pitch.
 - [ ] Resize note length.
 - [ ] Delete notes.
-- [ ] Duplicate notes.
-- [ ] Copy/paste notes.
+- [x] Duplicate notes.
+- [x] Copy/paste notes.
 - [ ] Quantize notes.
 - [ ] Quantize preview.
 - [ ] Transpose notes.
 - [ ] Edit note length numerically.
 - [ ] Split notes.
-- [ ] Mute/unmute notes.
+- [x] Mute/unmute notes.
 - [ ] Audition note on click.
 - [ ] Audition note during drag where safe.
 - [ ] Respect snap/grid.
@@ -103,30 +103,30 @@ Planning status: checklist only. No implementation code is implied.
 
 ## CC Control Lanes
 
-- [ ] Add CC1 Mod Wheel lane.
-- [ ] Add CC7 Volume lane.
-- [ ] Add CC10 Pan lane.
-- [ ] Add CC11 Expression lane.
-- [ ] Add CC64 Sustain lane.
+- [x] Add CC1 Mod Wheel lane.
+- [x] Add CC7 Volume lane.
+- [x] Add CC10 Pan lane.
+- [x] Add CC11 Expression lane.
+- [x] Add CC64 Sustain lane.
 - [ ] Add custom CC number lane.
-- [ ] Add Pitch Bend lane.
-- [ ] Add Channel Pressure lane.
-- [ ] Defer Poly Pressure with clear data-model note.
-- [ ] Draw CC points.
+- [x] Add Pitch Bend lane.
+- [x] Add Channel Pressure lane.
+- [x] Defer Poly Pressure with clear data-model note.
+- [x] Draw CC points.
 - [ ] Draw ramps/lines.
-- [ ] Erase points.
+- [x] Erase points.
 - [ ] Select points.
 - [ ] Marquee select points.
-- [ ] Move points.
-- [ ] Delete points.
+- [x] Move points.
+- [x] Delete points.
 - [ ] Resize lane height.
 - [ ] Collapse/expand lane.
 - [ ] Remove lane.
 - [ ] Per-lane value scale.
-- [ ] Snap horizontally when snap is enabled.
-- [ ] Keep value drag continuous vertically.
-- [ ] Save/load lanes and points.
-- [ ] Undo/redo CC edits.
+- [x] Snap horizontally when snap is enabled.
+- [x] Keep value drag continuous vertically.
+- [x] Save/load lanes and points.
+- [x] Undo/redo CC edits.
 
 ## MIDI Tools
 
@@ -147,11 +147,11 @@ Planning status: checklist only. No implementation code is implied.
 
 ## Clipboard
 
-- [ ] Copy selected notes.
-- [ ] Paste notes at playhead.
+- [x] Copy selected notes.
+- [x] Paste notes at playhead.
 - [ ] Paste notes at mouse beat.
-- [ ] Preserve relative timing.
-- [ ] Preserve pitch and velocity.
+- [x] Preserve relative timing.
+- [x] Preserve pitch and velocity.
 - [ ] Copy selected CC points.
 - [ ] Paste CC points into compatible lane.
 - [ ] Reject incompatible paste with clear status text.
@@ -159,34 +159,34 @@ Planning status: checklist only. No implementation code is implied.
 
 ## Undo/Redo
 
-- [ ] Note create command.
-- [ ] Note delete command.
-- [ ] Note move command.
-- [ ] Note resize command.
-- [ ] Note velocity command.
-- [ ] Note mute command.
+- [x] Note create command.
+- [x] Note delete command.
+- [x] Note move command.
+- [x] Note resize command.
+- [x] Note velocity command.
+- [x] Note mute command.
 - [ ] Note split command.
-- [ ] Note duplicate command.
-- [ ] Quantize batch command.
+- [x] Note duplicate command.
+- [x] Quantize batch command.
 - [ ] CC point create command.
 - [ ] CC point delete command.
 - [ ] CC point move command.
 - [ ] CC ramp command.
-- [ ] Batch drag gestures into one undo entry.
+- [x] Batch drag gestures into one undo entry.
 
 ## MIDI Playback
 
-- [ ] Convert notes to runtime note on/off events.
-- [ ] Skip muted notes.
-- [ ] Skip muted clips/tracks.
+- [x] Convert notes to runtime note on/off events.
+- [x] Skip muted notes.
+- [x] Skip muted clips/tracks.
 - [ ] Respect clip bounds.
 - [ ] Handle looped clip playback once clip loops exist.
-- [ ] Send notes to instrument track plugin.
+- [x] Send notes to instrument track plugin.
 - [ ] Add external MIDI output placeholder.
-- [ ] Convert CC points to runtime MIDI controller events.
-- [ ] Initial block-level scheduling documented.
+- [x] Convert CC points to runtime MIDI controller events.
+- [x] Initial block-level scheduling documented.
 - [ ] Sample-accurate scheduling planned.
-- [ ] No audio-thread allocation.
+- [x] No audio-thread allocation.
 
 ## Keyboard Shortcuts
 


### PR DESCRIPTION
Builds out the native MIDI editor and connects it to the audio engine, in incremental slices.

## What''s included
- **Note mute** — `muted` flag on notes (model + project format **v4** + distinct render). Toggle via `M`, toolbar, or inspector. Muted notes are excluded from the engine snapshot so they don''t sound.
- **Note clipboard** — copy/paste/duplicate (`Ctrl+C/V/D`) via a process-global clipboard and a batched `CreateMidiNotes` command (one undo entry).
- **Undo coverage** — move/resize/velocity/quantize/transpose/nudge route through a reversible `EditMidiNotes` command, one entry per gesture.
- **CC controller lanes** — `MidiControllerLane/Point/Kind` model on the MIDI clip, project format **v5** save/load with migration, and a lane editor below the velocity lane: preset selector (CC1/7/10/11/64, pitch-bend, channel-pressure), draw/erase/move points, undoable via `SetControllerPoints`.
- **CC -> engine bridge** — controller points flow UI -> engine snapshot -> runtime `ControlChange` events -> `Vst3MidiEvent` -> VST3 parameter changes via `IMidiMapping` in the C++ bridge. Block-level value; no-op when the plugin exposes no mapping.

## Tests
Engine MIDI runtime incl. CC; snapshot CC emission + omission; format roundtrips (v4/v5 + migration); note + CC undo roundtrips. `cargo check --workspace` clean (C++ recompiles); engine 12 / UI 17 tests green.

## Caveats
- CC->engine path is compile- and unit-test-verified but **not validated against a live VST3 instrument** (no audio device in dev env). Manual check needed (`FUTUREBOARD_VST3_MIDI_DEBUG=1`).
- CC values are block-level; no CC catch-up on seek.
- Deferred editor polish: CC marquee/multi-select, ramp draw, lane resize/collapse/remove, custom CC number, value-scale labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)