### PR TITLE
Audit hardening: untrusted-file/IPC safety + WASAPI sample-rate fix

### DIFF
--- a/crates/SphereDirectAudioEngine/src/audio_file.rs
+++ b/crates/SphereDirectAudioEngine/src/audio_file.rs
@@ -115,6 +115,12 @@ pub const STREAMING_WAV_THRESHOLD_BYTES: u64 = 64 * 1024 * 1024;
 /// Non-WAV formats refuse in-memory decode above this size.
 pub const MAX_IN_MEMORY_DECODE_BYTES: u64 = 256 * 1024 * 1024;
 
+/// A WAV `fmt ` chunk is 16 / 18 / 40 bytes in practice (PCM / WAVEFORMATEX /
+/// WAVEFORMATEXTENSIBLE). The chunk length is an untrusted 32-bit field, so a
+/// crafted file can claim up to 4 GiB here; reject anything past this generous
+/// ceiling before allocating the read buffer in `read_wav_header`.
+const MAX_WAV_FMT_CHUNK_BYTES: u64 = 4096;
+
 /// Generate a multi-LOD peak summary for any audio format supported by
 /// [`load_audio_file`] (WAV via inline RIFF parser, MP3 / FLAC / OGG / M4A /
 /// AIFF via symphonia). WAV files are scanned from disk in chunks without
@@ -202,6 +208,12 @@ fn generate_wav_peaks_streaming(
     })?;
     let (fmt, data_start, data_len) = read_wav_header(&mut file)
         .map_err(|e| SphereAudioError::NativeError(format!("WAV header read failed: {e}")))?;
