### PR TITLE
Enhance MIDI routing and clip management

### DIFF
--- a/crates/SphereUIComponents/src/components/panel.rs
+++ b/crates/SphereUIComponents/src/components/panel.rs
@@ -323,7 +323,18 @@ pub fn inspector_panel<'a>(
             .into_any_element()
     } else if let Some(tid) = selected_track_id {
         match tracks.iter().find(|t| t.id == tid) {
-            Some(t) => track_inspector(t, name_input, name_focused, callbacks).into_any_element(),
+            Some(t) => {
+                // MIDI Out needs the live Instrument-track roster (id, name)
+                // to offer/label real VSTi routing targets instead of the
+                // audio-only `Main` bus. Cheap: a handful of tracks at most.
+                let instrument_targets: Vec<(String, String)> = tracks
+                    .iter()
+                    .filter(|track| track.track_type == TrackType::Instrument)
+                    .map(|track| (track.id.clone(), track.name.clone()))
+                    .collect();
+                track_inspector(t, name_input, name_focused, &instrument_targets, callbacks)
+                    .into_any_element()
+            }
             None => no_selection(tracks.len()).into_any_element(),
         }
     } else {
@@ -840,6 +851,9 @@ fn audio_output_combo_label(
         TrackOutputRouting::HardwareOutput { channel, .. } => {
             format!("Channel {}", channel + 1)
         }
+        // Audio/Instrument tracks never carry `Instrument` routing (it only
+        // applies to MIDI tracks); kept for exhaustiveness.
+        TrackOutputRouting::Instrument { track_id } => format!("Instrument - {track_id}"),
         TrackOutputRouting::None => "None".to_string(),
     }
 }
@@ -884,10 +898,60 @@ fn midi_channel_options() -> Vec<String> {
         .collect()
 }
 
-fn midi_output_options(detected: &[String]) -> Vec<String> {
-    let mut options = vec!["Main".to_string(), "None".to_string()];
-    options.extend(detected.iter().cloned());
-    options
+/// MIDI Out destinations for a `TrackType::Midi` track: real Instrument
+/// (VSTi) tracks in the project to actually make sound, plus any detected
+/// external MIDI hardware/virtual ports. Deliberately excludes `Main` — a
+/// MIDI track has no audio to send to the Master bus, so offering it there
+/// just looked like a mislabeled audio-output field.
+fn build_midi_output_options(
+    track: &TrackState,
+    instrument_targets: &[(String, String)],
+    detected_midi_outputs: &[String],
+) -> Vec<(String, TrackOutputRouting)> {
+    let mut out = vec![("None".to_string(), TrackOutputRouting::None)];
+    for (track_id, name) in instrument_targets {
+        out.push((
+            format!("Instrument - {name}"),
+            TrackOutputRouting::Instrument {
+                track_id: track_id.clone(),
+            },
+        ));
+    }
+    for device in detected_midi_outputs {
+        out.push((
+            format!("MIDI Device - {device}"),
+            TrackOutputRouting::HardwareOutput {
+                device_id: device.clone(),
+                channel: 0,
+            },
+        ));
+    }
+    if !out.iter().any(|(_, r)| *r == track.routing.output) {
+        out.push((
+            format!(
+                "Missing - {}",
+                midi_output_combo_label(&track.routing.output, instrument_targets)
+            ),
+            track.routing.output.clone(),
+        ));
+    }
+    out
+}
+
+/// Display label for the MIDI Out trigger/selected value, resolving an
+/// `Instrument` target's live track name when it's still known.
+fn midi_output_combo_label(routing: &TrackOutputRouting, instrument_targets: &[(String, String)]) -> String {
+    match routing {
+        TrackOutputRouting::Instrument { track_id } => instrument_targets
+            .iter()
+            .find(|(id, _)| id == track_id)
+            .map(|(_, name)| format!("Instrument - {name}"))
+            .unwrap_or_else(|| routing.label()),
+        TrackOutputRouting::HardwareOutput { device_id, .. } => {
+            format!("MIDI Device - {device_id}")
+        }
+        _ => routing.label(),
+    }
 }
 
 fn parse_midi_input_option(label: &str) -> TrackMidiInputRouting {
@@ -905,17 +969,6 @@ fn parse_midi_channel_option(label: &str) -> Option<u8> {
         None
     } else {
         label.parse::<u8>().ok().map(|ch| ch.clamp(1, 16))
-    }
-}
-
-fn parse_midi_output_option(label: &str) -> TrackOutputRouting {
-    match label {
-        "Main" => TrackOutputRouting::Main,
-        "None" => TrackOutputRouting::None,
-        device => TrackOutputRouting::HardwareOutput {
-            device_id: device.to_string(),
-            channel: 0,
-        },
     }
 }
 
@@ -969,10 +1022,14 @@ fn midi_channel_selector(track: &TrackState, callbacks: &InspectorCallbacks) -> 
     )
 }
 
