### PR TITLE
Stabilization pass: all 10 phases (lifecycle, VST3 editor, routing, scan, automation, sample-rate, MIDI, PDC, mixer, realtime)

### DIFF
--- a/crates/SpherePluginHost/src/scanner.rs
+++ b/crates/SpherePluginHost/src/scanner.rs
@@ -105,11 +105,21 @@ fn scan_paths_for_format(
 }
 
 fn sort_and_dedup(plugins: &mut Vec<PluginInfo>) {
-    plugins.sort_by_key(|plugin| plugin.name.to_lowercase());
     // Deduplicate by stable id (path + classId hash) so multi-class modules
     // like WaveShell keep all their plugin entries — only true duplicates
     // (same classId from the same module scanned twice) are removed.
-    plugins.dedup_by(|a, b| a.id == b.id);
+    //
+    // Use a seen-set, NOT `sort_by(name)` + `Vec::dedup_by(id)`: dedup_by only
+    // collapses *consecutive* equal elements, so when two same-id entries are
+    // separated by a different-id plugin that happens to share a display name
+    // (common — many vendors ship "Compressor", "EQ", …), the sort-by-name
+    // order leaves them non-adjacent and the duplicate survives. `retain` with
+    // a seen-set is order-independent and keeps the first occurrence of each id.
+    let mut seen = std::collections::HashSet::new();
+    plugins.retain(|plugin| seen.insert(plugin.id.clone()));
+    // Display order is alphabetical by name; done after dedup so ordering can
+    // never affect which entries are removed.
+    plugins.sort_by_key(|plugin| plugin.name.to_lowercase());
 }
 
 fn scan_native_root(path: &str, format: PluginFormat) -> Result<Vec<PluginInfo>, String> {
@@ -286,4 +296,71 @@ fn stable_id(prefix: &str, input: &str) -> String {
 
 pub fn stable_id_for_au(input: &str) -> String {
     stable_id("au", input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sort_and_dedup, PluginInfo};
+
+    fn plugin(id: &str, name: &str) -> PluginInfo {
+        PluginInfo {
+            id: id.to_string(),
+            name: name.to_string(),
+            vendor: String::new(),
+            category: String::new(),
+            sub_categories: None,
+            format: "VST3".to_string(),
+            path: String::new(),
+            module_path: None,
+            class_id: None,
+            version: None,
+            sdk_version: None,
+            is_shell_child: false,
+            sdk_metadata_loaded: false,
+        }
+    }
+
+    fn ids(plugins: &[PluginInfo]) -> Vec<&str> {
+        plugins.iter().map(|p| p.id.as_str()).collect()
+    }
+
+    #[test]
+    fn dedup_removes_true_duplicates_and_sorts_by_name() {
+        let mut plugins = vec![
+            plugin("vst3:2", "Zebra"),
+            plugin("vst3:1", "Alpha"),
+            plugin("vst3:2", "Zebra"),
+        ];
+        sort_and_dedup(&mut plugins);
+        assert_eq!(ids(&plugins), vec!["vst3:1", "vst3:2"]);
+    }
+
+    #[test]
+    fn dedup_survives_same_name_different_id_separator() {
+        // Regression: the old sort-by-name + dedup_by(id) left same-id entries
+        // non-adjacent when a different-id plugin shared their display name, so
+        // the duplicate was never removed. All three share the name "Compressor".
+        let mut plugins = vec![
+            plugin("vst3:aaa", "Compressor"),
+            plugin("vst3:bbb", "Compressor"),
+            plugin("vst3:aaa", "Compressor"),
+        ];
+        sort_and_dedup(&mut plugins);
+        let mut got = ids(&plugins);
+        got.sort_unstable();
+        assert_eq!(got, vec!["vst3:aaa", "vst3:bbb"]);
+    }
+
+    #[test]
+    fn dedup_keeps_distinct_ids_from_multiclass_module() {
+        // WaveShell-style: one module path, many class ids -> all distinct ids
+        // must be preserved.
+        let mut plugins = vec![
+            plugin("vst3:shell#1", "WaveComp"),
+            plugin("vst3:shell#2", "WaveEQ"),
+            plugin("vst3:shell#3", "WaveGate"),
+        ];
+        sort_and_dedup(&mut plugins);
+        assert_eq!(plugins.len(), 3);
+    }
 }

--- a/crates/SphereUIComponents/src/components/routing_matrix_window.rs
+++ b/crates/SphereUIComponents/src/components/routing_matrix_window.rs
@@ -270,12 +270,17 @@ impl Render for RoutingMatrixWindow {
                     let source_id = track.id.clone();
                     let dest_id = dest.track_id.clone().expect("send target has a track id");
                     let on_toggle_send = on_toggle_send.clone();
-                    cell = cell.cursor(gpui::CursorStyle::PointingHand).on_mouse_down(
-                        MouseButton::Left,
-                        move |_, window, cx| {
+                    cell = cell
+                        .cursor(gpui::CursorStyle::PointingHand)
+                        // Hover feedback: highlight the cell the click would
+                        // toggle. Empty (addable) cells otherwise show only a
+                        // faint dot, so without this the interactive target is
+                        // ambiguous. Read-only output / unavailable cells are not
+                        // toggleable and get no hover, keeping the distinction.
+                        .hover(|style| style.bg(Colors::surface_hover()))
+                        .on_mouse_down(MouseButton::Left, move |_, window, cx| {
                             on_toggle_send(source_id.clone(), dest_id.clone(), window, cx);
-                        },
-                    );
+                        });
                 }
 
                 row = row.child(cell);

--- a/crates/SphereUIComponents/src/layout.rs
+++ b/crates/SphereUIComponents/src/layout.rs
@@ -549,6 +549,13 @@ pub struct StudioLayout {
     last_autosave_at: std::time::Instant,
     /// Guards the background autosave job so render/poll frames cannot enqueue duplicates.
     autosave_in_flight: bool,
+    /// Monotonic counter bumped every time the live session is torn down or
+    /// replaced (project reset / in-studio switch). Async project-load
+    /// completions capture the value at spawn time and self-reject if it has
+    /// advanced, so a completion from a superseded session can never install
+    /// over the session that replaced it. See
+    /// [`Self::advance_session_generation`].
+    session_generation: u64,
 }
 
 impl StudioLayout {
@@ -946,6 +953,7 @@ impl StudioLayout {
             session_install_warnings: Vec::new(),
             last_autosave_at: std::time::Instant::now(),
             autosave_in_flight: false,
+            session_generation: 0,
         };
 
         layout.ensure_mixer_tree_defaults_once(cx);

--- a/crates/SphereUIComponents/src/layout/close_ops.rs
+++ b/crates/SphereUIComponents/src/layout/close_ops.rs
@@ -51,6 +51,20 @@ impl PendingCloseAction {
     }
 }
 
+/// Whether a guarded project-lifecycle action (New / Open / Close / Quit /
+/// Switch) may begin, given the two global gates every entry point must
+/// respect: app shutdown and an in-flight project-lifecycle transaction.
+///
+/// Kept pure so the re-entrancy contract can be unit-tested without a live
+/// GPUI layout. All lifecycle entry points share this predicate so New/Open
+/// cannot slip a second transaction on top of a half-torn-down session — the
+/// gap that previously existed because `guard_dirty_then_lifecycle` checked
+/// only `is_shutting_down()`, unlike its `request_close` /
+/// `request_switch_project` siblings.
+pub(crate) fn lifecycle_action_allowed(shutting_down: bool, lifecycle_busy: bool) -> bool {
+    !shutting_down && !lifecycle_busy
+}
+
 impl StudioLayout {
     /// Entry point for OS window close (X), mapped to app quit on the studio window.
     pub fn request_close(
@@ -91,7 +105,18 @@ impl StudioLayout {
         owner_bounds: Option<Bounds<Pixels>>,
         cx: &mut Context<Self>,
     ) {
-        if ShutdownState::global().is_shutting_down() {
+        // Mirror request_close / request_switch_project: never start a New/Open
+        // lifecycle action while shutting down or while another project
+        // load/switch/close transaction is already in flight. Without the busy
+        // guard, New/Open could stack a second transaction on top of a
+        // half-torn-down session during the loading-session window.
+        if !lifecycle_action_allowed(
+            ShutdownState::global().is_shutting_down(),
+            crate::loading_session::is_project_lifecycle_busy(),
+        ) {
+            shutdown::log(&format!(
+                "lifecycle guard ignored (shutdown/busy) action={action:?}"
+            ));
             return;
         }
         let dirty = self.project_session.is_dirty;
@@ -254,5 +279,36 @@ impl StudioLayout {
         self.shutdown_studio(cx);
         shutdown::log("phase: cx.quit");
         cx.quit();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lifecycle_action_allowed;
+
+    #[test]
+    fn lifecycle_allowed_only_when_idle() {
+        // The only state that permits a New/Open/Close/Quit/Switch to begin is
+        // "not shutting down AND not already busy with a lifecycle transaction".
+        assert!(lifecycle_action_allowed(false, false));
+    }
+
+    #[test]
+    fn lifecycle_blocked_while_busy() {
+        // Regression: New/Open must be rejected while a project
+        // load/switch/close is in flight, matching request_close /
+        // request_switch_project. Previously guard_dirty_then_lifecycle ignored
+        // the busy flag, so New/Open could stack a second transaction.
+        assert!(!lifecycle_action_allowed(false, true));
+    }
+
+    #[test]
+    fn lifecycle_blocked_while_shutting_down() {
+        assert!(!lifecycle_action_allowed(true, false));
+    }
+
+    #[test]
+    fn lifecycle_blocked_while_shutting_down_and_busy() {
+        assert!(!lifecycle_action_allowed(true, true));
     }
 }

--- a/crates/SphereUIComponents/src/layout/plugin_ops.rs
+++ b/crates/SphereUIComponents/src/layout/plugin_ops.rs
@@ -207,6 +207,32 @@ fn bridge_editor_is_terminal(state: &BridgeEditorState) -> bool {
     )
 }
 
+/// What an Open-Editor request should do when a session already exists for the
+/// same plugin instance (spec A6 re-open semantics). Pure so the "a Failed /
+/// timed-out session is never treated as live" contract is unit-tested and
+/// cannot silently regress into focusing a dead loading shell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EditorReopenAction {
+    /// Live or still-in-flight (attaching) — focus it; never spawn a duplicate.
+    FocusExisting,
+    /// Still `Loading` in the host — reuse the existing loading shell.
+    ReuseLoadingShell,
+    /// Terminal (`Failed` / `TimedOut`) — drop the stale session and open fresh.
+    DropAndRetry,
+}
+
+fn editor_reopen_action(state: &BridgeEditorState) -> EditorReopenAction {
+    if bridge_editor_is_terminal(state) {
+        // Terminal first: a Failed/TimedOut session must never be focused as if
+        // it were live — that was the "cannot open the editor again" bug.
+        EditorReopenAction::DropAndRetry
+    } else if matches!(state, BridgeEditorState::Loading) {
+        EditorReopenAction::ReuseLoadingShell
+    } else {
+        EditorReopenAction::FocusExisting
+    }
+}
+
 impl StudioLayout {
     pub(super) fn poll_plugin_bridge_runtime(&mut self, cx: &mut Context<Self>) {
         use crate::components::timeline::timeline_state::{
@@ -876,30 +902,34 @@ impl StudioLayout {
             .map(|s| (s.state.clone(), s.requested_at));
         let mut loading_session = None;
         if let Some((state, requested_at)) = existing {
-            if bridge_editor_is_terminal(&state) {
-                ped_log!(
-                    "Open Request track={track_id} slot={instance_id} prior={state:?} -> retry (dropping stale session)"
-                );
-                self.close_bridge_editor(cx, track_id, instance_id);
-                // fall through to a fresh open below
-            } else if state == BridgeEditorState::Loading {
-                ped_log!(
-                    "Open Request track={track_id} slot={instance_id} state=Loading -> attach existing shell (loading_ms={})",
-                    requested_at.elapsed().as_millis()
-                );
-                loading_session = self.plugin_editors.bridge.remove(&key);
-            } else {
-                if let Some(session) = self.plugin_editors.bridge.get(&key) {
-                    session.shell.focus();
+            match editor_reopen_action(&state) {
+                EditorReopenAction::DropAndRetry => {
+                    ped_log!(
+                        "Open Request track={track_id} slot={instance_id} prior={state:?} -> retry (dropping stale session)"
+                    );
+                    self.close_bridge_editor(cx, track_id, instance_id);
+                    // fall through to a fresh open below
                 }
-                ped_log!(
-                    "Open Request track={track_id} slot={instance_id} state={state:?} -> focus existing (in_flight_ms={})",
-                    requested_at.elapsed().as_millis()
-                );
-                eprintln!(
-                    "[plugin-editor-window] existing native editor focus instance={instance_id}"
-                );
-                return;
+                EditorReopenAction::ReuseLoadingShell => {
+                    ped_log!(
+                        "Open Request track={track_id} slot={instance_id} state=Loading -> attach existing shell (loading_ms={})",
+                        requested_at.elapsed().as_millis()
+                    );
+                    loading_session = self.plugin_editors.bridge.remove(&key);
+                }
+                EditorReopenAction::FocusExisting => {
+                    if let Some(session) = self.plugin_editors.bridge.get(&key) {
+                        session.shell.focus();
+                    }
+                    ped_log!(
+                        "Open Request track={track_id} slot={instance_id} state={state:?} -> focus existing (in_flight_ms={})",
+                        requested_at.elapsed().as_millis()
+                    );
+                    eprintln!(
+                        "[plugin-editor-window] existing native editor focus instance={instance_id}"
+                    );
+                    return;
+                }
             }
         }
         ped_log!(
@@ -3758,4 +3788,70 @@ fn log_bridge_paint_stats(session: &BridgeEditorSession) {
         stats.shell_paint_count,
         stats.size_count
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        bridge_editor_is_open, bridge_editor_is_terminal, editor_reopen_action, BridgeEditorState,
+        EditorReopenAction,
+    };
+
+    // Every non-terminal, non-Loading state. These are "live or in flight" and
+    // a re-open must focus the existing shell rather than spawn a duplicate.
+    const FOCUS_STATES: &[BridgeEditorState] = &[
+        BridgeEditorState::ParentWindowCreated,
+        BridgeEditorState::ViewCreated,
+        BridgeEditorState::Sized,
+        BridgeEditorState::AwaitingAttach,
+        BridgeEditorState::Attached,
+        BridgeEditorState::Visible,
+        BridgeEditorState::Ready,
+    ];
+
+    #[test]
+    fn terminal_states_drop_and_retry() {
+        // The core spec contract: a Failed / timed-out session is NEVER treated
+        // as live — re-open drops it and opens fresh (the "cannot open the
+        // editor again" regression guard).
+        for state in [
+            BridgeEditorState::Failed("boom".to_string()),
+            BridgeEditorState::TimedOut("slow".to_string()),
+        ] {
+            assert!(bridge_editor_is_terminal(&state));
+            assert!(!bridge_editor_is_open(&state));
+            assert_eq!(editor_reopen_action(&state), EditorReopenAction::DropAndRetry);
+        }
+    }
+
+    #[test]
+    fn loading_state_reuses_shell() {
+        let state = BridgeEditorState::Loading;
+        assert!(!bridge_editor_is_open(&state));
+        assert!(!bridge_editor_is_terminal(&state));
+        assert_eq!(
+            editor_reopen_action(&state),
+            EditorReopenAction::ReuseLoadingShell
+        );
+    }
+
+    #[test]
+    fn live_and_inflight_states_focus_existing() {
+        for state in FOCUS_STATES {
+            assert!(!bridge_editor_is_terminal(state));
+            assert_eq!(
+                editor_reopen_action(state),
+                EditorReopenAction::FocusExisting
+            );
+        }
+    }
+
+    #[test]
+    fn only_attached_visible_ready_count_as_open() {
+        assert!(bridge_editor_is_open(&BridgeEditorState::Attached));
+        assert!(bridge_editor_is_open(&BridgeEditorState::Visible));
+        assert!(bridge_editor_is_open(&BridgeEditorState::Ready));
+        // Intermediate in-flight states are focusable but not "open" yet.
+        assert!(!bridge_editor_is_open(&BridgeEditorState::AwaitingAttach));
+    }
 }

--- a/crates/SphereUIComponents/src/layout/project_ops.rs
+++ b/crates/SphereUIComponents/src/layout/project_ops.rs
@@ -753,6 +753,13 @@ impl StudioLayout {
     ) {
         self.refresh_bridge_plugin_states(cx);
         let mut project = self.project_snapshot(cx);
+        // Stamp the session this save belongs to. A plain background save sets no
+        // lifecycle-busy flag, so a project switch/reset can land while the write
+        // is in flight; without this guard the completion below would rebind
+        // `project_session` (name/path/recent, mark saved) — stamping the old
+        // project's identity onto the session that replaced it. See
+        // `advance_session_generation`.
+        let generation = self.session_generation();
         self.project_switcher.current_project.subtitle = "Saving...".to_string();
         self.start_background_task(
             "project-save",
@@ -769,22 +776,44 @@ impl StudioLayout {
                 .background_executor()
                 .spawn(async move { save_project(&mut project, &path_for_job).map(|_| project) })
                 .await;
-            let _ = this.update(cx, move |this, cx| match result {
-                Ok(project) => {
-                    this.finish_project_save(project, path, cx);
-                    this.complete_background_task(
-                        "project-save",
-                        Some("Project saved".to_string()),
-                    );
-                    project_lifecycle_log!("save complete");
-                    if let Some(after_save) = after_save {
-                        this.apply_save_then(after_save, cx);
+            let _ = this.update(cx, move |this, cx| {
+                // The file is already written to disk regardless of the outcome
+                // below. Only skip the *session-state* mutation when the session
+                // was replaced mid-save.
+                let superseded = this.session_generation() != generation;
+                match result {
+                    Ok(project) => {
+                        if superseded {
+                            this.complete_background_task(
+                                "project-save",
+                                Some("Project saved (session changed)".to_string()),
+                            );
+                            project_lifecycle_log!(
+                                "save completed for superseded session — skipping rebind/after-save"
+                            );
+                            return;
+                        }
+                        this.finish_project_save(project, path, cx);
+                        this.complete_background_task(
+                            "project-save",
+                            Some("Project saved".to_string()),
+                        );
+                        project_lifecycle_log!("save complete");
+                        if let Some(after_save) = after_save {
+                            this.apply_save_then(after_save, cx);
+                        }
                     }
-                }
-                Err(e) => {
-                    let error = e.to_string();
-                    this.fail_background_task("project-save", error.clone());
-                    this.handle_project_save_error(error, cx);
+                    Err(e) => {
+                        let error = e.to_string();
+                        this.fail_background_task("project-save", error.clone());
+                        if superseded {
+                            project_lifecycle_log!(
+                                "save failed for superseded session — not surfacing on new session"
+                            );
+                            return;
+                        }
+                        this.handle_project_save_error(error, cx);
+                    }
                 }
             });
         })

--- a/crates/SphereUIComponents/src/layout/project_ops.rs
+++ b/crates/SphereUIComponents/src/layout/project_ops.rs
@@ -274,6 +274,9 @@ impl StudioLayout {
     }
 
     pub(super) fn reset_project(&mut self, cx: &mut Context<Self>) {
+        // Replacing the live session invalidates any in-flight project-load
+        // completion captured against the previous generation.
+        self.advance_session_generation();
         self.project_session = ProjectSession::untitled();
         self.project_path = None;
         self.project_folder = None;

--- a/crates/SphereUIComponents/src/layout/session_load.rs
+++ b/crates/SphereUIComponents/src/layout/session_load.rs
@@ -48,6 +48,24 @@ fn persisted_track_count(
 }
 
 impl StudioLayout {
+    /// Bump the session generation and return the new value. Call this at every
+    /// point that tears down or replaces the live session (project reset,
+    /// in-studio switch). A background project-load completion captures the
+    /// value returned here at spawn time and rejects itself if
+    /// [`Self::session_generation`] has since advanced — see
+    /// [`Self::begin_in_studio_project_switch`]. Cheap (a `u64` increment); the
+    /// generation is purely a staleness token, never persisted.
+    pub(super) fn advance_session_generation(&mut self) -> u64 {
+        self.session_generation = self.session_generation.wrapping_add(1);
+        self.session_generation
+    }
+
+    /// Current session generation. Async work compares its captured value
+    /// against this to detect that the session was replaced mid-flight.
+    pub(super) fn session_generation(&self) -> u64 {
+        self.session_generation
+    }
+
     /// Capture the live session for rollback before an in-studio project swap.
     pub fn capture_session_rollback_snapshot(
         &self,
@@ -313,6 +331,11 @@ impl StudioLayout {
         eprintln!("[ProjectSwitch] closing transient windows count={transient_count}");
         eprintln!("[ProjectSwitch] old session quiesced");
 
+        // Stamp this switch. If another switch/reset replaces the session while
+        // the decode is in flight, the generation advances and the completion
+        // below rejects itself instead of installing a superseded project.
+        let generation = self.advance_session_generation();
+
         self.session_install_status = SessionInstallStatus::Loading;
         self.project_state = ProjectState::Loading;
         cx.update_global::<AppSessionGate, _>(|gate, _| {
@@ -339,7 +362,15 @@ impl StudioLayout {
                 })
                 .await;
 
-            let _ = entity.update(cx, |this, cx| match decoded {
+            let _ = entity.update(cx, |this, cx| {
+                if this.session_generation() != generation {
+                    eprintln!(
+                        "[ProjectSwitch] stale switch completion ignored (generation {generation} != {})",
+                        this.session_generation()
+                    );
+                    return;
+                }
+                match decoded {
                 Ok((project, path)) => {
                     eprintln!("[ProjectSwitch] loaded target project");
                     eprintln!("[ProjectSwitch] installing session");
@@ -404,6 +435,7 @@ impl StudioLayout {
                         open_options,
                         cx,
                     );
+                }
                 }
             });
         })


### PR DESCRIPTION
Stabilization/compatibility pass across all ten planned phases — small, scoped, buildable, reversible fixes plus regression-test coverage. No redesigns, no mock behavior, no realtime-path behavior changes beyond the documented fixes.

## Commits (12)

**Phase 9 — Project switching / close lifecycle**
1. New/Open re-entrancy guard — `guard_dirty_then_lifecycle` now rejects re-entry via `is_project_lifecycle_busy()` like its siblings. Pure `lifecycle_action_allowed` + tests.
2. Stale switch-completion rejection — `session_generation` stamp; async switch completion self-rejects if the session was replaced mid-flight.
3. Racing-save session guard — a background save landing mid-switch no longer rebinds the replaced session's identity.

**Phase 5 — Routing Matrix UX**
4. Hover feedback on toggleable send cells (`surface.hover`).

**Phase 1 — VST3 editor compatibility**
5. Re-open contract behind a tested `editor_reopen_action` predicate — Failed/TimedOut never focused as live (the "cannot open editor again" regression), tests over all 10 states.

**Phase 8 — Plugin scan reliability**
6. Dedup bug — seen-set retain fixes non-adjacent duplicate plugins that `Vec::dedup_by` missed.
8. Cache-invalidation foundation — `file_modified_at`/`file_size` now captured; pure tested `signature_is_fresh`.
9. Incremental rescan (opt-in `FUTUREBOARD_PLUGIN_SCAN_INCREMENTAL`) — skips unchanged bundles; changed binary / prior failure forces rescan. Default OFF, tested `bundle_is_reusable`.

**Phase 7 — Automation UI**
7. Tests for the shared `evaluate_automation` curve evaluator (endpoints, linear, Hold, segment selection).

**Phase 2 — VSTi timing / latency / PDC**
10. PDC latency undercount fix — `strip_plugin_latency_samples` dropped bridge latency on mixed VST3+bridge tracks, causing PDC misalignment AND perpetual latency-graph rebuilds. `max(vst3_sum, stored)` keeps the complete latency; build path byte-identical.

**Phase 4 — Mixer GPU renderer**
11. Extended `static_key` invalidation test coverage — recolor, accent-bar/separator width, master presence/geometry invalidate; hover/meter/scroll don't.

**Phase 10 — Realtime stability under heavy plugin load**
12. Extracted + tested the not-ready bypass policy — effect passes dry through (bypass), instrument silences, never replays stale output. Pure wait-free `apply_bridge_insert_output`, 5 tests.

## Phases audited clean (no change — already correct + tested)
- **Phase 3 (96 kHz):** `tempo_map` sample↔beat conversions covered by 44.1/48/88.2/96/192 kHz round-trip tests; the latency-signature rebuild gate already exists.
- **Phase 6 (MIDI import):** multi-track clip-id uniqueness and stale-instrument-target degradation already implemented and regression-tested.

## Tests
40 new unit tests, all green. Suites: `sphere_ui_components` 370 / 0, `sphere-plugin-host` 40 / 0, `sphere_directaudioengine` 130 / 0. clippy clean on touched crates.

## Verification honesty
Everything is `cargo check` + `cargo test` + `clippy` verified. The following are **not** runtime-validated in this environment (no live plugins / audio hardware / GPU compositing) and are called out per-commit:
- routing-matrix hover (needs a live window),
- editor re-open (needs real plugins),
- incremental-scan flag (needs a real plug-in library — why it defaults OFF),
- the mixed VST3+bridge PDC path and the bridged-insert bypass callback (need a live host).

For each, the extracted pure logic / decision predicate is unit-tested, and realtime-hot-path changes are either verbatim extractions or minimal monotonic fixes with the reasoning documented in the commit.

## Deferred follow-ups (honest)
- Enable incremental scan by default after validation against a real plug-in library.
- Detached waveform/import completions still lack a generation guard (lower severity — keyed by clip id, not session identity).
- Main loading-session/transaction flow relies on `PROJECT_LIFECYCLE_BUSY`, not the generation stamp (defense-in-depth).
- Full runtime validation of the PDC mixed-track fix and bridge-bypass path on real plugin hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)