+
+    // The `data` chunk size is an untrusted 32-bit header field; clamp it to the
+    // bytes actually on disk so a crafted size can't pre-size the LOD builders to
+    // gigabytes (`Vec::with_capacity`) before the read loop reaches EOF.
+    let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let data_len = data_len.min(file_size.saturating_sub(data_start));
 
     let bytes_per_sample = match fmt.bits_per_sample {
         8 => 1usize,
@@ -311,6 +323,11 @@ fn generate_rauf_peaks_streaming(
     let channels = (header.channels as usize).max(1);
     let bytes_per_sample = 4usize; // S32 / F32 little-endian
     let bytes_per_frame = channels * bytes_per_sample;
+    // `frames_written` is an untrusted header field; clamp to the frames the file
+    // can actually hold so a crafted value can't blow up the LOD builders.
+    let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    let max_frames = file_size.saturating_sub(header.data_offset) / bytes_per_frame as u64;
+    let frames = frames.min(max_frames);
     let data_len = frames.saturating_mul(bytes_per_frame as u64);
 
     let mut builders: Vec<PeakLodBuilder> = PEAK_LOD_LEVELS
@@ -966,7 +983,17 @@ fn load_rauf(path: &Path) -> Result<AudioFileBuffer, String> {
             .map_err(|e| format!("RAUF recovery failed: {e}"))?
     };
     let channels = header.channels as usize;
-    let sample_count = frames as usize * channels;
+    // `frames` (from `frames_written` or size recovery) is untrusted — clamp to
+    // what the file can actually hold so a crafted header can't pre-allocate
+    // gigabytes via the `vec![0u8; byte_len]` below.
+    let file_size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    let bytes_per_frame = (channels as u64).saturating_mul(4);
+    let frames = if bytes_per_frame == 0 {
+        0
+    } else {
+        frames.min(file_size.saturating_sub(header.data_offset) / bytes_per_frame)
+    };
+    let sample_count = (frames as usize).saturating_mul(channels);
     let mut file = File::open(path).map_err(|e| format!("open failed: {e}"))?;
     file.seek(SeekFrom::Start(header.data_offset))
         .map_err(|e| format!("seek failed: {e}"))?;
@@ -1021,6 +1048,12 @@ fn read_wav_header(file: &mut File) -> Result<(WavFmt, u64, u64), String> {
 
         match id {
             b"fmt " => {
+                // `len` is an untrusted 32-bit header field. Validate it against a
+                // sane ceiling *before* allocating so a crafted file can't drive a
+                // multi-gigabyte `vec![0u8; len]` (OOM/abort on import/probe).
+                if len < 16 || len > MAX_WAV_FMT_CHUNK_BYTES {
+                    return Err(format!("invalid fmt chunk length: {len}"));
+                }
                 let mut buf = vec![0u8; len as usize];
                 file.read_exact(&mut buf)
                     .map_err(|e| format!("read fmt chunk failed: {e}"))?;
@@ -1298,5 +1331,59 @@ mod peak_tests {
         assert_eq!(peaks.total_frames, 512);
         let first = peaks.lods[0].peaks.first().expect("at least one peak");
         assert!((first.max - 0.5).abs() < 1e-3, "max was {}", first.max);
+    }
+
+    /// A crafted WAV whose `fmt ` chunk claims ~4 GiB must be rejected by the
+    /// header parser instead of attempting a multi-gigabyte allocation.
+    #[test]
+    fn wav_header_rejects_absurd_fmt_chunk_length() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // riff size (unused here)
+        bytes.extend_from_slice(b"WAVE");
+        bytes.extend_from_slice(b"fmt ");
+        bytes.extend_from_slice(&0xFFFF_FFF0u32.to_le_bytes()); // absurd fmt length
+        let path = std::env::temp_dir().join(format!(
+            "fb_wav_fmt_guard_{}_{}.wav",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::write(&path, &bytes).unwrap();
+        let mut file = File::open(&path).unwrap();
+        let result = read_wav_header(&mut file);
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_err(), "absurd fmt chunk length must be rejected");
+    }
+
+    /// A finalized RAUF whose `frames_written` claims `u64::MAX` must not drive a
+    /// gigantic `Vec::with_capacity`; the scan clamps to the real file size.
+    #[test]
+    fn rauf_peaks_clamp_corrupt_frames_written_to_file_size() {
+        use std::io::Write;
+
+        let path = temp_path("corrupt_frames");
+        let samples: Vec<i32> = (0..256).map(|_| s32(0.25)).collect();
+        write_rauf(&path, 1, &samples);
+
+        // Patch `frames_written` (header offset 24, u64 LE) to a hostile value.
+        {
+            let mut f = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+            f.seek(SeekFrom::Start(24)).unwrap();
+            f.write_all(&u64::MAX.to_le_bytes()).unwrap();
+        }
+
+        let peaks = generate_audio_peaks(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        // Bounded by the 256 frames actually present, not u64::MAX.
+        let finest = &peaks.lods[0];
+        assert!(
+            finest.peaks.len() <= 4,
+            "finest LOD must stay bounded to real frames, got {}",
+            finest.peaks.len()
+        );
     }
 }

--- a/crates/SphereDirectAudioEngine/src/backend/wasapi_exclusive.rs
+++ b/crates/SphereDirectAudioEngine/src/backend/wasapi_exclusive.rs
@@ -305,15 +305,39 @@ unsafe fn open_exclusive_stream(
 
     let native_sr = (*mix_fmt).nSamplesPerSec.max(1);
     let device_ch = (*mix_fmt).nChannels as usize;
-    let sample_rate = requested_sr.unwrap_or(native_sr);
+    let block_align = (*mix_fmt).nBlockAlign as u32;
+
+    // Negotiate the actual exclusive-mode sample rate. The device mix format is
+    // initialized as-is unless a *different* rate was requested — in which case
+    // it is only honoured when the device supports it in exclusive mode; we fall
+    // back to the device's native rate otherwise. `sample_rate` is the rate
+    // reported to the engine, so it must always equal the rate the hardware
+    // actually runs at — storing the requested rate while initializing the device
+    // at the native rate (the previous behaviour) desyncs transport/tempo/pitch.
+    // Stamping `nSamplesPerSec` requires updating `nAvgBytesPerSec` too or some
+    // drivers reject the format.
+    let mut sample_rate = requested_sr.unwrap_or(native_sr).max(1);
+    if sample_rate != native_sr {
+        (*mix_fmt).nSamplesPerSec = sample_rate;
+        (*mix_fmt).nAvgBytesPerSec = sample_rate.saturating_mul(block_align);
+        let probe = client.IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE, mix_fmt, None);
+        if !probe.is_ok() {
+            eprintln!(
+                "[DAUx WASAPI Excl] Requested {sample_rate} Hz unsupported in exclusive mode — using device rate {native_sr} Hz"
+            );
+            sample_rate = native_sr;
+            (*mix_fmt).nSamplesPerSec = native_sr;
+            (*mix_fmt).nAvgBytesPerSec = native_sr.saturating_mul(block_align);
+        }
+    }
 
     // ── Query device periods ───────────────────────────────────────────────────
     // hnsMinimumDevicePeriod is the minimum exclusive-mode period.
     let mut _default_period: i64 = 0;
     let mut min_period_hns: i64 = 0;
     let _ = client.GetDevicePeriod(Some(&mut _default_period), Some(&mut min_period_hns));
-    // Compute HNS period from requested buffer size, clamped to minimum.
-    let requested_hns = (buf_frames as i64 * 10_000_000i64) / native_sr as i64;
+    // Compute HNS period from the buffer size at the rate we will actually run at.
+    let requested_hns = (buf_frames as i64 * 10_000_000i64) / sample_rate as i64;
     let hns = requested_hns.max(min_period_hns.max(1));
 
     // ── Check exclusive format support ────────────────────────────────────────
@@ -350,7 +374,7 @@ unsafe fn open_exclusive_stream(
                     return false;
                 }
             };
-            let aligned_hns = ((aligned_frames as i64) * 10_000_000i64) / native_sr as i64;
+            let aligned_hns = ((aligned_frames as i64) * 10_000_000i64) / sample_rate as i64;
             eprintln!(
                 "[DAUx WASAPI Excl] Aligned buffer: {aligned_frames} frames, {aligned_hns} hns"
             );

--- a/crates/SpherePluginHost/src/audio_bridge.rs
+++ b/crates/SpherePluginHost/src/audio_bridge.rs
@@ -627,7 +627,9 @@ impl std::fmt::Debug for BridgeKickEvent {
 #[cfg(windows)]
 mod imp {
     use windows::core::HSTRING;
-    use windows::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+    use windows::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_ALREADY_EXISTS, HANDLE, INVALID_HANDLE_VALUE,
+    };
     use windows::Win32::System::Memory::{
         CreateFileMappingW, MapViewOfFile, OpenFileMappingW, UnmapViewOfFile, FILE_MAP_ALL_ACCESS,
         MEMORY_MAPPED_VIEW_ADDRESS, PAGE_READWRITE,
@@ -660,6 +662,20 @@ mod imp {
                 )
             }
             .map_err(std::io::Error::other)?;
+            // Reject name squatting: `CreateFileMappingW` opens the existing
+            // section (returning a valid handle) when the name is already taken,
+            // signalling it only via `ERROR_ALREADY_EXISTS`. The creator side
+            // must own a fresh, exclusively-created region — never map one another
+            // process planted first.
+            if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
+                unsafe {
+                    let _ = CloseHandle(handle);
+                }
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    "shared audio bridge name already in use (possible squatting)",
+                ));
+            }
             let view = unsafe { MapViewOfFile(handle, FILE_MAP_ALL_ACCESS, 0, 0, size) };
             if view.Value.is_null() {
                 let err = std::io::Error::last_os_error();
@@ -788,6 +804,19 @@ mod tests {
         };
         bridge.store_transport(&pushed);
         assert_eq!(bridge.load_transport(), pushed);
+    }
+
+    /// A second creator on an already-taken section name must be rejected rather
+    /// than silently handed the existing region (name-squatting defence).
+    #[cfg(windows)]
+    #[test]
+    fn create_named_rejects_squatted_name() {
+        let name = format!("Local\\FutureboardBridgeSquatTest-{}", std::process::id());
+        let first =
+            SharedAudioRegion::create_named(&name, 48_000, 256, 2).expect("first create succeeds");
+        let second = SharedAudioRegion::create_named(&name, 48_000, 256, 2);
+        assert!(second.is_err(), "squatted name must be rejected");
+        drop(first);
     }
 
     /// The producer-wake event pairs a creator and an opener on the same name:

--- a/crates/SpherePluginHost/src/ipc/mod.rs
+++ b/crates/SpherePluginHost/src/ipc/mod.rs
@@ -16,7 +16,7 @@
 //! loader in `native_editor`); sharing one instance with the audio engine is a
 //! later slice. See the plan / `native_editor` module docs.
 
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, Read, Write};
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -321,17 +321,40 @@ pub fn write_frame<W: Write>(writer: &mut W, msg: &impl Serialize) -> io::Result
     writer.flush()
 }
 
