### PR TITLE
Refactor error handling and improve code readability

### DIFF
--- a/crates/SphereSoundfontPlayer/src/lib.rs
+++ b/crates/SphereSoundfontPlayer/src/lib.rs
@@ -27,11 +27,17 @@ pub enum SoundfontPlayerError {
     /// `(bank, patch)` requested but not present in the loaded SoundFont's
     /// preset list — distinct from `InvalidBank`/`InvalidPatch`, which reject
     /// out-of-range values before ever consulting the font.
-    PresetNotFound { bank: i32, patch: i32 },
+    PresetNotFound {
+        bank: i32,
+        patch: i32,
+    },
     Io(std::io::Error),
     SoundFont(rustysynth::SoundFontError),
     Synthesizer(rustysynth::SynthesizerError),
-    BufferLengthMismatch { left: usize, right: usize },
+    BufferLengthMismatch {
+        left: usize,
+        right: usize,
+    },
 }
 
 impl std::fmt::Display for SoundfontPlayerError {
@@ -46,7 +52,10 @@ impl std::fmt::Display for SoundfontPlayerError {
             Self::InvalidBank(bank) => write!(f, "invalid preset bank: {bank}"),
             Self::InvalidPatch(patch) => write!(f, "invalid preset patch: {patch}"),
             Self::PresetNotFound { bank, patch } => {
-                write!(f, "no preset at bank {bank} patch {patch} in this SoundFont")
+                write!(
+                    f,
+                    "no preset at bank {bank} patch {patch} in this SoundFont"
+                )
             }
             Self::Io(error) => write!(f, "SoundFont I/O failed: {error}"),
             Self::SoundFont(error) => write!(f, "SoundFont load failed: {error:?}"),

--- a/crates/SphereUIComponents/src/components/panel.rs
+++ b/crates/SphereUIComponents/src/components/panel.rs
@@ -940,7 +940,10 @@ fn build_midi_output_options(
 
 /// Display label for the MIDI Out trigger/selected value, resolving an
 /// `Instrument` target's live track name when it's still known.
-fn midi_output_combo_label(routing: &TrackOutputRouting, instrument_targets: &[(String, String)]) -> String {
+fn midi_output_combo_label(
+    routing: &TrackOutputRouting,
+    instrument_targets: &[(String, String)],
+) -> String {
     match routing {
         TrackOutputRouting::Instrument { track_id } => instrument_targets
             .iter()
@@ -1189,7 +1192,9 @@ pub fn inspector_routing_combo_overlay(
                 .iter()
                 .find(|(_, r)| *r == track.routing.output)
                 .map(|(l, _)| l.clone())
-                .unwrap_or_else(|| midi_output_combo_label(&track.routing.output, &instrument_targets));
+                .unwrap_or_else(|| {
+                    midi_output_combo_label(&track.routing.output, &instrument_targets)
+                });
             let labels: Vec<String> = routing_options.iter().map(|(l, _)| l.clone()).collect();
             let cb = callbacks.on_set_output_routing.clone();
             let close = on_close.clone();

--- a/crates/SphereUIComponents/src/components/piano_roll/render.rs
+++ b/crates/SphereUIComponents/src/components/piano_roll/render.rs
@@ -422,9 +422,8 @@ impl PianoRoll {
                     .unwrap_or_default()
             })
             .unwrap_or_default();
-        let has_data = |kind: MidiControllerKind| {
-            clip_lane_kinds.iter().any(|(k, has)| *k == kind && *has)
-        };
+        let has_data =
+            |kind: MidiControllerKind| clip_lane_kinds.iter().any(|(k, has)| *k == kind && *has);
         // CC lanes with real data that aren't already offered by the common
         // `LANE_CYCLE` list get their own "In This Clip" section.
         let mut extra_kinds: Vec<MidiControllerKind> = clip_lane_kinds

--- a/crates/SphereUIComponents/src/components/timeline/midi_clip.rs
+++ b/crates/SphereUIComponents/src/components/timeline/midi_clip.rs
@@ -342,8 +342,8 @@ fn midi_note_preview_canvas(
                         as usize;
                     let norm_pitch = (note.pitch as i32 - bottom_pitch as i32) as f32 / pitch_range;
                     let y = (1.0 - norm_pitch) * (note_area_h - 4.0) + 1.0;
-                    for col in x0..=x1 {
-                        spans[col] = Some(match spans[col] {
+                    for cell in &mut spans[x0..=x1] {
+                        *cell = Some(match *cell {
                             Some((top, bottom)) => (top.min(y), bottom.max(y + note_h)),
                             None => (y, y + note_h),
                         });

--- a/crates/SphereUIComponents/src/components/timeline/state/routing.rs
+++ b/crates/SphereUIComponents/src/components/timeline/state/routing.rs
@@ -71,13 +71,20 @@ impl TrackInputRouting {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TrackOutputRouting {
     Main,
-    Bus { bus_id: String },
-    HardwareOutput { device_id: String, channel: u32 },
+    Bus {
+        bus_id: String,
+    },
+    HardwareOutput {
+        device_id: String,
+        channel: u32,
+    },
     /// A MIDI track's notes/controllers are redirected to the named
     /// Instrument track's own plugin instead of that instrument's own clips.
     /// Only meaningful on `TrackType::Midi` tracks; see
     /// `TimelineState::effective_instrument_track_id`.
-    Instrument { track_id: String },
+    Instrument {
+        track_id: String,
+    },
     None,
 }
 
@@ -266,7 +273,9 @@ impl TimelineState {
         match track.track_type {
             TrackType::Instrument => Some(track.id.clone()),
             TrackType::Midi => match &track.routing.output {
-                TrackOutputRouting::Instrument { track_id: target_id } => self
+                TrackOutputRouting::Instrument {
+                    track_id: target_id,
+                } => self
                     .tracks
                     .iter()
                     .find(|t| t.id == *target_id && t.track_type == TrackType::Instrument)

--- a/crates/SphereUIComponents/src/components/timeline/state/tests.rs
+++ b/crates/SphereUIComponents/src/components/timeline/state/tests.rs
@@ -1470,7 +1470,11 @@ mod midi_import_tests {
         );
         let track_ids: std::collections::HashSet<&String> =
             clips.iter().map(|(track_id, _)| track_id).collect();
-        assert_eq!(track_ids.len(), 3, "each channel should land on its own track");
+        assert_eq!(
+            track_ids.len(),
+            3,
+            "each channel should land on its own track"
+        );
     }
 }
 
@@ -1514,10 +1518,7 @@ mod midi_output_routing_tests {
             state.effective_instrument_track_id(&midi_id),
             Some(inst_id.clone())
         );
-        assert_eq!(
-            state.effective_instrument_track_id(&inst_id),
-            Some(inst_id)
-        );
+        assert_eq!(state.effective_instrument_track_id(&inst_id), Some(inst_id));
     }
 
     /// An unrouted MIDI track (default `TrackOutputRouting::None`) has no

--- a/crates/SphereUIComponents/src/layout/studio_render.rs
+++ b/crates/SphereUIComponents/src/layout/studio_render.rs
@@ -105,7 +105,8 @@ impl Render for StudioLayout {
             tracks
                 .iter()
                 .filter(|track| {
-                    track.track_type == crate::components::timeline::timeline_state::TrackType::Instrument
+                    track.track_type
+                        == crate::components::timeline::timeline_state::TrackType::Instrument
                 })
                 .map(|track| (track.id.clone(), track.name.clone()))
                 .collect()
@@ -116,43 +117,42 @@ impl Render for StudioLayout {
         // the same cached registry Settings renders from (`device_registry`),
         // not a mocked/empty placeholder. Only enabled ports are offered as
         // routing targets, matching the Preferences toggle the user set.
-        let (detected_midi_inputs, detected_midi_outputs): (Vec<String>, Vec<String>) =
-            if matches!(
-                self.overlay.inspector_routing_combo,
-                Some(crate::components::panel::InspectorRoutingCombo::MidiInput)
-                    | Some(crate::components::panel::InspectorRoutingCombo::MidiOut)
-            ) {
-                let saved = self.settings.read(cx).current.hardware.midi.devices.clone();
-                let detected = crate::device_registry::cached_midi_devices();
-                let resolved = sphere_midi_service::resolve_midi_devices(&saved, &detected);
-                let inputs = resolved
-                    .iter()
-                    .filter(|d| {
-                        d.enabled
-                            && matches!(
-                                d.direction,
-                                crate::settings::MidiDeviceDirection::Input
-                                    | crate::settings::MidiDeviceDirection::InputOutput
-                            )
-                    })
-                    .map(|d| d.name.clone())
-                    .collect();
-                let outputs = resolved
-                    .iter()
-                    .filter(|d| {
-                        d.enabled
-                            && matches!(
-                                d.direction,
-                                crate::settings::MidiDeviceDirection::Output
-                                    | crate::settings::MidiDeviceDirection::InputOutput
-                            )
-                    })
-                    .map(|d| d.name.clone())
-                    .collect();
-                (inputs, outputs)
-            } else {
-                (Vec::new(), Vec::new())
-            };
+        let (detected_midi_inputs, detected_midi_outputs): (Vec<String>, Vec<String>) = if matches!(
+            self.overlay.inspector_routing_combo,
+            Some(crate::components::panel::InspectorRoutingCombo::MidiInput)
+                | Some(crate::components::panel::InspectorRoutingCombo::MidiOut)
+        ) {
+            let saved = self.settings.read(cx).current.hardware.midi.devices.clone();
+            let detected = crate::device_registry::cached_midi_devices();
+            let resolved = sphere_midi_service::resolve_midi_devices(&saved, &detected);
+            let inputs = resolved
+                .iter()
+                .filter(|d| {
+                    d.enabled
+                        && matches!(
+                            d.direction,
+                            crate::settings::MidiDeviceDirection::Input
+                                | crate::settings::MidiDeviceDirection::InputOutput
+                        )
+                })
+                .map(|d| d.name.clone())
+                .collect();
+            let outputs = resolved
+                .iter()
+                .filter(|d| {
+                    d.enabled
+                        && matches!(
+                            d.direction,
+                            crate::settings::MidiDeviceDirection::Output
+                                | crate::settings::MidiDeviceDirection::InputOutput
+                        )
+                })
+                .map(|d| d.name.clone())
+                .collect();
+            (inputs, outputs)
+        } else {
+            (Vec::new(), Vec::new())
+        };
         let inspector_routing_combo_overlay: Option<gpui::AnyElement> =
             if let (Some(combo), Some(anchor)) = (
                 self.overlay.inspector_routing_combo,


### PR DESCRIPTION
- Reformatted the `SoundfontPlayerError` enum for better clarity by aligning fields.
- Enhanced the `midi_output_combo_label` function for improved readability with clearer formatting.
- Simplified the `has_data` closure in the piano roll component for better conciseness.
- Updated the MIDI note preview logic to use a more idiomatic approach for span assignment.
- Refactored the `TrackOutputRouting` enum to improve structure and readability.
- Adjusted test assertions for better clarity and consistency in the MIDI import tests.
- Cleaned up the MIDI device detection logic in the studio layout for improved readability.