-fn midi_output_selector(track: &TrackState, callbacks: &InspectorCallbacks) -> impl IntoElement {
+fn midi_output_selector(
+    track: &TrackState,
+    instrument_targets: &[(String, String)],
+    callbacks: &InspectorCallbacks,
+) -> impl IntoElement {
     routing_combo_trigger(
         "inspector-midi-output-combo",
-        track.routing.output.label(),
+        midi_output_combo_label(&track.routing.output, instrument_targets),
         InspectorRoutingCombo::MidiOut,
         callbacks.open_routing_combo,
         callbacks.on_toggle_routing_combo.clone(),
@@ -996,12 +1053,16 @@ pub fn inspector_routing_combo_overlay(
     audio_output_buses: Vec<(String, String)>,
     // Selected output device `(name, channel_count)` for hardware output routes.
     audio_output_device: Option<(String, u32)>,
+    // Instrument (VSTi) tracks in the project as `(track_id, display_name)` —
+    // the real MIDI Out destinations for a plain MIDI track.
+    instrument_targets: Vec<(String, String)>,
+    // Real, Preferences-enabled MIDI hardware/virtual ports from the shared
+    // `device_registry` cache (same source Settings → MIDI renders from).
+    detected_midi_inputs: Vec<String>,
+    detected_midi_outputs: Vec<String>,
 ) -> impl IntoElement {
     let position =
         inspector_combo_menu_position(anchor, INSPECTOR_WIDTH, ROUTING_COMBO_MENU_HEIGHT, window);
-    // Placeholder until DirectAudio exposes MIDI device lists to the UI shell.
-    let detected_midi_inputs: Vec<String> = Vec::new();
-    let detected_midi_outputs: Vec<String> = Vec::new();
 
     let track_id = track.id.clone();
     let menu = match open_combo {
@@ -1122,17 +1183,27 @@ pub fn inspector_routing_combo_overlay(
             .into_any_element()
         }
         InspectorRoutingCombo::MidiOut => {
-            let selected = track.routing.output.label();
-            let options = midi_output_options(&detected_midi_outputs);
+            let routing_options =
+                build_midi_output_options(track, &instrument_targets, &detected_midi_outputs);
+            let selected = routing_options
+                .iter()
+                .find(|(_, r)| *r == track.routing.output)
+                .map(|(l, _)| l.clone())
+                .unwrap_or_else(|| midi_output_combo_label(&track.routing.output, &instrument_targets));
+            let labels: Vec<String> = routing_options.iter().map(|(l, _)| l.clone()).collect();
             let cb = callbacks.on_set_output_routing.clone();
             let close = on_close.clone();
             combo_box_string_menu(
                 "inspector-midi-output-menu",
                 position,
                 &selected,
-                &options,
+                &labels,
                 Arc::new(move |value, window, cx| {
-                    let output = parse_midi_output_option(&value);
+                    let output = routing_options
+                        .iter()
+                        .find(|(l, _)| *l == value)
+                        .map(|(_, r)| r.clone())
+                        .unwrap_or(TrackOutputRouting::None);
                     cb(&(track_id.clone(), output), window, cx);
                     close(cx);
                 }),
@@ -1151,7 +1222,11 @@ pub fn inspector_routing_combo_overlay(
         .child(menu)
 }
 
-fn routing_section(track: &TrackState, callbacks: &InspectorCallbacks) -> impl IntoElement {
+fn routing_section(
+    track: &TrackState,
+    instrument_targets: &[(String, String)],
+    callbacks: &InspectorCallbacks,
+) -> impl IntoElement {
     let mut section = div()
         .flex()
         .flex_col()
@@ -1189,7 +1264,7 @@ fn routing_section(track: &TrackState, callbacks: &InspectorCallbacks) -> impl I
                 ))
                 .child(fb_form_row(
                     "MIDI Out",
-                    midi_output_selector(track, callbacks),
+                    midi_output_selector(track, instrument_targets, callbacks),
                 ));
         }
         TrackType::Bus | TrackType::Return | TrackType::Master => {
@@ -1569,6 +1644,7 @@ fn track_inspector(
     track: &TrackState,
     name_input: &TextInputState,
     name_focused: bool,
+    instrument_targets: &[(String, String)],
     callbacks: &InspectorCallbacks,
 ) -> impl IntoElement {
     let automation_points: usize = track
@@ -1757,7 +1833,7 @@ fn track_inspector(
                 ))
                 .child(fb_form_row("State", state_row)),
         )
-        .child(routing_section(track, callbacks))
+        .child(routing_section(track, instrument_targets, callbacks))
         .when(track.track_type == TrackType::Instrument, |this| {
             this.child(instrument_section(track, callbacks))
         })

--- a/crates/SphereUIComponents/src/components/piano_roll.rs
+++ b/crates/SphereUIComponents/src/components/piano_roll.rs
@@ -22,10 +22,10 @@ use std::time::Duration;
 
 use gpui::prelude::FluentBuilder;
 use gpui::{
-    canvas, div, fill, point, pulsating_between, px, size, svg, Animation, AnimationExt, Bounds,
-    Context, Entity, FocusHandle, InteractiveElement, IntoElement, KeyDownEvent, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Render, ScrollWheelEvent,
-    StatefulInteractiveElement, Styled, Subscription, Window,
+    canvas, deferred, div, fill, point, pulsating_between, px, size, svg, Animation, AnimationExt,
+    Bounds, Context, Entity, FocusHandle, InteractiveElement, IntoElement, KeyDownEvent,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement, Pixels, Render,
+    ScrollWheelEvent, StatefulInteractiveElement, Styled, Subscription, Window,
 };
 
 use crate::assets;
@@ -44,6 +44,17 @@ mod render;
 const ROW_H: f32 = 14.0; // px per semitone
 const PITCH_CNT: i32 = 128;
 const TOTAL_H: f32 = PITCH_CNT as f32 * ROW_H;
+/// Horizontal overview zoom floor for long MIDI clips. 1 px/beat lets a
+/// 200-bar/800-beat song fit in an ~800px editor while preserving interactions.
+const PIANO_ROLL_MIN_PPB: f32 = 1.0;
+const PIANO_ROLL_MAX_PPB: f32 = 400.0;
+/// Paint priority for the toolbar's deferred dropdown menus (Grid / Scale /
+/// Lane). Without `deferred()`, an absolutely-positioned panel still paints
+/// in normal tree order and gets covered by the piano roll body (keys/grid),
+/// which is a later sibling with an opaque background. Matches the priority
+/// used by other popovers in this crate (e.g. `SELECT_MENU_PRIORITY`).
+const PIANO_ROLL_MENU_PRIORITY: usize = 100;
+const PIANO_ROLL_FIT_PAD_PX: f32 = 48.0;
 
 /// Reversed-pitch row mapping shared by the note grid and the left piano-key
 /// lane: higher pitches sit at the top, lower at the bottom, offset by the
@@ -839,17 +850,31 @@ impl PianoRoll {
                 .map(|ch| ch.saturating_sub(1).min(15))
                 .unwrap_or(0)
         };
+        // Preview must reach whichever plugin instance actually plays this
+        // track's notes: a MIDI track routed to an Instrument via
+        // `TrackOutputRouting::Instrument` previews through that target, not
+        // through itself (it owns no plugin). Keeps live audition in sync
+        // with the same redirect the playback engine snapshot applies.
+        let resolved_target = |track: &crate::components::timeline::timeline_state::TrackState| {
+            tl.state
+                .effective_instrument_track_id(&track.id)
+                .map(|target_id| (target_id, channel_for(track)))
+        };
+        // Once a MIDI clip/track is actually selected, trust that as the
+        // preview target rather than falling through to an unrelated track —
+        // an unrouted MIDI track should stay silent, not surprise-preview
+        // through whichever other track happens to own a plugin.
         if let Some(clip_id) = tl.state.selection.selected_clip_ids.first() {
             if let Some((track, clip)) = tl.state.find_clip(clip_id) {
                 if matches!(clip.clip_type, ClipType::Midi { .. }) {
-                    return Some((track.id.clone(), channel_for(track)));
+                    return resolved_target(track);
                 }
             }
         }
         if let Some(track_id) = tl.state.selection.selected_track_id.as_deref() {
             if let Some(track) = tl.state.find_track(track_id) {
                 if matches!(track.track_type, TrackType::Instrument | TrackType::Midi) {
-                    return Some((track.id.clone(), channel_for(track)));
+                    return resolved_target(track);
                 }
             }
         }
@@ -1268,8 +1293,8 @@ impl PianoRoll {
 
     /// Scroll/zoom the grid so selected notes (or all notes) are visible.
     fn fit_piano_roll_to_notes(&mut self, cx: &Context<Self>, clip_id: &str) {
-        let (_, view_h) = self.grid_view_size();
-        if view_h <= 1.0 {
+        let (view_w, view_h) = self.grid_view_size();
+        if view_w <= 1.0 || view_h <= 1.0 {
             return;
         }
 
@@ -1301,13 +1326,25 @@ impl PianoRoll {
         let target_scroll = ((PITCH_CNT - 1) as f32 - mid) * ROW_H - view_h * 0.5 + ROW_H * 0.5;
         self.scroll_y = target_scroll.clamp(0.0, self.max_scroll_y());
 
+        let (_, clip_len) = self.clip_meta(cx, clip_id);
         if !target_notes.is_empty() {
             let min_start = target_notes
                 .iter()
                 .map(|n| n.start)
-                .fold(f32::INFINITY, f32::min);
-            self.scroll_x = (min_start * self.ppb - 24.0).max(0.0);
+                .fold(f32::INFINITY, f32::min)
+                .max(0.0);
+            let max_end = target_notes
+                .iter()
+                .map(|n| n.start + n.duration)
+                .fold(0.0_f32, f32::max)
+                .min(clip_len.max(0.0));
+            let span = (max_end - min_start).max(1.0);
+            let fit_w = (view_w - PIANO_ROLL_FIT_PAD_PX * 2.0).max(96.0);
+            self.ppb = (fit_w / span).clamp(PIANO_ROLL_MIN_PPB, PIANO_ROLL_MAX_PPB);
+            self.scroll_x = (min_start * self.ppb - PIANO_ROLL_FIT_PAD_PX).max(0.0);
         } else {
+            let fit_w = (view_w - PIANO_ROLL_FIT_PAD_PX * 2.0).max(96.0);
+            self.ppb = (fit_w / clip_len.max(1.0)).clamp(PIANO_ROLL_MIN_PPB, PIANO_ROLL_MAX_PPB);
             self.scroll_x = 0.0;
         }
 
@@ -2980,7 +3017,7 @@ impl PianoRoll {
     /// Scale horizontal zoom by `factor`, clamped to the same range as wheel
     /// zoom. Used by the toolbar zoom buttons.
     fn zoom_by(&mut self, factor: f32, cx: &mut Context<Self>) {
-        self.ppb = (self.ppb * factor).clamp(20.0, 400.0);
+        self.ppb = (self.ppb * factor).clamp(PIANO_ROLL_MIN_PPB, PIANO_ROLL_MAX_PPB);
         cx.notify();
     }
 
@@ -2991,8 +3028,8 @@ impl PianoRoll {
         };
         if event.modifiers.control || event.modifiers.platform {
             // Zoom horizontal.
-            let factor = (1.0015_f32).powf(-dy);
-            self.ppb = (self.ppb * factor).clamp(20.0, 400.0);
+            let factor = (1.0022_f32).powf(-dy);
+            self.ppb = (self.ppb * factor).clamp(PIANO_ROLL_MIN_PPB, PIANO_ROLL_MAX_PPB);
         } else if event.modifiers.shift {
             self.scroll_x = (self.scroll_x - dy - dx).max(0.0);
         } else {

--- a/crates/SphereUIComponents/src/components/piano_roll/render.rs
+++ b/crates/SphereUIComponents/src/components/piano_roll/render.rs
@@ -313,14 +313,18 @@ impl PianoRoll {
                 );
             }
             dropdown = Some(
-                panel
-                    .with_animation(
-                        "pr-select-menu-open",
-                        Animation::new(Duration::from_millis(90))
-                            .with_easing(pulsating_between(0.9, 1.0)),
-                        |this, delta| this.opacity(delta),
-                    )
-                    .into_any_element(),
+                deferred(
+                    panel
+                        .with_animation(
+                            "pr-select-menu-open",
+                            Animation::new(Duration::from_millis(90))
+                                .with_easing(pulsating_between(0.9, 1.0)),
+                            |this, delta| this.opacity(delta),
+                        )
+                        .into_any_element(),
+                )
+                .with_priority(PIANO_ROLL_MENU_PRIORITY)
+                .into_any_element(),
             );
         }
 
@@ -397,6 +401,46 @@ impl PianoRoll {
         let visible = self.lane_visible;
         let custom = self.custom_cc;
 
+        // Controller kinds that actually carry points in the clip being
+        // edited. Merged into the dropdown below so CC lanes that come from
+        // an imported/recorded MIDI clip (any of the 128 CC numbers, not
+        // just the six common ones in `LANE_CYCLE`) are still reachable
+        // without the user having to already know the CC number to type into
+        // the "Custom CC" stepper.
+        let clip_lane_kinds: Vec<(MidiControllerKind, bool)> = self
+            .editing_clip_id(cx)
+            .map(|clip_id| {
+                let tl = self.timeline.read(cx);
+                tl.state
+                    .midi_clip_controller_lanes(&clip_id)
+                    .map(|lanes| {
+                        lanes
+                            .iter()
+                            .map(|lane| (lane.kind, !lane.points.is_empty()))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default();
+        let has_data = |kind: MidiControllerKind| {
+            clip_lane_kinds.iter().any(|(k, has)| *k == kind && *has)
+        };
+        // CC lanes with real data that aren't already offered by the common
+        // `LANE_CYCLE` list get their own "In This Clip" section.
+        let mut extra_kinds: Vec<MidiControllerKind> = clip_lane_kinds
+            .iter()
+            .filter(|(kind, has)| {
+                *has && !LANE_CYCLE.contains(&ControllerLaneKind::Controller(*kind))
+            })
+            .map(|(kind, _)| *kind)
+            .collect();
+        extra_kinds.sort_by_key(|kind| match kind {
+            MidiControllerKind::CC(n) => *n as u16,
+            MidiControllerKind::PitchBend => 200,
+            MidiControllerKind::ChannelPressure => 201,
+            MidiControllerKind::PolyPressure => 202,
+        });
+
         let mut dropdown: Option<gpui::AnyElement> = None;
         if open {
             let mut panel = div()
@@ -422,11 +466,16 @@ impl PianoRoll {
                     ControllerLaneKind::Velocity => "Velocity".to_string(),
                     ControllerLaneKind::Controller(k) => cc_kind_label(k),
                 };
+                let lane_has_data = match kind {
+                    ControllerLaneKind::Velocity => false,
+                    ControllerLaneKind::Controller(k) => has_data(k),
+                };
                 panel = panel.child(
                     div()
                         .id(("pr-lane-opt", i))
                         .flex()
                         .items_center()
+                        .justify_between()
                         .h(px(20.0))
                         .px(px(7.0))
                         .rounded(px(4.0))
@@ -442,8 +491,68 @@ impl PianoRoll {
                             cx.stop_propagation();
                             this.set_lane(kind, cx);
                         }))
-                        .child(text),
+                        .child(text)
+                        .when(lane_has_data, |row| {
+                            row.child(
+                                div()
+                                    .size(px(4.0))
+                                    .rounded(px(2.0))
+                                    .bg(Colors::accent_primary())
+                                    .flex_shrink_0(),
+                            )
+                        }),
                 );
+            }
+            if !extra_kinds.is_empty() {
+                panel = panel.child(
+                    div()
+                        .h(px(1.0))
+                        .mt(px(2.0))
+                        .mb(px(2.0))
+                        .bg(Colors::divider()),
+                );
+                panel = panel.child(
+                    div()
+                        .px(px(7.0))
+                        .text_size(px(9.0))
+                        .text_color(Colors::text_faint())
+                        .child("In This Clip"),
+                );
+                for (i, kind) in extra_kinds.iter().enumerate() {
+                    let kind = *kind;
+                    let lane_kind = ControllerLaneKind::Controller(kind);
+                    let selected = lane_kind == current;
+                    panel = panel.child(
+                        div()
+                            .id(("pr-lane-extra", i))
+                            .flex()
+                            .items_center()
+                            .justify_between()
+                            .h(px(20.0))
+                            .px(px(7.0))
+                            .rounded(px(4.0))
+                            .text_size(px(10.0))
+                            .text_color(if selected {
+                                Colors::accent_primary()
+                            } else {
+                                Colors::text_secondary()
+                            })
+                            .hover(|s| s.bg(Colors::surface_hover()))
+                            .cursor(gpui::CursorStyle::PointingHand)
+                            .on_click(cx.listener(move |this, _ev, _w, cx| {
+                                cx.stop_propagation();
+                                this.set_lane(lane_kind, cx);
+                            }))
+                            .child(cc_kind_label(kind))
+                            .child(
+                                div()
+                                    .size(px(4.0))
+                                    .rounded(px(2.0))
+                                    .bg(Colors::accent_primary())
+                                    .flex_shrink_0(),
+                            ),
+                    );
+                }
             }
             // Custom CC row: − / CCnn (select) / + . Steppers keep the menu open.
             panel = panel.child(
@@ -531,14 +640,18 @@ impl PianoRoll {
                     ),
             );
             dropdown = Some(
-                panel
-                    .with_animation(
-                        "pr-lane-menu-open",
-                        Animation::new(Duration::from_millis(90))
-                            .with_easing(pulsating_between(0.92, 1.0)),
-                        |this, delta| this.opacity(delta),
-                    )
-                    .into_any_element(),
+                deferred(
+                    panel
+                        .with_animation(
+                            "pr-lane-menu-open",
+                            Animation::new(Duration::from_millis(90))
+                                .with_easing(pulsating_between(0.92, 1.0)),
+                            |this, delta| this.opacity(delta),
+                        )
+                        .into_any_element(),
+                )
+                .with_priority(PIANO_ROLL_MENU_PRIORITY)
+                .into_any_element(),
             );
         }
 
@@ -926,13 +1039,13 @@ impl PianoRoll {
                         "pr-zoom-out",
                         "−",
                         false,
-                        cx.listener(|this, _, _w, cx| this.zoom_by(0.8, cx)),
+                        cx.listener(|this, _, _w, cx| this.zoom_by(0.5, cx)),
                     ))
                     .child(tool_btn(
                         "pr-zoom-in",
                         "+",
                         false,
-                        cx.listener(|this, _, _w, cx| this.zoom_by(1.25, cx)),
+                        cx.listener(|this, _, _w, cx| this.zoom_by(2.0, cx)),
                     ))
                     .child(tool_btn(
                         "pr-c4",
@@ -1652,13 +1765,22 @@ impl PianoRoll {
         let show_beats = ppb >= 10.0;
         let sub_step = self.grid_res.beats().max(1.0 / 32.0);
         let show_subs = show_beats && sub_step * ppb >= 7.0 && ppb >= 24.0;
+        let bar_step = if ppb * bpb >= 18.0 {
+            bpb
+        } else {
+            let mut bars = 2.0_f32;
+            while bars * bpb * ppb < 18.0 && bars < 256.0 {
+                bars *= 2.0;
+            }
+            bpb * bars
+        };
 
         let iter_step = if show_subs {
             sub_step
         } else if show_beats {
             1.0
         } else {
-            bpb
+            bar_step
         };
 
         let mut out = Vec::new();
@@ -1679,7 +1801,7 @@ impl PianoRoll {
                 GridLineKind::Subdivision
             };
             let keep = match kind {
-                GridLineKind::Bar => true,
+                GridLineKind::Bar => is_multiple(b, bar_step),
                 GridLineKind::Beat => show_beats,
                 GridLineKind::Subdivision => show_subs,
             };
@@ -1936,9 +2058,19 @@ impl PianoRoll {
     ) -> Vec<gpui::AnyElement> {
         let ppb = self.ppb.max(0.0001);
         let bpb = bpb.max(1.0);
-        // Label each beat when zoomed in; otherwise label only bar starts.
+        // Label each beat when zoomed in; otherwise label sparse bar starts.
         let label_beats = ppb >= 36.0;
-        let step = if label_beats { 1.0 } else { bpb };
+        let step = if label_beats {
+            1.0
+        } else if ppb * bpb >= 56.0 {
+            bpb
+        } else {
+            let mut bars = 2.0_f32;
+            while bars * bpb * ppb < 56.0 && bars < 256.0 {
+                bars *= 2.0;
+            }
+            bpb * bars
+        };
 
         let mut out: Vec<gpui::AnyElement> = Vec::new();
         let mut beat = (start_beat / step).floor() * step;

--- a/crates/SphereUIComponents/src/components/timeline/state/clip.rs
+++ b/crates/SphereUIComponents/src/components/timeline/state/clip.rs
@@ -103,21 +103,29 @@ pub enum ClipTimebase {
     Absolute,
 }
 
-impl TimelineState {
-    pub fn next_clip_id(&self) -> String {
-        let mut n = 0u32;
-        for t in &self.tracks {
-            for c in &t.clips {
-                if let Some(rest) = c.id.strip_prefix("clip-") {
-                    if let Ok(v) = rest.parse::<u32>() {
-                        if v > n {
-                            n = v;
-                        }
+/// Highest numeric suffix among existing `clip-N` ids, plus one. Exposed so
+/// callers that mint several clip ids in a row (e.g. multi-track MIDI import)
+/// can reserve a run of ids locally instead of re-scanning `tracks` — clips
+/// built but not yet attached to a track are invisible to that scan.
+pub fn next_clip_id_number(tracks: &[TrackState]) -> u32 {
+    let mut n = 0u32;
+    for t in tracks {
+        for c in &t.clips {
+            if let Some(rest) = c.id.strip_prefix("clip-") {
+                if let Ok(v) = rest.parse::<u32>() {
+                    if v > n {
+                        n = v;
                     }
                 }
             }
         }
-        format!("clip-{}", n + 1)
+    }
+    n + 1
+}
+
+impl TimelineState {
+    pub fn next_clip_id(&self) -> String {
+        format!("clip-{}", next_clip_id_number(&self.tracks))
     }
 
     /// Length of a clip in beats, if it exists.

--- a/crates/SphereUIComponents/src/components/timeline/state/midi.rs
+++ b/crates/SphereUIComponents/src/components/timeline/state/midi.rs
@@ -660,6 +660,15 @@ impl TimelineState {
 
         let multi_track = musical_tracks.len() > 1;
         let mut clips = Vec::with_capacity(musical_tracks.len());
+        // `next_clip_id()` only scans clips already attached to `self.tracks`.
+        // Clips built in this loop aren't pushed onto their track until the
+        // caller applies the returned batch (`BatchCreateClips`), so calling
+        // `next_clip_id()` per iteration would hand out the *same* id to every
+        // channel-split clip. Reserve one id up front and increment it
+        // locally so each clip in the batch gets a distinct id — otherwise
+        // clips across split tracks share an id and selecting one selects
+        // all of them (they compare equal).
+        let mut next_id_num = next_clip_id_number(&self.tracks);
         for (index, imported_track) in musical_tracks.into_iter().enumerate() {
             let track_id = if index == 0 {
                 first_track_id.clone()
@@ -682,9 +691,11 @@ impl TimelineState {
                         file_stem.clone()
                     }
                 });
-            if let Some(clip) =
+            if let Some(mut clip) =
                 self.build_imported_midi_clip(&track_id, clip_name, start_beat, imported_track.clip)
             {
+                clip.id = format!("clip-{next_id_num}");
+                next_id_num += 1;
                 clips.push((track_id, clip));
             }
         }

--- a/crates/SphereUIComponents/src/components/timeline/state/routing.rs
+++ b/crates/SphereUIComponents/src/components/timeline/state/routing.rs
@@ -73,6 +73,11 @@ pub enum TrackOutputRouting {
     Main,
     Bus { bus_id: String },
     HardwareOutput { device_id: String, channel: u32 },
+    /// A MIDI track's notes/controllers are redirected to the named
+    /// Instrument track's own plugin instead of that instrument's own clips.
+    /// Only meaningful on `TrackType::Midi` tracks; see
+    /// `TimelineState::effective_instrument_track_id`.
+    Instrument { track_id: String },
     None,
 }
 
@@ -84,6 +89,10 @@ impl TrackOutputRouting {
             Self::HardwareOutput { device_id, channel } => {
                 format!("{device_id} ch {}", channel + 1)
             }
+            // Callers that know the live track list should prefer
+            // `panel::midi_output_combo_label`, which resolves the target's
+            // display name; this is the id-only fallback.
+            Self::Instrument { track_id } => format!("Instrument - {track_id}"),
             Self::None => "None".to_string(),
         }
     }
@@ -243,6 +252,29 @@ impl TimelineState {
             }
         }
         false
+    }
+
+    /// Resolve which track's plugin instance should actually receive a
+    /// track's MIDI events during playback/preview: an Instrument track
+    /// plays its own clips; a MIDI track routed via
+    /// `TrackOutputRouting::Instrument` plays through that target instead
+    /// (only while the target still exists and is still an Instrument
+    /// track — a stale/retyped target yields `None`, i.e. silence, rather
+    /// than guessing a different destination).
+    pub fn effective_instrument_track_id(&self, track_id: &str) -> Option<String> {
+        let track = self.tracks.iter().find(|t| t.id == track_id)?;
+        match track.track_type {
+            TrackType::Instrument => Some(track.id.clone()),
+            TrackType::Midi => match &track.routing.output {
+                TrackOutputRouting::Instrument { track_id: target_id } => self
+                    .tracks
+                    .iter()
+                    .find(|t| t.id == *target_id && t.track_type == TrackType::Instrument)
+                    .map(|t| t.id.clone()),
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     pub fn set_track_output_routing(&mut self, track_id: &str, output: TrackOutputRouting) -> bool {

--- a/crates/SphereUIComponents/src/components/timeline/state/tests.rs
+++ b/crates/SphereUIComponents/src/components/timeline/state/tests.rs
@@ -1420,3 +1420,130 @@ mod fx_reorder_tests {
         assert_eq!(sorted, expected);
     }
 }
+
+#[cfg(test)]
+mod midi_import_tests {
+    use super::*;
+    use crate::components::timeline::midi_import::{ImportedMidiClip, ImportedMidiTrack};
+
+    fn imported_track(name: &str, pitch: u8) -> ImportedMidiTrack {
+        ImportedMidiTrack {
+            name: Some(name.to_string()),
+            channel_hint: None,
+            clip: ImportedMidiClip {
+                notes: vec![MidiNoteState::new(pitch, 0.0, 1.0, 100)],
+                controller_lanes: Vec::new(),
+                sysex_events: Vec::new(),
+                markers: Vec::new(),
+                duration_beats: 4.0,
+            },
+        }
+    }
+
+    /// Regression test: importing a multi-track MIDI batch (e.g. a
+    /// channel-split file) must give every resulting clip a distinct id.
+    /// `next_clip_id()` only sees clips already attached to `state.tracks`,
+    /// so before this fix, clips built earlier in the same batch (still only
+    /// in the local `clips` Vec, not yet pushed to any track) were invisible
+    /// to later `next_clip_id()` calls and all received the same id — which
+    /// broke solo-selecting a single clip, since selection matches by id and
+    /// every split clip compared equal.
+    #[test]
+    fn multi_track_import_assigns_distinct_clip_ids() {
+        let mut state = TimelineState::default();
+        state.tracks.clear();
+        let imported = vec![
+            imported_track("Ch 1", 60),
+            imported_track("Ch 2", 64),
+            imported_track("Ch 3", 67),
+        ];
+        let clips = state.import_midi_tracks_at("Song".to_string(), imported, 0.0, 0.0);
+
+        assert_eq!(clips.len(), 3, "all three channel clips should build");
+        let ids: std::collections::HashSet<&String> =
+            clips.iter().map(|(_, clip)| &clip.id).collect();
+        assert_eq!(
+            ids.len(),
+            3,
+            "every imported clip must have a unique id, got {:?}",
+            clips.iter().map(|(_, c)| &c.id).collect::<Vec<_>>()
+        );
+        let track_ids: std::collections::HashSet<&String> =
+            clips.iter().map(|(track_id, _)| track_id).collect();
+        assert_eq!(track_ids.len(), 3, "each channel should land on its own track");
+    }
+}
+
+#[cfg(test)]
+mod midi_output_routing_tests {
+    use super::*;
+
+    fn track(state: &mut TimelineState, track_type: TrackType, name: &str) -> String {
+        state.create_track(CreateTrackOptions {
+            track_type,
+            name: name.to_string(),
+            color: gpui::Rgba {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+            volume: 1.0,
+            pan: 0.0,
+            armed: false,
+            input_monitor: InputMonitorMode::Off,
+        })
+    }
+
+    /// A MIDI track routed to a real Instrument track resolves to that
+    /// instrument for both playback (`engine_snapshot`) and live preview.
+    #[test]
+    fn midi_track_routes_to_instrument_target() {
+        let mut state = TimelineState::default();
+        state.tracks.clear();
+        let inst_id = track(&mut state, TrackType::Instrument, "Synth");
+        let midi_id = track(&mut state, TrackType::Midi, "Notes");
+        state.set_track_output_routing(
+            &midi_id,
+            TrackOutputRouting::Instrument {
+                track_id: inst_id.clone(),
+            },
+        );
+
+        assert_eq!(
+            state.effective_instrument_track_id(&midi_id),
+            Some(inst_id.clone())
+        );
+        assert_eq!(
+            state.effective_instrument_track_id(&inst_id),
+            Some(inst_id)
+        );
+    }
+
+    /// An unrouted MIDI track (default `TrackOutputRouting::None`) has no
+    /// effective instrument — it should stay silent rather than guessing a
+    /// target, matching the "no silent misrouting" rule.
+    #[test]
+    fn unrouted_midi_track_has_no_effective_instrument() {
+        let mut state = TimelineState::default();
+        state.tracks.clear();
+        let midi_id = track(&mut state, TrackType::Midi, "Notes");
+        assert_eq!(state.effective_instrument_track_id(&midi_id), None);
+    }
+
+    /// Routing to a track id that no longer exists (or isn't an Instrument
+    /// track anymore) resolves to `None` instead of panicking or guessing.
+    #[test]
+    fn stale_instrument_target_resolves_to_none() {
+        let mut state = TimelineState::default();
+        state.tracks.clear();
+        let midi_id = track(&mut state, TrackType::Midi, "Notes");
+        state.set_track_output_routing(
+            &midi_id,
+            TrackOutputRouting::Instrument {
+                track_id: "does-not-exist".to_string(),
+            },
+        );
+        assert_eq!(state.effective_instrument_track_id(&midi_id), None);
+    }
+}

--- a/crates/SphereUIComponents/src/components/timeline/state/viewport.rs
+++ b/crates/SphereUIComponents/src/components/timeline/state/viewport.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+/// Arrangement overview zoom floor. At 120 BPM this is 0.25 px/beat, enough to
+/// fit very long MIDI songs on screen while the grid LOD thins bar lines.
+const TIMELINE_MIN_PIXELS_PER_SECOND: f32 = 0.5;
+const TIMELINE_MAX_PIXELS_PER_SECOND: f32 = 4000.0;
+
 /// Playback follow / auto-scroll behavior for the timeline viewport.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AutoScrollMode {
@@ -197,7 +202,10 @@ impl TimelineState {
     pub fn zoom_by(&mut self, factor: f32, anchor_x: f32) {
         let factor = factor.max(0.0001);
         let old_pps = self.viewport.pixels_per_second.max(0.0001);
-        let new_pps = (old_pps * factor).clamp(4.0, 4000.0);
+        let new_pps = (old_pps * factor).clamp(
+            TIMELINE_MIN_PIXELS_PER_SECOND,
+            TIMELINE_MAX_PIXELS_PER_SECOND,
+        );
         if (new_pps - old_pps).abs() < 0.0001 {
             return;
         }

--- a/crates/SphereUIComponents/src/components/timeline/timeline/render.rs
+++ b/crates/SphereUIComponents/src/components/timeline/timeline/render.rs
@@ -473,14 +473,14 @@ impl Render for Timeline {
         let on_zoom_in = cx.listener(|this, _: &(), window, cx| {
             let viewport_w: f32 = window.bounds().size.width.into();
             let anchor = ((viewport_w - SIDEBAR_WIDTH - HEADER_WIDTH) * 0.5).max(0.0);
-            this.state.zoom_by(1.10, anchor);
+            this.state.zoom_by(1.35, anchor);
             cx.notify();
         });
 
         let on_zoom_out = cx.listener(|this, _: &(), window, cx| {
             let viewport_w: f32 = window.bounds().size.width.into();
             let anchor = ((viewport_w - SIDEBAR_WIDTH - HEADER_WIDTH) * 0.5).max(0.0);
-            this.state.zoom_by(1.0 / 1.10, anchor);
+            this.state.zoom_by(1.0 / 1.35, anchor);
             cx.notify();
         });
 
@@ -1212,7 +1212,7 @@ impl Render for Timeline {
 
             let x: f32 = event.position.x.into();
             let anchor = (x - SIDEBAR_WIDTH - HEADER_WIDTH).max(0.0);
-            let factor = (1.0018_f32).powf(-delta.1);
+            let factor = (1.0024_f32).powf(-delta.1);
             this.state.zoom_by(factor, anchor);
             let (max_x, max_y) = this.max_scroll_offsets(window);
             this.state.clamp_scroll(max_x, max_y);

--- a/crates/SphereUIComponents/src/layout/engine_snapshot.rs
+++ b/crates/SphereUIComponents/src/layout/engine_snapshot.rs
@@ -542,7 +542,11 @@ fn build_engine_project_snapshot_inner(
                 timeline_state::TrackOutputRouting::Bus { bus_id } => Some(bus_id.clone()),
                 timeline_state::TrackOutputRouting::Main
                 | timeline_state::TrackOutputRouting::None
-                | timeline_state::TrackOutputRouting::HardwareOutput { .. } => None,
+                | timeline_state::TrackOutputRouting::HardwareOutput { .. }
+                // Instrument-routing redirects MIDI events (see `midi_clips`
+                // below), not audio bus summing — a MIDI track has no audio
+                // of its own to route.
+                | timeline_state::TrackOutputRouting::Instrument { .. } => None,
             },
             inserts: {
                 let inserts = build_engine_inserts(track, export_mode);
@@ -690,7 +694,14 @@ fn build_engine_project_snapshot_inner(
         .tracks
         .iter()
         .flat_map(|track| {
-            let track_id = track.id.clone();
+            // A MIDI track with no Instrument plugin of its own can route its
+            // notes to an Instrument track's plugin instead
+            // (`TrackOutputRouting::Instrument`); everything else (including
+            // an Instrument track's own clips) keeps playing through its own
+            // track id, unchanged.
+            let track_id = state
+                .effective_instrument_track_id(&track.id)
+                .unwrap_or_else(|| track.id.clone());
             track.clips.iter().filter_map(move |clip| {
                 if clip.muted {
                     return None;

--- a/crates/SphereUIComponents/src/layout/studio_render.rs
+++ b/crates/SphereUIComponents/src/layout/studio_render.rs
@@ -99,6 +99,60 @@ impl Render for StudioLayout {
         } else {
             None
         };
+        let instrument_targets: Vec<(String, String)> = if self.overlay.inspector_routing_combo
+            == Some(crate::components::panel::InspectorRoutingCombo::MidiOut)
+        {
+            tracks
+                .iter()
+                .filter(|track| {
+                    track.track_type == crate::components::timeline::timeline_state::TrackType::Instrument
+                })
+                .map(|track| (track.id.clone(), track.name.clone()))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        // Real MIDI hardware/virtual ports, enabled in Preferences → MIDI —
+        // the same cached registry Settings renders from (`device_registry`),
+        // not a mocked/empty placeholder. Only enabled ports are offered as
+        // routing targets, matching the Preferences toggle the user set.
+        let (detected_midi_inputs, detected_midi_outputs): (Vec<String>, Vec<String>) =
+            if matches!(
+                self.overlay.inspector_routing_combo,
+                Some(crate::components::panel::InspectorRoutingCombo::MidiInput)
+                    | Some(crate::components::panel::InspectorRoutingCombo::MidiOut)
+            ) {
+                let saved = self.settings.read(cx).current.hardware.midi.devices.clone();
+                let detected = crate::device_registry::cached_midi_devices();
+                let resolved = sphere_midi_service::resolve_midi_devices(&saved, &detected);
+                let inputs = resolved
+                    .iter()
+                    .filter(|d| {
+                        d.enabled
+                            && matches!(
+                                d.direction,
+                                crate::settings::MidiDeviceDirection::Input
+                                    | crate::settings::MidiDeviceDirection::InputOutput
+                            )
+                    })
+                    .map(|d| d.name.clone())
+                    .collect();
+                let outputs = resolved
+                    .iter()
+                    .filter(|d| {
+                        d.enabled
+                            && matches!(
+                                d.direction,
+                                crate::settings::MidiDeviceDirection::Output
+                                    | crate::settings::MidiDeviceDirection::InputOutput
+                            )
+                    })
+                    .map(|d| d.name.clone())
+                    .collect();
+                (inputs, outputs)
+            } else {
+                (Vec::new(), Vec::new())
+            };
         let inspector_routing_combo_overlay: Option<gpui::AnyElement> =
             if let (Some(combo), Some(anchor)) = (
                 self.overlay.inspector_routing_combo,
@@ -126,6 +180,9 @@ impl Render for StudioLayout {
                             audio_input_device.clone(),
                             audio_output_buses.clone(),
                             audio_output_device.clone(),
+                            instrument_targets.clone(),
+                            detected_midi_inputs.clone(),
+                            detected_midi_outputs.clone(),
                         )
                         .into_any_element()
                     })

--- a/crates/SphereUIComponents/src/project/format.rs
+++ b/crates/SphereUIComponents/src/project/format.rs
@@ -685,6 +685,10 @@ fn encode_track_output_routing(w: &mut FbWriter, output: &ProjectTrackOutputRout
             w.write_u32(*channel);
         }
         ProjectTrackOutputRouting::None => w.write_u8(3),
+        ProjectTrackOutputRouting::Instrument { track_id } => {
+            w.write_u8(4);
+            w.write_str(track_id);
+        }
     }
 }
 
@@ -1301,6 +1305,9 @@ fn decode_track_output_routing(
             channel: r.read_u32()?,
         },
         3 => ProjectTrackOutputRouting::None,
+        4 => ProjectTrackOutputRouting::Instrument {
+            track_id: r.read_str()?,
+        },
         t => {
             return Err(ProjectError::Corrupted(format!(
                 "unknown track output routing {t}"

--- a/crates/SphereUIComponents/src/project/mod.rs
+++ b/crates/SphereUIComponents/src/project/mod.rs
@@ -254,6 +254,7 @@ pub enum ProjectTrackOutputRouting {
     Main,
     Bus { bus_id: String },
     HardwareOutput { device_id: String, channel: u32 },
+    Instrument { track_id: String },
     None,
 }
 
@@ -1307,6 +1308,9 @@ fn timeline_output_to_project(
             device_id: device_id.clone(),
             channel: *channel,
         },
+        T::Instrument { track_id } => ProjectTrackOutputRouting::Instrument {
+            track_id: track_id.clone(),
+        },
         T::None => ProjectTrackOutputRouting::None,
     }
 }
@@ -1377,6 +1381,9 @@ fn project_routing_to_timeline(
                 channel: *channel,
             }
         }
+        ProjectTrackOutputRouting::Instrument { track_id } => TrackOutputRouting::Instrument {
+            track_id: track_id.clone(),
+        },
         ProjectTrackOutputRouting::None => TrackOutputRouting::None,
     };
     state.audio_format = match routing.audio_format {


### PR DESCRIPTION
- Introduced `TrackOutputRouting::Instrument` to allow MIDI tracks to route notes to Instrument tracks' plugins.
- Updated MIDI output options to reflect real Instrument targets for MIDI tracks.
- Improved clip ID generation to ensure unique IDs for imported MIDI clips across multiple tracks.
- Refactored MIDI output handling in the inspector panel and piano roll components for better usability.
- Added tests to verify distinct clip ID assignment during multi-track MIDI imports and effective routing to Instrument tracks.