+/// Maximum size of a single newline-delimited frame. Frames carry base64
+/// plugin-state blobs, so the cap is generous — but bounded so a stuck or
+/// hostile peer cannot drive unbounded memory growth with one giant,
+/// newline-less line.
+pub const MAX_FRAME_BYTES: u64 = 128 * 1024 * 1024;
+
 /// Read one newline-delimited JSON frame, skipping blank lines.
 ///
 /// Returns `Ok(None)` on EOF (the peer closed the pipe — for the client this
 /// means the host exited/crashed; for the host it means the main app is gone).
 pub fn read_frame<T: DeserializeOwned, R: BufRead>(reader: &mut R) -> io::Result<Option<T>> {
+    read_frame_limited(reader, MAX_FRAME_BYTES)
+}
+
+/// [`read_frame`] with an explicit per-frame byte ceiling. Split out so the
+/// bound is unit-testable without allocating the production-size limit.
+fn read_frame_limited<T: DeserializeOwned, R: BufRead>(
+    reader: &mut R,
+    max_bytes: u64,
+) -> io::Result<Option<T>> {
     let mut line = String::new();
     loop {
         line.clear();
-        let read = reader.read_line(&mut line)?;
+        // Bound the read so a frame without a trailing newline cannot grow
+        // `line` past the ceiling. `take` caps this single `read_line` call.
+        let read = reader.by_ref().take(max_bytes + 1).read_line(&mut line)?;
         if read == 0 {
             return Ok(None); // EOF
+        }
+        if read as u64 > max_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "IPC frame exceeds maximum size",
+            ));
         }
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -390,6 +413,26 @@ mod tests {
         let mut reader = Cursor::new(Vec::new());
         let decoded: Option<HostCommand> = read_frame(&mut reader).unwrap();
         assert!(decoded.is_none());
+    }
+
+    #[test]
+    fn read_frame_rejects_oversized_line() {
+        // A line longer than the ceiling must error instead of growing the
+        // buffer without bound.
+        let line = format!("{}\n", "x".repeat(64));
+        let mut reader = Cursor::new(line.into_bytes());
+        let result: io::Result<Option<HostCommand>> = read_frame_limited(&mut reader, 16);
+        assert!(result.is_err(), "oversized frame must be rejected");
+    }
+
+    #[test]
+    fn read_frame_limited_accepts_within_limit() {
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &HostCommand::Shutdown).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded: Option<HostCommand> =
+            read_frame_limited(&mut reader, MAX_FRAME_BYTES).unwrap();
+        assert_eq!(decoded, Some(HostCommand::Shutdown));
     }
 
     #[test]

