### PR TITLE
fix(linux): Welcome create/open project no longer quits the app

### DIFF
--- a/apps/native/studio/src/app.rs
+++ b/apps/native/studio/src/app.rs
@@ -271,13 +271,20 @@ fn open_welcome_window(cx: &mut App) {
     set_app_mode(cx, AppMode::Welcome);
     let callbacks = WelcomeCallbacks {
         on_action: Arc::new(|action, welcome_window, cx| match action {
+            // Always open the LoadingSession shell before retiring Welcome.
+            // On Linux, QuitMode::LastWindowClosed would otherwise quit the app
+            // the moment Welcome closes with no replacement window yet.
             WelcomeAction::OpenProjectFile(path) => {
-                welcome_window.remove_window();
                 begin_load_project_from_welcome(path, ProjectOpenOptions::default(), cx);
+                welcome_window.remove_window();
             }
             WelcomeAction::OpenRecent(path) => {
+                begin_load_project_from_welcome(
+                    path,
+                    ProjectOpenOptions { from_recent: true },
+                    cx,
+                );
                 welcome_window.remove_window();
-                begin_load_project_from_welcome(path, ProjectOpenOptions { from_recent: true }, cx);
             }
             other => {
                 open_studio_for_action(other, cx);

--- a/crates/gpui/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui/crates/gpui_linux/src/linux/wayland/window.rs
@@ -194,10 +194,16 @@ impl WaylandSurfaceState {
         let toplevel = xdg_surface.get_toplevel(&globals.qh, surface.id());
         let xdg_parent = parent.as_ref().and_then(|w| w.toplevel());
 
-        if matches!(
-            params.kind,
-            WindowKind::Floating | WindowKind::MdiChild | WindowKind::Dialog
-        ) {
+        // Dialogs with `dialog_parenting = false` must outlive the window they
+        // were opened from (Welcome → LoadingSession → Studio). Parenting them
+        // would cascade-close the loader when Welcome is removed and trigger
+        // QuitMode::LastWindowClosed.
+        let should_attach_parent = match params.kind {
+            WindowKind::Floating | WindowKind::MdiChild => true,
+            WindowKind::Dialog => params.dialog_parenting,
+            _ => false,
+        };
+        if should_attach_parent {
             toplevel.set_parent(xdg_parent.as_ref());
         }
 
@@ -208,7 +214,9 @@ impl WaylandSurfaceState {
                 xdg_dialog
             });
 
-            if let Some(parent) = parent.as_ref() {
+            if params.dialog_parenting
+                && let Some(parent) = parent.as_ref()
+            {
                 parent.add_child(surface.id());
             }
 

--- a/crates/gpui/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui/crates/gpui_linux/src/linux/x11/window.rs
@@ -574,10 +574,16 @@ impl X11WindowState {
                 )?;
             }
 
-            if matches!(
-                params.kind,
-                WindowKind::Floating | WindowKind::MdiChild | WindowKind::Dialog
-            ) {
+            // Dialogs with `dialog_parenting = false` must outlive the window they
+            // were opened from (Welcome → LoadingSession → Studio). Parenting them
+            // would cascade-close the loader when Welcome is removed and trigger
+            // QuitMode::LastWindowClosed.
+            let should_attach_parent = match params.kind {
+                WindowKind::Floating | WindowKind::MdiChild => true,
+                WindowKind::Dialog => params.dialog_parenting,
+                _ => false,
+            };
+            if should_attach_parent {
                 if let Some(parent_window) = parent_window.as_ref().map(|w| w.x_window) {
                     // WM_TRANSIENT_FOR hint indicating the main application window. For floating windows, we set
                     // a parent window (WM_TRANSIENT_FOR) such that the window manager knows where to
@@ -597,6 +603,7 @@ impl X11WindowState {
             }
 
             let parent = if params.kind == WindowKind::Dialog
+                && params.dialog_parenting
                 && let Some(parent) = parent_window
             {
                 parent.add_child(x_window);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Creating or opening a project from Welcome was closing the app on Linux. The LoadingSession dialog was parented to Welcome; closing Welcome cascade-closed the loader, then `QuitMode::LastWindowClosed` exited GPUI.

## Root cause
- LoadingSession opens with `WindowKind::Dialog` and `dialog_parenting = false` (intended to outlive Welcome).
- Windows/macOS honor `dialog_parenting`; Wayland/X11 ignored it and always parented + tracked Dialog children.
- Parent `close()` cascade-closed the loader → empty window set → app quit.
- Open Project / Open Recent also removed Welcome *before* opening the loader, which alone can trigger LastWindowClosed.

## Changes
- Wayland + X11: honor `dialog_parenting = false` (skip `set_parent` / child tracking).
- Welcome actions: always open LoadingSession before retiring Welcome.

## Validation
- `cargo build -p futureboard_native -p sphere-plugin-host --bins` — pass
- Manual under nested Weston + Pulse null sink:
  - Welcome → Blank Project → Create → `[SessionLoad] studio ready` (app stayed alive)
  - Studio → Close Project → Welcome → Open Recent → Studio again (app stayed alive)
- Logs show stage advance past `begin pre-studio workspace prepare` (previously exited there).

[welcome-create-project-studio-alive.mp4](https://cursor.com/agents/bc-d86207f1-6033-4b16-a66e-47067d770a3d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwelcome-create-project-studio-alive.mp4)

[Welcome before create](https://cursor.com/agents/bc-d86207f1-6033-4b16-a66e-47067d770a3d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fwelcome-blank-project.webp)
[Studio after create](https://cursor.com/agents/bc-d86207f1-6033-4b16-a66e-47067d770a3d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-after-create.webp)
[Welcome after close project](https://cursor.com/agents/bc-d86207f1-6033-4b16-a66e-47067d770a3d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fwelcome-recent-after-close.webp)
[Studio after open recent](https://cursor.com/agents/bc-d86207f1-6033-4b16-a66e-47067d770a3d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstudio-after-open-recent.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d86207f1-6033-4b16-a66e-47067d770a3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d86207f1-6033-4b16-a66e-47067d770a3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