--- a/crates/SpherePluginHost/src/scan/isolation.rs
+++ b/crates/SpherePluginHost/src/scan/isolation.rs
@@ -143,8 +143,19 @@ pub fn run_isolated_format_scan(request: IsolatedScanRequest) -> IsolatedScanOut
         };
     }
 
-    if request.format == PluginScanFormat::AudioUnit {
+    // Prefer the out-of-process scanner for EVERY format, not just AudioUnit, so
+    // a crashing or malicious plugin takes down the scanner child rather than the
+    // host process. (Previously VST3/CLAP loaded plugin binaries directly
+    // in-process here — `catch_unwind` cannot stop a C++ access violation, so a
+    // single bad plugin crashed the app despite the "isolated" name.) The
+    // in-process branch below is a best-effort fallback for builds shipped
+    // without the scanner binary.
+    if locate_scanner_binary().is_ok() {
         return run_subprocess_scan(request);
+    }
+
+    if request.format == PluginScanFormat::AudioUnit {
+        return run_inprocess_au_scan(request);
     }
 
     match run_inprocess_scan(request.format, &request.paths) {
@@ -287,7 +298,10 @@ fn run_subprocess_scan(request: IsolatedScanRequest) -> IsolatedScanOutcome {
     let exit_code = output.status.code();
     if !output.status.success() {
         scan_process_crashed(request.format, exit_code);
-        let error = PluginScanError::AudioUnitScannerCrashed { exit_code };
+        let error = PluginScanError::ScannerProcessCrashed {
+            format: request.format,
+            exit_code,
+        };
         scan_finished(request.format, 0, 0, 1);
         return IsolatedScanOutcome {
             payload: ScanResultPayload::process_crash(request.format, exit_code, error.message()),

--- a/crates/SpherePluginHost/src/scan/types.rs
+++ b/crates/SpherePluginHost/src/scan/types.rs
@@ -98,6 +98,12 @@ pub enum PluginScanError {
     AudioUnitMetadataFailed(String),
     AudioUnitInstantiationFailed(String),
     AudioUnitScannerCrashed { exit_code: Option<i32> },
+    /// The out-of-process scanner child exited abnormally while scanning the
+    /// given format (used for VST3/CLAP isolation, not just AudioUnit).
+    ScannerProcessCrashed {
+        format: PluginScanFormat,
+        exit_code: Option<i32>,
+    },
     InvalidComponent(String),
     NullComponentName,
     ScannerBinaryMissing(String),
@@ -126,6 +132,10 @@ impl PluginScanError {
             Self::AudioUnitScannerCrashed { exit_code } => match exit_code {
                 Some(code) => format!("AudioUnit scan process crashed (exit {code})"),
                 None => "AudioUnit scan process crashed".into(),
+            },
+            Self::ScannerProcessCrashed { format, exit_code } => match exit_code {
+                Some(code) => format!("{} scan process crashed (exit {code})", format.cli_arg()),
+                None => format!("{} scan process crashed", format.cli_arg()),
             },
             Self::InvalidComponent(detail) => format!("Invalid AudioUnit component: {detail}"),
             Self::NullComponentName => "AudioUnit component name was missing".into(),


### PR DESCRIPTION
Lead-engineer security/robustness sweep of all non-gpui crates (2026-06-19). Six findings, all fixed. Common theme: trust the real file/OS state, not attacker-controllable header/IPC values.

## Fixes (one commit each, except #2/#4 share a file)

- **#1 WASAPI exclusive sample-rate desync** (`backend/wasapi_exclusive.rs`) — exclusive mode passed the device mix format (native rate) to `Initialize` unchanged but stored the *requested* rate as the engine rate → hardware ran one rate while the engine believed another (silent pitch/tempo desync). Now stamps the requested rate into `mix_fmt` (`nSamplesPerSec`+`nAvgBytesPerSec`), probes `IsFormatSupported`, and falls back to native if unsupported; period/aligned-period derive from the chosen rate.
- **#2 WAV `fmt ` chunk OOM** (`audio_file.rs`) — `read_wav_header` allocated `vec![0u8; len]` from an untrusted 32-bit chunk length (up to 4 GiB) before reading. Reject lengths outside `16..=MAX_WAV_FMT_CHUNK_BYTES`.
- **#3 VST3/CLAP scan not isolated** (`scan/isolation.rs`, `scan/types.rs`) — `run_isolated_format_scan` only isolated AudioUnit; VST3/CLAP loaded plugin binaries in-process (`catch_unwind` can't stop a C++ access violation). Now prefers the scanner subprocess for every format, in-process fallback only when the binary is missing. Added a format-generic `ScannerProcessCrashed` error.
- **#4 WAV/RAUF peak/decode pre-alloc OOM** (`audio_file.rs`) — LOD builders and `load_rauf`'s `vec![0u8; byte_len]` trusted header frame counts (WAV `data` size, RAUF `frames_written`). Clamp to the bytes actually on disk.
- **#5 Shared-audio-bridge name squatting** (`audio_bridge.rs`) — `CreateFileMappingW` opens an existing section (valid handle) on name collision, signalling only via `ERROR_ALREADY_EXISTS`, which the creator never checked. Now fails closed. (Ring indices were already masked/clamped, so this was DoS/correctness, not memory-unsafety.)
- **#6 IPC unbounded frame read** (`ipc/mod.rs`) — `read_frame` used `read_line` with no ceiling. Cap each frame at `MAX_FRAME_BYTES` (128 MiB) via a `take()`-bounded read.

## Tests
- `audio_file::peak_tests` — absurd `fmt ` length rejected; corrupt `frames_written` clamped.
- `ipc::tests` — oversized frame rejected; within-limit frame round-trips.
- `audio_bridge::tests::create_named_rejects_squatted_name` (Windows).

`cargo check` + `cargo test --lib` pass for both `sphere-direct-audio-engine` and `sphere-plugin-host`.

## Not runtime-verified
- **#1** needs real hardware: set a sample rate different from the device's native rate in exclusive mode and confirm no pitch/tempo shift + correct fallback log.
- **#3** needs the scanner binary + real plugins; verified by compile + logic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)