### PR TITLE
feat(BuiltinAudioPlugins): stock DSP cores (easy→hard), no engine wire-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,16 @@ version = 4
 [[package]]
 name = "BuiltinAudioPlugins"
 version = "0.1.0"
+dependencies = [
+ "builtin_dsp_core",
+ "c1073",
+ "compresser",
+ "echospace",
+ "equz8",
+ "fa2a",
+ "fa76",
+ "meowsyn",
+]
 
 [[package]]
 name = "SphereDiscordRPC"
@@ -157,7 +167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -899,6 +909,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "biquad"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dee8f423f64504139bdc53d7fbe6a1cd8eff4f354be3652e7cf26385c9f1cb4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,7 +971,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -961,7 +980,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1028,6 +1047,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
+name = "builtin_dsp_core"
+version = "0.1.0"
+dependencies = [
+ "biquad",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1104,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "c1073"
+version = "0.1.0"
+dependencies = [
+ "biquad",
+ "builtin_dsp_core",
 ]
 
 [[package]]
@@ -1403,6 +1437,13 @@ checksum = "1b60b5124979fccd9addd89d8b97a1d6eebb4950694520c75ddd722535ea443f"
 dependencies = [
  "nix 0.31.3",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "compresser"
+version = "0.1.0"
+dependencies = [
+ "builtin_dsp_core",
 ]
 
 [[package]]
@@ -1872,7 +1913,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2220,6 +2261,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "echospace"
+version = "0.1.0"
+dependencies = [
+ "biquad",
+ "builtin_dsp_core",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2381,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "equz8"
+version = "0.1.0"
+dependencies = [
+ "biquad",
+ "builtin_dsp_core",
+]
+
+[[package]]
 name = "erased-serde"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,6 +2475,20 @@ name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
+name = "fa2a"
+version = "0.1.0"
+dependencies = [
+ "builtin_dsp_core",
+]
+
+[[package]]
+name = "fa76"
+version = "0.1.0"
+dependencies = [
+ "builtin_dsp_core",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -2663,6 +2734,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "fundsp"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6969e5c9d5c5c704723f547237494fde9b1addf16f718f65cd786b3b6e320a4f"
+dependencies = [
+ "dyn-clone",
+ "funutd",
+ "hashbrown 0.16.1",
+ "libm",
+ "microfft",
+ "num-complex",
+ "numeric-array",
+ "once_cell",
+ "resampler",
+ "thingbuf",
+ "tinyvec",
+ "wide",
+]
+
+[[package]]
+name = "funutd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30f658de1fbeca3b70faf090e33d1ecf32b0efd1805bede4a8fd6ef562b7ab83"
+dependencies = [
+ "dyn-clone",
+ "glam",
+ "hashbrown 0.14.5",
+ "libm",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,6 +2951,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4e5aa225bc56696909483320f0ff9b600f1a971b52e07a17d70f3d9b43254b"
+dependencies = [
+ "rustversion",
+ "typenum",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,6 +3055,15 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -3361,6 +3483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -3808,7 +3931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -3963,13 +4086,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -4335,6 +4457,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "meowsyn"
+version = "0.1.0"
+dependencies = [
+ "builtin_dsp_core",
+ "fundsp",
+]
+
+[[package]]
 name = "metal"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4362,6 +4492,17 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "microfft"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b6673eb0cc536241d6734c2ca45abfdbf90e9e7791c66a36a7ba3c315b76cf"
+dependencies = [
+ "cfg-if",
+ "num-complex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -4824,6 +4965,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "numeric-array"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a6096447d657bfba01c49d38338b6c8e68e0e34d595360345375b798a4a765"
+dependencies = [
+ "generic-array 1.4.4",
+ "num-traits",
 ]
 
 [[package]]
@@ -6063,6 +6214,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "resampler"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f5ab61459422b1a350caae1aadef48ebae234b12e80248e9ba9557018ef060"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "resvg"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6326,6 +6486,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -7426,6 +7595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thingbuf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662b54ef6f7b4e71f683dadc787bbb2d8e8ef2f91b682ebed3164a5a7abca905"
+dependencies = [
+ "pin-project",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7792,9 +7970,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -8207,9 +8385,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8220,9 +8398,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8230,9 +8408,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8240,9 +8418,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8253,18 +8431,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
 dependencies = [
  "async-trait",
  "cast",
@@ -8284,9 +8462,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8295,9 +8473,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
+checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
 
 [[package]]
 name = "wasm-encoder"
@@ -8446,9 +8624,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8657,6 +8835,16 @@ dependencies = [
  "home",
  "rustix 0.38.44",
  "winsafe",
+]
+
+[[package]]
+name = "wide"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,15 @@ members = [
     "crates/SpherePlatform",
     "crates/SphereWebView",
     "crates/BuiltinAudioPlugins",
+    # Builtin stock DSP cores (engine integration deferred).
+    "crates/BuiltinAudioPlugins/crates/builtin_dsp_core",
+    "crates/BuiltinAudioPlugins/crates/equz8",
+    "crates/BuiltinAudioPlugins/crates/compresser",
+    "crates/BuiltinAudioPlugins/crates/fa2a",
+    "crates/BuiltinAudioPlugins/crates/echospace",
+    "crates/BuiltinAudioPlugins/crates/fa76",
+    "crates/BuiltinAudioPlugins/crates/c1073",
+    "crates/BuiltinAudioPlugins/crates/meowsyn",
 
     "xtask",
 ]
@@ -74,6 +83,23 @@ sphere-soundfont-player = { path = "crates/SphereSoundfontPlayer", package = "Sp
 sphere-discord-rpc = { path = "crates/SphereDiscordRPC", package = "SphereDiscordRPC" }
 sphere-platform = { path = "crates/SpherePlatform", package = "SpherePlatform" }
 sphere-webview = { path = "crates/SphereWebView", package = "SphereWebView" }
+
+# BuiltinAudioPlugins stock DSP cores (no DirectAudioEngine wiring yet).
+builtin-audio-plugins = { path = "crates/BuiltinAudioPlugins", package = "BuiltinAudioPlugins" }
+builtin-dsp-core = { path = "crates/BuiltinAudioPlugins/crates/builtin_dsp_core", package = "builtin_dsp_core" }
+equz8 = { path = "crates/BuiltinAudioPlugins/crates/equz8" }
+compresser = { path = "crates/BuiltinAudioPlugins/crates/compresser" }
+fa2a = { path = "crates/BuiltinAudioPlugins/crates/fa2a" }
+echospace = { path = "crates/BuiltinAudioPlugins/crates/echospace" }
+fa76 = { path = "crates/BuiltinAudioPlugins/crates/fa76" }
+c1073 = { path = "crates/BuiltinAudioPlugins/crates/c1073" }
+meowsyn = { path = "crates/BuiltinAudioPlugins/crates/meowsyn" }
+
+# MIT/Apache-2.0 DSP libraries used by BuiltinAudioPlugins.
+biquad = "0.6"
+# `std` required (fundsp no_std path currently misses Vec imports in resample).
+# Keep `files`/`fft` off to avoid pulling Symphonia into stock synth DSP.
+fundsp = { version = "0.23", default-features = false, features = ["std"] }
 
 # CEF 150.0.11 bindings have not reached crates.io yet. Keep the exact upstream
 # revision that declares workspace version 150.1.0+150.0.11.

--- a/crates/BuiltinAudioPlugins/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/Cargo.toml
@@ -4,8 +4,21 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true
+description = "Futureboard stock builtin audio plugin DSP cores (engine-agnostic)"
+
+[lib]
+name = "builtin_audio_plugins"
+path = "src/lib.rs"
 
 [dependencies]
+builtin-dsp-core.workspace = true
+equz8.workspace = true
+compresser.workspace = true
+fa2a.workspace = true
+echospace.workspace = true
+fa76.workspace = true
+c1073.workspace = true
+meowsyn.workspace = true
 
 [lints]
 workspace = true

--- a/crates/BuiltinAudioPlugins/README.md
+++ b/crates/BuiltinAudioPlugins/README.md
@@ -1,0 +1,38 @@
+# BuiltinAudioPlugins
+
+Engine-agnostic stock DSP cores for Futureboard Studio.
+
+These crates intentionally **do not** depend on `SphereDirectAudioEngine`.
+Wire-up into DAUx / `SphereAudioPlugins` happens in a later integration pass.
+
+## Focus crates (this phase)
+
+| Crate | Role | Phase | 3rd-party DSP (license) |
+| --- | --- | --- | --- |
+| `equz8` | 8-band parametric EQ | 1 easy | [`biquad`](https://crates.io/crates/biquad) (MIT OR Apache-2.0) |
+| `compresser` | Soft-knee VCA compressor | 1 easy | `biquad` (sidechain HPF) |
+| `fa2a` | Optical compressor (LA-2A-style) | 1 easy | `biquad` (sidechain HPF) |
+| `echospace` | Stereo / ping-pong delay | 2 medium | `biquad` (feedback HP/LP) |
+| `fa76` | FET compressor (1176-style) | 2 medium | `biquad` (sidechain HPF) |
+| `c1073` | 3-band channel EQ + drive | 3 hard | `biquad` |
+| `meowsyn` | Polyphonic soft-synth | 3 hard | [`fundsp`](https://crates.io/crates/fundsp) (MIT OR Apache-2.0) |
+
+Other stub crates under `crates/` (`ampstage`, `verbspace`, …) stay placeholders until a later slice.
+
+## Shared contract
+
+Every effect exposes:
+
+- typed `Params` + `default_params()`
+- `descriptor()` metadata
+- `Dsp::new(sample_rate)` / `set_params` / `reset`
+- allocation-free `process_stereo(l, r) -> (l, r)`
+
+`meowsyn` additionally exposes MIDI `note_on` / `note_off`.
+
+## Validate
+
+```bash
+cargo test -p BuiltinAudioPlugins
+cargo test -p equz8 -p compresser -p fa2a -p echospace -p fa76 -p c1073 -p meowsyn
+```

--- a/crates/BuiltinAudioPlugins/crates/builtin_dsp_core/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/crates/builtin_dsp_core/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
-name = "c1073"
+name = "builtin_dsp_core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "C1073 — 3-band channel EQ + preamp drive DSP core"
+description = "Shared realtime-safe helpers for BuiltinAudioPlugins DSP cores"
 
 [dependencies]
 biquad.workspace = true
-builtin-dsp-core.workspace = true
 
 [lints]
 workspace = true

--- a/crates/BuiltinAudioPlugins/crates/builtin_dsp_core/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/builtin_dsp_core/src/lib.rs
@@ -1,0 +1,271 @@
+//! Shared descriptors, math, and dynamics helpers for BuiltinAudioPlugins.
+//!
+//! Keep this crate free of engine / host dependencies. Hot-path helpers must
+//! stay allocation-free after construction.
+
+use biquad::{Biquad, Coefficients, DirectForm1, ToHertz, Type};
+
+/// Metadata for a builtin DSP core (host integration can map this later).
+#[derive(Debug, Clone)]
+pub struct PluginDescriptor {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub vendor: &'static str,
+    pub category: PluginCategory,
+    pub version: &'static str,
+    pub params: &'static [ParamDescriptor],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginCategory {
+    Effect,
+    Instrument,
+    Analyzer,
+    Utility,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ParamDescriptor {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub default_value: f32,
+    pub min: f32,
+    pub max: f32,
+    pub unit: &'static str,
+}
+
+/// Realtime-safe stereo insert contract.
+pub trait StereoEffect: Send {
+    fn reset(&mut self);
+    fn set_sample_rate(&mut self, sample_rate: f32);
+    fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32);
+}
+
+/// Realtime-safe instrument contract (MIDI + render).
+pub trait Instrument: Send {
+    fn reset(&mut self);
+    fn set_sample_rate(&mut self, sample_rate: f32);
+    fn note_on(&mut self, note: u8, velocity: u8);
+    fn note_off(&mut self, note: u8);
+    fn process_stereo(&mut self) -> (f32, f32);
+}
+
+#[inline]
+pub fn clamp(value: f32, min: f32, max: f32) -> f32 {
+    value.max(min).min(max)
+}
+
+#[inline]
+pub fn db_to_linear(db: f32) -> f32 {
+    10.0f32.powf(db / 20.0)
+}
+
+#[inline]
+pub fn linear_to_db(linear: f32) -> f32 {
+    20.0 * linear.max(1.0e-12).log10()
+}
+
+#[inline]
+pub fn mix(dry: f32, wet: f32, amount: f32) -> f32 {
+    let a = clamp(amount, 0.0, 1.0);
+    dry * (1.0 - a) + wet * a
+}
+
+/// One-pole coefficient for attack/release times in seconds.
+#[inline]
+pub fn time_constant(sample_rate: f32, seconds: f32) -> f32 {
+    let samples = sample_rate.max(1.0) * seconds.max(1.0e-6);
+    (-1.0 / samples).exp()
+}
+
+/// Soft-knee peak compressor (Giannoulis / Reiss style gain computer).
+///
+/// Envelope detection is allocation-free. Sidechain HPF uses `biquad`.
+#[derive(Debug, Clone)]
+pub struct SoftKneeCompressor {
+    sample_rate: f32,
+    threshold_db: f32,
+    ratio: f32,
+    knee_db: f32,
+    attack_coeff: f32,
+    release_coeff: f32,
+    makeup_linear: f32,
+    envelope: f32,
+    sidechain_hpf: Option<DirectForm1<f32>>,
+    sc_cutoff_hz: f32,
+}
+
+impl SoftKneeCompressor {
+    pub fn new(sample_rate: f32) -> Self {
+        let mut dsp = Self {
+            sample_rate: sample_rate.max(1.0),
+            threshold_db: -18.0,
+            ratio: 4.0,
+            knee_db: 6.0,
+            attack_coeff: 0.0,
+            release_coeff: 0.0,
+            makeup_linear: 1.0,
+            envelope: 0.0,
+            sidechain_hpf: None,
+            sc_cutoff_hz: 0.0,
+        };
+        dsp.set_timing(0.01, 0.1);
+        dsp
+    }
+
+    pub fn set_sample_rate(&mut self, sample_rate: f32) {
+        self.sample_rate = sample_rate.max(1.0);
+        self.rebuild_sidechain();
+    }
+
+    pub fn set_timing(&mut self, attack_sec: f32, release_sec: f32) {
+        self.attack_coeff = time_constant(self.sample_rate, attack_sec);
+        self.release_coeff = time_constant(self.sample_rate, release_sec);
+    }
+
+    pub fn set_curve(&mut self, threshold_db: f32, ratio: f32, knee_db: f32, makeup_db: f32) {
+        self.threshold_db = threshold_db;
+        self.ratio = ratio.max(1.0);
+        self.knee_db = knee_db.max(0.0);
+        self.makeup_linear = db_to_linear(makeup_db);
+    }
+
+    pub fn set_sidechain_hpf(&mut self, cutoff_hz: f32) {
+        self.sc_cutoff_hz = cutoff_hz.max(0.0);
+        self.rebuild_sidechain();
+    }
+
+    pub fn reset(&mut self) {
+        self.envelope = 0.0;
+        if let Some(filter) = self.sidechain_hpf.as_mut() {
+            filter.reset_state();
+        }
+    }
+
+    pub fn gain_reduction_db(&self) -> f32 {
+        let level_db = linear_to_db(self.envelope.max(1.0e-12));
+        -self.compute_gr_db(level_db)
+    }
+
+    /// Returns wet sample after compression (makeup applied).
+    #[inline]
+    pub fn process_mono(&mut self, input: f32) -> f32 {
+        let detected = match self.sidechain_hpf.as_mut() {
+            Some(hpf) => hpf.run(input),
+            None => input,
+        };
+        let level = detected.abs();
+        let coeff = if level > self.envelope {
+            self.attack_coeff
+        } else {
+            self.release_coeff
+        };
+        self.envelope = coeff * self.envelope + (1.0 - coeff) * level;
+
+        let level_db = linear_to_db(self.envelope.max(1.0e-12));
+        let gr_db = self.compute_gr_db(level_db);
+        input * db_to_linear(gr_db) * self.makeup_linear
+    }
+
+    #[inline]
+    pub fn process_stereo_linked(&mut self, left: f32, right: f32) -> (f32, f32) {
+        let detector = left.abs().max(right.abs());
+        let detected = match self.sidechain_hpf.as_mut() {
+            Some(hpf) => hpf.run(detector),
+            None => detector,
+        };
+        let level = detected.abs();
+        let coeff = if level > self.envelope {
+            self.attack_coeff
+        } else {
+            self.release_coeff
+        };
+        self.envelope = coeff * self.envelope + (1.0 - coeff) * level;
+
+        let level_db = linear_to_db(self.envelope.max(1.0e-12));
+        let gr_db = self.compute_gr_db(level_db);
+        let gain = db_to_linear(gr_db) * self.makeup_linear;
+        (left * gain, right * gain)
+    }
+
+    #[inline]
+    fn compute_gr_db(&self, level_db: f32) -> f32 {
+        let over = level_db - self.threshold_db;
+        let half_knee = self.knee_db * 0.5;
+        let compressed = if over <= -half_knee {
+            level_db
+        } else if over >= half_knee {
+            self.threshold_db + over / self.ratio
+        } else {
+            let t = over + half_knee;
+            level_db + (1.0 / self.ratio - 1.0) * (t * t) / (2.0 * self.knee_db.max(1.0e-6))
+        };
+        compressed - level_db
+    }
+
+    fn rebuild_sidechain(&mut self) {
+        if self.sc_cutoff_hz < 10.0 {
+            self.sidechain_hpf = None;
+            return;
+        }
+        let fs = self.sample_rate.hz();
+        let f0 = self.sc_cutoff_hz.min(self.sample_rate * 0.45).hz();
+        let Ok(coeffs) = Coefficients::<f32>::from_params(Type::HighPass, fs, f0, 0.707) else {
+            self.sidechain_hpf = None;
+            return;
+        };
+        self.sidechain_hpf = Some(DirectForm1::<f32>::new(coeffs));
+    }
+}
+
+/// Build a `biquad` DirectForm1 from common EQ band kinds.
+pub fn make_eq_biquad(
+    kind: &str,
+    freq_hz: f32,
+    gain_db: f32,
+    q: f32,
+    sample_rate: f32,
+) -> Option<DirectForm1<f32>> {
+    let fs = sample_rate.max(1.0);
+    let f0 = clamp(freq_hz, 10.0, fs * 0.45);
+    let q = clamp(q, 0.1, 12.0);
+    let filter_type = match kind {
+        "bell" | "peak" | "peaking" => Type::PeakingEQ(gain_db),
+        "lowshelf" | "ls" => Type::LowShelf(gain_db),
+        "highshelf" | "hs" => Type::HighShelf(gain_db),
+        "lowpass" | "lp" => Type::LowPass,
+        "highpass" | "hp" => Type::HighPass,
+        "notch" => Type::Notch,
+        _ => return None,
+    };
+    let coeffs = Coefficients::<f32>::from_params(filter_type, fs.hz(), f0.hz(), q).ok()?;
+    Some(DirectForm1::<f32>::new(coeffs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compressor_reduces_hot_signal() {
+        let mut comp = SoftKneeCompressor::new(48_000.0);
+        comp.set_curve(-12.0, 4.0, 6.0, 0.0);
+        // Very fast attack so steady-state GR is reached quickly.
+        comp.set_timing(0.0001, 0.05);
+        for _ in 0..2_000 {
+            let _ = comp.process_mono(0.9);
+        }
+        let mut peak_out = 0.0f32;
+        for _ in 0..256 {
+            peak_out = peak_out.max(comp.process_mono(0.9).abs());
+        }
+        assert!(peak_out < 0.9 * 0.95);
+        assert!(comp.gain_reduction_db() > 1.0);
+    }
+
+    #[test]
+    fn eq_biquad_builds() {
+        assert!(make_eq_biquad("bell", 1_000.0, 3.0, 1.0, 48_000.0).is_some());
+        assert!(make_eq_biquad("highpass", 80.0, 0.0, 0.7, 48_000.0).is_some());
+    }
+}

--- a/crates/BuiltinAudioPlugins/crates/c1073/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/c1073/src/lib.rs
@@ -1,5 +1,334 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+//! C1073 — 3-band channel EQ with preamp drive (Neve 1073-inspired).
+//!
+//! Phase 3 (harder). Tone stages use the MIT/Apache [`biquad`] crate:
+//! high-pass, low shelf, mid bell (selectable center), high shelf, plus
+//! mild class-A style tanh saturation.
+
+use biquad::{Biquad, DirectForm1};
+use builtin_dsp_core::{
+    clamp, db_to_linear, make_eq_biquad, mix, ParamDescriptor, PluginCategory, PluginDescriptor,
+    StereoEffect,
+};
+
+pub const PLUGIN_ID: &str = "futureboard.c1073";
+
+/// Classic mid-band center frequencies (Hz).
+pub const MID_FREQ_CHOICES: [f32; 6] = [360.0, 700.0, 1_600.0, 3_200.0, 4_800.0, 7_200.0];
+
+#[derive(Debug, Clone)]
+pub struct Params {
+    pub power: bool,
+    /// Mic/line preamp drive into the EQ (dB).
+    pub preamp_db: f32,
+    pub highpass_hz: f32,
+    pub highpass_enabled: bool,
+    pub low_shelf_db: f32,
+    pub low_shelf_hz: f32,
+    pub mid_db: f32,
+    pub mid_hz: f32,
+    pub mid_q: f32,
+    pub high_shelf_db: f32,
+    pub high_shelf_hz: f32,
+    pub output_db: f32,
+    pub drive: f32,
+    pub mix: f32,
+}
+
+pub fn default_params() -> Params {
+    Params {
+        power: true,
+        preamp_db: 0.0,
+        highpass_hz: 50.0,
+        highpass_enabled: true,
+        low_shelf_db: 0.0,
+        low_shelf_hz: 220.0,
+        mid_db: 0.0,
+        mid_hz: 1_600.0,
+        mid_q: 0.9,
+        high_shelf_db: 0.0,
+        high_shelf_hz: 12_000.0,
+        output_db: 0.0,
+        drive: 12.0,
+        mix: 100.0,
+    }
+}
+
+pub fn descriptor() -> PluginDescriptor {
+    PluginDescriptor {
+        id: PLUGIN_ID,
+        name: "C1073",
+        vendor: "Futureboard",
+        category: PluginCategory::Effect,
+        version: env!("CARGO_PKG_VERSION"),
+        params: &[
+            ParamDescriptor {
+                id: "power",
+                name: "Power",
+                default_value: 1.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
+            ParamDescriptor {
+                id: "preampDb",
+                name: "Preamp",
+                default_value: 0.0,
+                min: -12.0,
+                max: 36.0,
+                unit: "dB",
+            },
+            ParamDescriptor {
+                id: "lowShelfDb",
+                name: "Low",
+                default_value: 0.0,
+                min: -18.0,
+                max: 18.0,
+                unit: "dB",
+            },
+            ParamDescriptor {
+                id: "midDb",
+                name: "Mid",
+                default_value: 0.0,
+                min: -18.0,
+                max: 18.0,
+                unit: "dB",
+            },
+            ParamDescriptor {
+                id: "highShelfDb",
+                name: "High",
+                default_value: 0.0,
+                min: -18.0,
+                max: 18.0,
+                unit: "dB",
+            },
+            ParamDescriptor {
+                id: "drive",
+                name: "Drive",
+                default_value: 12.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+            ParamDescriptor {
+                id: "outputDb",
+                name: "Output",
+                default_value: 0.0,
+                min: -24.0,
+                max: 12.0,
+                unit: "dB",
+            },
+        ],
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ChannelFilters {
+    hpf: Option<DirectForm1<f32>>,
+    low: Option<DirectForm1<f32>>,
+    mid: Option<DirectForm1<f32>>,
+    high: Option<DirectForm1<f32>>,
+}
+
+impl ChannelFilters {
+    fn empty() -> Self {
+        Self {
+            hpf: None,
+            low: None,
+            mid: None,
+            high: None,
+        }
+    }
+
+    fn reset(&mut self) {
+        if let Some(f) = self.hpf.as_mut() {
+            f.reset_state();
+        }
+        if let Some(f) = self.low.as_mut() {
+            f.reset_state();
+        }
+        if let Some(f) = self.mid.as_mut() {
+            f.reset_state();
+        }
+        if let Some(f) = self.high.as_mut() {
+            f.reset_state();
+        }
+    }
+
+    #[inline]
+    fn process(&mut self, mut sample: f32) -> f32 {
+        if let Some(f) = self.hpf.as_mut() {
+            sample = f.run(sample);
+        }
+        if let Some(f) = self.low.as_mut() {
+            sample = f.run(sample);
+        }
+        if let Some(f) = self.mid.as_mut() {
+            sample = f.run(sample);
+        }
+        if let Some(f) = self.high.as_mut() {
+            sample = f.run(sample);
+        }
+        sample
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Dsp {
+    sample_rate: f32,
+    params: Params,
+    left: ChannelFilters,
+    right: ChannelFilters,
+    preamp_gain: f32,
+    output_gain: f32,
+}
+
+impl Dsp {
+    pub fn new(sample_rate: f32) -> Self {
+        let mut dsp = Self {
+            sample_rate: sample_rate.max(1.0),
+            params: default_params(),
+            left: ChannelFilters::empty(),
+            right: ChannelFilters::empty(),
+            preamp_gain: 1.0,
+            output_gain: 1.0,
+        };
+        dsp.rebuild();
+        dsp
+    }
+
+    pub fn params(&self) -> &Params {
+        &self.params
+    }
+
+    pub fn set_params(&mut self, params: Params) {
+        self.params = Params {
+            power: params.power,
+            preamp_db: clamp(params.preamp_db, -12.0, 36.0),
+            highpass_hz: clamp(params.highpass_hz, 20.0, 300.0),
+            highpass_enabled: params.highpass_enabled,
+            low_shelf_db: clamp(params.low_shelf_db, -18.0, 18.0),
+            low_shelf_hz: clamp(params.low_shelf_hz, 50.0, 400.0),
+            mid_db: clamp(params.mid_db, -18.0, 18.0),
+            mid_hz: nearest_mid_freq(params.mid_hz),
+            mid_q: clamp(params.mid_q, 0.3, 4.0),
+            high_shelf_db: clamp(params.high_shelf_db, -18.0, 18.0),
+            high_shelf_hz: clamp(params.high_shelf_hz, 4_000.0, 16_000.0),
+            output_db: clamp(params.output_db, -24.0, 12.0),
+            drive: clamp(params.drive, 0.0, 100.0),
+            mix: clamp(params.mix, 0.0, 100.0),
+        };
+        self.rebuild();
+    }
+
+    fn rebuild(&mut self) {
+        self.preamp_gain = db_to_linear(self.params.preamp_db);
+        self.output_gain = db_to_linear(self.params.output_db);
+
+        let hpf = if self.params.highpass_enabled {
+            make_eq_biquad(
+                "highpass",
+                self.params.highpass_hz,
+                0.0,
+                0.707,
+                self.sample_rate,
+            )
+        } else {
+            None
+        };
+        let low = if self.params.low_shelf_db.abs() > 0.01 {
+            make_eq_biquad(
+                "lowshelf",
+                self.params.low_shelf_hz,
+                self.params.low_shelf_db,
+                0.7,
+                self.sample_rate,
+            )
+        } else {
+            None
+        };
+        let mid = if self.params.mid_db.abs() > 0.01 {
+            make_eq_biquad(
+                "bell",
+                self.params.mid_hz,
+                self.params.mid_db,
+                self.params.mid_q,
+                self.sample_rate,
+            )
+        } else {
+            None
+        };
+        let high = if self.params.high_shelf_db.abs() > 0.01 {
+            make_eq_biquad(
+                "highshelf",
+                self.params.high_shelf_hz,
+                self.params.high_shelf_db,
+                0.7,
+                self.sample_rate,
+            )
+        } else {
+            None
+        };
+
+        self.left = ChannelFilters {
+            hpf,
+            low,
+            mid,
+            high,
+        };
+        self.right = ChannelFilters { hpf, low, mid, high };
+    }
+
+    #[inline]
+    fn drive(sample: f32, amount: f32) -> f32 {
+        if amount <= 0.0 {
+            return sample;
+        }
+        // Mild asymmetric flavor for "iron" color without heavy aliasing.
+        let drive = 1.0 + amount * 5.0;
+        let shaped = (sample * drive).tanh();
+        let even = shaped + 0.03 * amount * shaped * shaped;
+        even / drive.tanh().max(0.001)
+    }
+}
+
+fn nearest_mid_freq(freq: f32) -> f32 {
+    let mut best = MID_FREQ_CHOICES[0];
+    let mut best_err = (freq - best).abs();
+    for &candidate in &MID_FREQ_CHOICES[1..] {
+        let err = (freq - candidate).abs();
+        if err < best_err {
+            best = candidate;
+            best_err = err;
+        }
+    }
+    best
+}
+
+impl StereoEffect for Dsp {
+    fn reset(&mut self) {
+        self.left.reset();
+        self.right.reset();
+    }
+
+    fn set_sample_rate(&mut self, sample_rate: f32) {
+        self.sample_rate = sample_rate.max(1.0);
+        self.rebuild();
+    }
+
+    fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32) {
+        if !self.params.power {
+            return (left, right);
+        }
+
+        let drive = self.params.drive / 100.0;
+        let mut wet_l = Self::drive(left * self.preamp_gain, drive);
+        let mut wet_r = Self::drive(right * self.preamp_gain, drive);
+        wet_l = self.left.process(wet_l) * self.output_gain;
+        wet_r = self.right.process(wet_r) * self.output_gain;
+
+        let amount = self.params.mix / 100.0;
+        (mix(left, wet_l, amount), mix(right, wet_r, amount))
+    }
 }
 
 #[cfg(test)]
@@ -7,8 +336,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn snaps_mid_frequency() {
+        assert_eq!(nearest_mid_freq(1_500.0), 1_600.0);
+        assert_eq!(nearest_mid_freq(7_000.0), 7_200.0);
+    }
+
+    #[test]
+    fn eq_boost_changes_signal() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.mid_db = 12.0;
+        params.mid_hz = 1_600.0;
+        params.drive = 0.0;
+        params.preamp_db = 0.0;
+        params.mix = 100.0;
+        dsp.set_params(params);
+
+        // Drive a mid-frequency sine-ish impulse train and ensure finite output.
+        let mut peak = 0.0f32;
+        for n in 0..2_000 {
+            let phase = (n as f32) * 1_600.0 * std::f32::consts::TAU / 48_000.0;
+            let x = phase.sin() * 0.25;
+            let (l, _) = dsp.process_stereo(x, x);
+            peak = peak.max(l.abs());
+        }
+        assert!(peak.is_finite());
+        assert!(peak > 0.0);
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/compresser/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/crates/compresser/Cargo.toml
@@ -1,6 +1,13 @@
 [package]
 name = "compresser"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Compresser — soft-knee VCA compressor DSP core"
 
 [dependencies]
+builtin-dsp-core.workspace = true
+
+[lints]
+workspace = true

--- a/crates/BuiltinAudioPlugins/crates/compresser/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/compresser/src/lib.rs
@@ -1,5 +1,182 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+//! Compresser — soft-knee VCA compressor.
+//!
+//! Phase 1 (easy). Dynamics use `builtin_dsp_core::SoftKneeCompressor`, which
+//! builds its optional sidechain HPF with the MIT/Apache [`biquad`] crate.
+
+use builtin_dsp_core::{
+    clamp, mix, ParamDescriptor, PluginCategory, PluginDescriptor, SoftKneeCompressor, StereoEffect,
+};
+
+pub const PLUGIN_ID: &str = "futureboard.compresser";
+
+#[derive(Debug, Clone)]
+pub struct Params {
+    pub power: bool,
+    pub threshold_db: f32,
+    pub ratio: f32,
+    pub knee_db: f32,
+    pub attack_ms: f32,
+    pub release_ms: f32,
+    pub makeup_db: f32,
+    pub mix: f32,
+    pub sidechain_hpf_hz: f32,
+}
+
+pub fn default_params() -> Params {
+    Params {
+        power: true,
+        threshold_db: -18.0,
+        ratio: 4.0,
+        knee_db: 6.0,
+        attack_ms: 10.0,
+        release_ms: 100.0,
+        makeup_db: 0.0,
+        mix: 100.0,
+        sidechain_hpf_hz: 80.0,
+    }
+}
+
+pub fn descriptor() -> PluginDescriptor {
+    PluginDescriptor {
+        id: PLUGIN_ID,
+        name: "Compresser",
+        vendor: "Futureboard",
+        category: PluginCategory::Effect,
+        version: env!("CARGO_PKG_VERSION"),
+        params: &[
+            ParamDescriptor {
+                id: "power",
+                name: "Power",
+                default_value: 1.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
+            ParamDescriptor {
+                id: "thresholdDb",
+                name: "Threshold",
+                default_value: -18.0,
+                min: -60.0,
+                max: 0.0,
+                unit: "dB",
+            },
+            ParamDescriptor {
+                id: "ratio",
+                name: "Ratio",
+                default_value: 4.0,
+                min: 1.0,
+                max: 20.0,
+                unit: ":1",
+            },
+            ParamDescriptor {
+                id: "attackMs",
+                name: "Attack",
+                default_value: 10.0,
+                min: 0.1,
+                max: 100.0,
+                unit: "ms",
+            },
+            ParamDescriptor {
+                id: "releaseMs",
+                name: "Release",
+                default_value: 100.0,
+                min: 10.0,
+                max: 2_000.0,
+                unit: "ms",
+            },
+            ParamDescriptor {
+                id: "makeupDb",
+                name: "Makeup",
+                default_value: 0.0,
+                min: -12.0,
+                max: 24.0,
+                unit: "dB",
+            },
+            ParamDescriptor {
+                id: "mix",
+                name: "Mix",
+                default_value: 100.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+        ],
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Dsp {
+    params: Params,
+    compressor: SoftKneeCompressor,
+}
+
+impl Dsp {
+    pub fn new(sample_rate: f32) -> Self {
+        let mut dsp = Self {
+            params: default_params(),
+            compressor: SoftKneeCompressor::new(sample_rate),
+        };
+        dsp.apply_params();
+        dsp
+    }
+
+    pub fn params(&self) -> &Params {
+        &self.params
+    }
+
+    pub fn gain_reduction_db(&self) -> f32 {
+        self.compressor.gain_reduction_db()
+    }
+
+    pub fn set_params(&mut self, params: Params) {
+        self.params = Params {
+            power: params.power,
+            threshold_db: clamp(params.threshold_db, -60.0, 0.0),
+            ratio: clamp(params.ratio, 1.0, 20.0),
+            knee_db: clamp(params.knee_db, 0.0, 24.0),
+            attack_ms: clamp(params.attack_ms, 0.1, 100.0),
+            release_ms: clamp(params.release_ms, 10.0, 2_000.0),
+            makeup_db: clamp(params.makeup_db, -12.0, 24.0),
+            mix: clamp(params.mix, 0.0, 100.0),
+            sidechain_hpf_hz: clamp(params.sidechain_hpf_hz, 0.0, 500.0),
+        };
+        self.apply_params();
+    }
+
+    fn apply_params(&mut self) {
+        self.compressor.set_curve(
+            self.params.threshold_db,
+            self.params.ratio,
+            self.params.knee_db,
+            self.params.makeup_db,
+        );
+        self.compressor.set_timing(
+            self.params.attack_ms * 0.001,
+            self.params.release_ms * 0.001,
+        );
+        self.compressor
+            .set_sidechain_hpf(self.params.sidechain_hpf_hz);
+    }
+}
+
+impl StereoEffect for Dsp {
+    fn reset(&mut self) {
+        self.compressor.reset();
+    }
+
+    fn set_sample_rate(&mut self, sample_rate: f32) {
+        self.compressor.set_sample_rate(sample_rate);
+        self.apply_params();
+    }
+
+    fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32) {
+        if !self.params.power {
+            return (left, right);
+        }
+        let (wet_l, wet_r) = self.compressor.process_stereo_linked(left, right);
+        let amount = self.params.mix / 100.0;
+        (mix(left, wet_l, amount), mix(right, wet_r, amount))
+    }
 }
 
 #[cfg(test)]
@@ -7,8 +184,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn compresses_hot_signal() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.threshold_db = -24.0;
+        params.ratio = 8.0;
+        params.attack_ms = 1.0;
+        params.release_ms = 50.0;
+        params.makeup_db = 0.0;
+        dsp.set_params(params);
+
+        for _ in 0..4_000 {
+            let _ = dsp.process_stereo(0.95, 0.95);
+        }
+        let mut peak_out = 0.0f32;
+        for _ in 0..256 {
+            let (l, _) = dsp.process_stereo(0.95, 0.95);
+            peak_out = peak_out.max(l.abs());
+        }
+        assert!(peak_out < 0.95 * 0.95);
+        assert!(dsp.gain_reduction_db() > 1.0);
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/echospace/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/crates/echospace/Cargo.toml
@@ -1,6 +1,14 @@
 [package]
 name = "echospace"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "EchoSpace — stereo / ping-pong delay DSP core"
 
 [dependencies]
+biquad.workspace = true
+builtin-dsp-core.workspace = true
+
+[lints]
+workspace = true

--- a/crates/BuiltinAudioPlugins/crates/echospace/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/echospace/src/lib.rs
@@ -1,5 +1,333 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+//! EchoSpace — stereo / ping-pong delay with filtered feedback.
+//!
+//! Phase 2 (medium). Feedback tone controls use the MIT/Apache [`biquad`]
+//! crate. Delay lines are preallocated ring buffers (no realtime heap growth).
+
+use biquad::{Biquad, DirectForm1};
+use builtin_dsp_core::{
+    clamp, db_to_linear, make_eq_biquad, mix, ParamDescriptor, PluginCategory, PluginDescriptor,
+    StereoEffect,
+};
+
+pub const PLUGIN_ID: &str = "futureboard.echospace";
+const MAX_DELAY_MS: f32 = 4_000.0;
+const MAX_DELAY_SAMPLES: usize = 192_000; // 4s @ 48k; clamped per sample-rate
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DelayMode {
+    Stereo,
+    PingPong,
+    Mono,
+}
+
+#[derive(Debug, Clone)]
+pub struct Params {
+    pub power: bool,
+    pub mode: DelayMode,
+    pub time_ms_l: f32,
+    pub time_ms_r: f32,
+    pub feedback: f32,
+    pub cross_feedback: f32,
+    pub low_cut_hz: f32,
+    pub high_cut_hz: f32,
+    pub saturation: f32,
+    pub mix: f32,
+    pub output_db: f32,
+    pub freeze: bool,
+}
+
+pub fn default_params() -> Params {
+    Params {
+        power: true,
+        mode: DelayMode::PingPong,
+        time_ms_l: 375.0,
+        time_ms_r: 563.0,
+        feedback: 34.0,
+        cross_feedback: 65.0,
+        low_cut_hz: 180.0,
+        high_cut_hz: 9_000.0,
+        saturation: 8.0,
+        mix: 20.0,
+        output_db: 0.0,
+        freeze: false,
+    }
+}
+
+pub fn descriptor() -> PluginDescriptor {
+    PluginDescriptor {
+        id: PLUGIN_ID,
+        name: "EchoSpace",
+        vendor: "Futureboard",
+        category: PluginCategory::Effect,
+        version: env!("CARGO_PKG_VERSION"),
+        params: &[
+            ParamDescriptor {
+                id: "power",
+                name: "Power",
+                default_value: 1.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
+            ParamDescriptor {
+                id: "timeMsL",
+                name: "Time L",
+                default_value: 375.0,
+                min: 1.0,
+                max: MAX_DELAY_MS,
+                unit: "ms",
+            },
+            ParamDescriptor {
+                id: "timeMsR",
+                name: "Time R",
+                default_value: 563.0,
+                min: 1.0,
+                max: MAX_DELAY_MS,
+                unit: "ms",
+            },
+            ParamDescriptor {
+                id: "feedback",
+                name: "Feedback",
+                default_value: 34.0,
+                min: 0.0,
+                max: 98.0,
+                unit: "%",
+            },
+            ParamDescriptor {
+                id: "mix",
+                name: "Mix",
+                default_value: 20.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+        ],
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DelayLine {
+    buffer: Vec<f32>,
+    write: usize,
+}
+
+impl DelayLine {
+    fn new(capacity: usize) -> Self {
+        Self {
+            buffer: vec![0.0; capacity.max(1)],
+            write: 0,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.buffer.fill(0.0);
+        self.write = 0;
+    }
+
+    #[inline]
+    fn read(&self, delay_samples: usize) -> f32 {
+        let len = self.buffer.len();
+        let idx = (self.write + len - (delay_samples.min(len - 1))) % len;
+        self.buffer[idx]
+    }
+
+    #[inline]
+    fn write_sample(&mut self, sample: f32) {
+        self.buffer[self.write] = sample;
+        self.write += 1;
+        if self.write >= self.buffer.len() {
+            self.write = 0;
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Dsp {
+    sample_rate: f32,
+    params: Params,
+    delay_l: DelayLine,
+    delay_r: DelayLine,
+    delay_samples_l: usize,
+    delay_samples_r: usize,
+    hpf_l: Option<DirectForm1<f32>>,
+    hpf_r: Option<DirectForm1<f32>>,
+    lpf_l: Option<DirectForm1<f32>>,
+    lpf_r: Option<DirectForm1<f32>>,
+    output_gain: f32,
+}
+
+impl Dsp {
+    pub fn new(sample_rate: f32) -> Self {
+        let sr = sample_rate.max(1.0);
+        let capacity = ((sr * MAX_DELAY_MS * 0.001) as usize).clamp(1, MAX_DELAY_SAMPLES);
+        let mut dsp = Self {
+            sample_rate: sr,
+            params: default_params(),
+            delay_l: DelayLine::new(capacity),
+            delay_r: DelayLine::new(capacity),
+            delay_samples_l: 1,
+            delay_samples_r: 1,
+            hpf_l: None,
+            hpf_r: None,
+            lpf_l: None,
+            lpf_r: None,
+            output_gain: 1.0,
+        };
+        dsp.apply_params();
+        dsp
+    }
+
+    pub fn params(&self) -> &Params {
+        &self.params
+    }
+
+    pub fn set_params(&mut self, params: Params) {
+        self.params = Params {
+            power: params.power,
+            mode: params.mode,
+            time_ms_l: clamp(params.time_ms_l, 1.0, MAX_DELAY_MS),
+            time_ms_r: clamp(params.time_ms_r, 1.0, MAX_DELAY_MS),
+            feedback: clamp(params.feedback, 0.0, 98.0),
+            cross_feedback: clamp(params.cross_feedback, 0.0, 100.0),
+            low_cut_hz: clamp(params.low_cut_hz, 20.0, 2_000.0),
+            high_cut_hz: clamp(params.high_cut_hz, 1_000.0, 20_000.0),
+            saturation: clamp(params.saturation, 0.0, 100.0),
+            mix: clamp(params.mix, 0.0, 100.0),
+            output_db: clamp(params.output_db, -24.0, 12.0),
+            freeze: params.freeze,
+        };
+        self.apply_params();
+    }
+
+    fn apply_params(&mut self) {
+        self.delay_samples_l =
+            ((self.params.time_ms_l * 0.001 * self.sample_rate) as usize).max(1);
+        self.delay_samples_r =
+            ((self.params.time_ms_r * 0.001 * self.sample_rate) as usize).max(1);
+        self.output_gain = db_to_linear(self.params.output_db);
+
+        let hpf = make_eq_biquad(
+            "highpass",
+            self.params.low_cut_hz,
+            0.0,
+            0.707,
+            self.sample_rate,
+        );
+        self.hpf_l = hpf;
+        self.hpf_r = hpf;
+        let lpf = make_eq_biquad(
+            "lowpass",
+            self.params.high_cut_hz.min(self.sample_rate * 0.45),
+            0.0,
+            0.707,
+            self.sample_rate,
+        );
+        self.lpf_l = lpf;
+        self.lpf_r = lpf;
+    }
+
+    #[inline]
+    fn saturate(sample: f32, amount: f32) -> f32 {
+        if amount <= 0.0 {
+            return sample;
+        }
+        let drive = 1.0 + amount * 6.0;
+        (sample * drive).tanh() / drive.tanh().max(0.001)
+    }
+
+    #[inline]
+    fn filter_feedback(
+        sample: f32,
+        hpf: &mut Option<DirectForm1<f32>>,
+        lpf: &mut Option<DirectForm1<f32>>,
+    ) -> f32 {
+        let mut x = sample;
+        if let Some(f) = hpf.as_mut() {
+            x = f.run(x);
+        }
+        if let Some(f) = lpf.as_mut() {
+            x = f.run(x);
+        }
+        x
+    }
+}
+
+impl StereoEffect for Dsp {
+    fn reset(&mut self) {
+        self.delay_l.clear();
+        self.delay_r.clear();
+        if let Some(f) = self.hpf_l.as_mut() {
+            f.reset_state();
+        }
+        if let Some(f) = self.hpf_r.as_mut() {
+            f.reset_state();
+        }
+        if let Some(f) = self.lpf_l.as_mut() {
+            f.reset_state();
+        }
+        if let Some(f) = self.lpf_r.as_mut() {
+            f.reset_state();
+        }
+    }
+
+    fn set_sample_rate(&mut self, sample_rate: f32) {
+        let sr = sample_rate.max(1.0);
+        let capacity = ((sr * MAX_DELAY_MS * 0.001) as usize).clamp(1, MAX_DELAY_SAMPLES);
+        self.sample_rate = sr;
+        self.delay_l = DelayLine::new(capacity);
+        self.delay_r = DelayLine::new(capacity);
+        self.apply_params();
+    }
+
+    fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32) {
+        if !self.params.power {
+            return (left, right);
+        }
+
+        let delayed_l = self.delay_l.read(self.delay_samples_l);
+        let delayed_r = self.delay_r.read(self.delay_samples_r);
+
+        let fb = if self.params.freeze {
+            1.0
+        } else {
+            self.params.feedback / 100.0
+        };
+        let xfb = self.params.cross_feedback / 100.0;
+        let sat = self.params.saturation / 100.0;
+
+        let (in_l, in_r) = match self.params.mode {
+            DelayMode::Mono => {
+                let m = (left + right) * 0.5;
+                (m, m)
+            }
+            DelayMode::Stereo | DelayMode::PingPong => (left, right),
+        };
+
+        let mut fb_l = delayed_l * fb + delayed_r * xfb * fb;
+        let mut fb_r = delayed_r * fb + delayed_l * xfb * fb;
+        if self.params.mode == DelayMode::PingPong {
+            // Swap cross paths for classic ping-pong bounce.
+            std::mem::swap(&mut fb_l, &mut fb_r);
+        }
+
+        fb_l = Self::filter_feedback(fb_l, &mut self.hpf_l, &mut self.lpf_l);
+        fb_r = Self::filter_feedback(fb_r, &mut self.hpf_r, &mut self.lpf_r);
+        fb_l = Self::saturate(fb_l, sat);
+        fb_r = Self::saturate(fb_r, sat);
+
+        if !self.params.freeze {
+            self.delay_l.write_sample(in_l + fb_l);
+            self.delay_r.write_sample(in_r + fb_r);
+        } else {
+            self.delay_l.write_sample(fb_l);
+            self.delay_r.write_sample(fb_r);
+        }
+
+        let wet_l = delayed_l * self.output_gain;
+        let wet_r = delayed_r * self.output_gain;
+        let amount = self.params.mix / 100.0;
+        (mix(left, wet_l, amount), mix(right, wet_r, amount))
+    }
 }
 
 #[cfg(test)]
@@ -7,8 +335,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn delay_produces_echo() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.time_ms_l = 10.0;
+        params.time_ms_r = 10.0;
+        params.feedback = 0.0;
+        params.mix = 100.0;
+        params.mode = DelayMode::Stereo;
+        dsp.set_params(params);
+
+        // Impulse
+        let _ = dsp.process_stereo(1.0, 1.0);
+        let mut heard = 0.0f32;
+        for _ in 0..480 {
+            let (l, _) = dsp.process_stereo(0.0, 0.0);
+            heard = heard.max(l.abs());
+        }
+        assert!(heard > 0.1);
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/equz8/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/crates/equz8/Cargo.toml
@@ -1,6 +1,14 @@
 [package]
 name = "equz8"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Equz8 — 8-band parametric EQ DSP core (biquad)"
 
 [dependencies]
+biquad.workspace = true
+builtin-dsp-core.workspace = true
+
+[lints]
+workspace = true

--- a/crates/BuiltinAudioPlugins/crates/equz8/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/equz8/src/lib.rs
@@ -1,5 +1,265 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+//! Equz8 — 8-band parametric EQ.
+//!
+//! Phase 1 (easy). Filter coefficients and runtime state use the MIT/Apache
+//! [`biquad`] crate. No DirectAudioEngine dependency.
+
+use biquad::{Biquad, DirectForm1};
+use builtin_dsp_core::{
+    clamp, db_to_linear, make_eq_biquad, mix, ParamDescriptor, PluginCategory, PluginDescriptor,
+    StereoEffect,
+};
+
+pub const PLUGIN_ID: &str = "futureboard.equz8";
+pub const BAND_COUNT: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BandType {
+    HighPass,
+    LowShelf,
+    Bell,
+    Notch,
+    HighShelf,
+    LowPass,
+}
+
+impl BandType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::HighPass => "highpass",
+            Self::LowShelf => "lowshelf",
+            Self::Bell => "bell",
+            Self::Notch => "notch",
+            Self::HighShelf => "highshelf",
+            Self::LowPass => "lowpass",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "highpass" | "hp" => Some(Self::HighPass),
+            "lowshelf" | "ls" => Some(Self::LowShelf),
+            "bell" | "peak" | "peaking" => Some(Self::Bell),
+            "notch" => Some(Self::Notch),
+            "highshelf" | "hs" => Some(Self::HighShelf),
+            "lowpass" | "lp" => Some(Self::LowPass),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BandParams {
+    pub active: bool,
+    pub band_type: BandType,
+    pub freq: f32,
+    pub gain_db: f32,
+    pub q: f32,
+}
+
+#[derive(Debug, Clone)]
+pub struct Params {
+    pub power: bool,
+    pub output_db: f32,
+    pub mix: f32,
+    pub bands: [BandParams; BAND_COUNT],
+}
+
+pub fn default_params() -> Params {
+    Params {
+        power: true,
+        output_db: 0.0,
+        mix: 100.0,
+        bands: [
+            BandParams {
+                active: true,
+                band_type: BandType::HighPass,
+                freq: 50.0,
+                gain_db: 0.0,
+                q: 0.7,
+            },
+            BandParams {
+                active: true,
+                band_type: BandType::LowShelf,
+                freq: 120.0,
+                gain_db: 0.0,
+                q: 0.8,
+            },
+            BandParams {
+                active: true,
+                band_type: BandType::Bell,
+                freq: 250.0,
+                gain_db: 2.5,
+                q: 1.2,
+            },
+            BandParams {
+                active: true,
+                band_type: BandType::Bell,
+                freq: 750.0,
+                gain_db: -1.5,
+                q: 1.4,
+            },
+            BandParams {
+                active: true,
+                band_type: BandType::Bell,
+                freq: 1_500.0,
+                gain_db: 1.0,
+                q: 1.0,
+            },
+            BandParams {
+                active: true,
+                band_type: BandType::Bell,
+                freq: 3_500.0,
+                gain_db: 0.0,
+                q: 1.1,
+            },
+            BandParams {
+                active: true,
+                band_type: BandType::HighShelf,
+                freq: 8_000.0,
+                gain_db: 1.5,
+                q: 0.8,
+            },
+            BandParams {
+                active: true,
+                band_type: BandType::LowPass,
+                freq: 16_000.0,
+                gain_db: 0.0,
+                q: 0.7,
+            },
+        ],
+    }
+}
+
+pub fn descriptor() -> PluginDescriptor {
+    PluginDescriptor {
+        id: PLUGIN_ID,
+        name: "Equz8",
+        vendor: "Futureboard",
+        category: PluginCategory::Effect,
+        version: env!("CARGO_PKG_VERSION"),
+        params: &[
+            ParamDescriptor {
+                id: "power",
+                name: "Power",
+                default_value: 1.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
+            ParamDescriptor {
+                id: "mix",
+                name: "Mix",
+                default_value: 100.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+            ParamDescriptor {
+                id: "outputDb",
+                name: "Output",
+                default_value: 0.0,
+                min: -24.0,
+                max: 12.0,
+                unit: "dB",
+            },
+        ],
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Dsp {
+    sample_rate: f32,
+    params: Params,
+    left: [Option<DirectForm1<f32>>; BAND_COUNT],
+    right: [Option<DirectForm1<f32>>; BAND_COUNT],
+    output_gain: f32,
+}
+
+impl Dsp {
+    pub fn new(sample_rate: f32) -> Self {
+        let mut dsp = Self {
+            sample_rate: sample_rate.max(1.0),
+            params: default_params(),
+            left: [None, None, None, None, None, None, None, None],
+            right: [None, None, None, None, None, None, None, None],
+            output_gain: 1.0,
+        };
+        dsp.rebuild();
+        dsp
+    }
+
+    pub fn params(&self) -> &Params {
+        &self.params
+    }
+
+    pub fn set_params(&mut self, params: Params) {
+        self.params = params;
+        self.params.output_db = clamp(self.params.output_db, -24.0, 12.0);
+        self.params.mix = clamp(self.params.mix, 0.0, 100.0);
+        for band in &mut self.params.bands {
+            band.freq = clamp(band.freq, 20.0, 20_000.0);
+            band.gain_db = clamp(band.gain_db, -18.0, 18.0);
+            band.q = clamp(band.q, 0.1, 12.0);
+        }
+        self.rebuild();
+    }
+
+    fn rebuild(&mut self) {
+        self.output_gain = db_to_linear(self.params.output_db);
+        for i in 0..BAND_COUNT {
+            let band = self.params.bands[i];
+            if !band.active {
+                self.left[i] = None;
+                self.right[i] = None;
+                continue;
+            }
+            let filter = make_eq_biquad(
+                band.band_type.as_str(),
+                band.freq,
+                band.gain_db,
+                band.q,
+                self.sample_rate,
+            );
+            self.left[i] = filter;
+            self.right[i] = filter;
+        }
+    }
+}
+
+impl StereoEffect for Dsp {
+    fn reset(&mut self) {
+        for filter in self.left.iter_mut().flatten() {
+            filter.reset_state();
+        }
+        for filter in self.right.iter_mut().flatten() {
+            filter.reset_state();
+        }
+    }
+
+    fn set_sample_rate(&mut self, sample_rate: f32) {
+        self.sample_rate = sample_rate.max(1.0);
+        self.rebuild();
+    }
+
+    fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32) {
+        if !self.params.power {
+            return (left, right);
+        }
+
+        let mut wet_l = left;
+        let mut wet_r = right;
+        for filter in self.left.iter_mut().flatten() {
+            wet_l = filter.run(wet_l);
+        }
+        for filter in self.right.iter_mut().flatten() {
+            wet_r = filter.run(wet_r);
+        }
+        wet_l *= self.output_gain;
+        wet_r *= self.output_gain;
+
+        let amount = self.params.mix / 100.0;
+        (mix(left, wet_l, amount), mix(right, wet_r, amount))
+    }
 }
 
 #[cfg(test)]
@@ -7,8 +267,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn descriptor_id() {
+        assert_eq!(descriptor().id, PLUGIN_ID);
+    }
+
+    #[test]
+    fn bypass_when_power_off() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.power = false;
+        dsp.set_params(params);
+        assert_eq!(dsp.process_stereo(0.25, -0.25), (0.25, -0.25));
+    }
+
+    #[test]
+    fn processes_without_nan() {
+        let mut dsp = Dsp::new(48_000.0);
+        let (l, r) = dsp.process_stereo(0.5, -0.5);
+        assert!(l.is_finite() && r.is_finite());
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/fa2a/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/crates/fa2a/Cargo.toml
@@ -1,6 +1,13 @@
 [package]
 name = "fa2a"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "FA-2A — optical compressor DSP core (LA-2A-style)"
 
 [dependencies]
+builtin-dsp-core.workspace = true
+
+[lints]
+workspace = true

--- a/crates/BuiltinAudioPlugins/crates/fa2a/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/fa2a/src/lib.rs
@@ -1,5 +1,234 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+//! FA-2A — optical / program-dependent compressor (LA-2A-style).
+//!
+//! Phase 1 (easy). Parameter model mirrors `plugins/FB2AComp/Core`. Dynamics
+//! use `SoftKneeCompressor` (sidechain HPF via [`biquad`]).
+
+use builtin_dsp_core::{
+    clamp, db_to_linear, mix, ParamDescriptor, PluginCategory, PluginDescriptor,
+    SoftKneeCompressor, StereoEffect,
+};
+
+pub const PLUGIN_ID: &str = "futureboard.fa2a";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Compress,
+    Limit,
+}
+
+#[derive(Debug, Clone)]
+pub struct Params {
+    pub power: bool,
+    pub peak_reduction: f32,
+    pub gain_db: f32,
+    pub mode: Mode,
+    pub emphasis: f32,
+    pub mix: f32,
+    pub color: f32,
+    pub sidechain_low_cut_hz: f32,
+    pub output_trim_db: f32,
+}
+
+pub fn default_params() -> Params {
+    Params {
+        power: true,
+        peak_reduction: 35.0,
+        gain_db: 0.0,
+        mode: Mode::Compress,
+        emphasis: 45.0,
+        mix: 100.0,
+        color: 12.0,
+        sidechain_low_cut_hz: 90.0,
+        output_trim_db: 0.0,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct OpticalModel {
+    pub threshold_db: f32,
+    pub ratio: f32,
+    pub knee_db: f32,
+    pub attack_sec: f32,
+    pub release_sec: f32,
+}
+
+pub fn optical_model_from_params(params: &Params) -> OpticalModel {
+    let amount = clamp(params.peak_reduction, 0.0, 100.0) / 100.0;
+    let emphasis = clamp(params.emphasis, 0.0, 100.0) / 100.0;
+    let sc_cut = clamp(params.sidechain_low_cut_hz, 20.0, 500.0);
+    let sc_relief = ((sc_cut - 20.0) / 480.0) * 5.5;
+    let emphasis_push = (emphasis - 0.5) * 7.0;
+    let limit = params.mode == Mode::Limit;
+    let threshold_db = clamp(
+        peak_reduction_to_threshold_db(params.peak_reduction) - emphasis_push + sc_relief,
+        -54.0,
+        -3.0,
+    );
+    OpticalModel {
+        threshold_db,
+        ratio: if limit {
+            12.0 + amount * 8.0
+        } else {
+            2.2 + amount * 1.6
+        },
+        knee_db: if limit {
+            2.5 + (1.0 - amount) * 2.0
+        } else {
+            8.0 + (1.0 - amount) * 8.0
+        },
+        attack_sec: clamp(
+            (if limit { 0.004 } else { 0.008 }) + (1.0 - amount) * 0.032 - emphasis * 0.003,
+            0.002,
+            0.07,
+        ),
+        release_sec: clamp(0.12 + amount * 0.68 + emphasis * 0.12, 0.08, 1.1),
+    }
+}
+
+pub fn peak_reduction_to_threshold_db(peak_reduction: f32) -> f32 {
+    let t = clamp(peak_reduction, 0.0, 100.0) / 100.0;
+    -8.0 - t.powf(1.18) * 38.0
+}
+
+pub fn descriptor() -> PluginDescriptor {
+    PluginDescriptor {
+        id: PLUGIN_ID,
+        name: "FA-2A",
+        vendor: "Futureboard",
+        category: PluginCategory::Effect,
+        version: env!("CARGO_PKG_VERSION"),
+        params: &[
+            ParamDescriptor {
+                id: "power",
+                name: "Power",
+                default_value: 1.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
+            ParamDescriptor {
+                id: "peakReduction",
+                name: "Peak Reduction",
+                default_value: 35.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+            ParamDescriptor {
+                id: "gainDb",
+                name: "Gain",
+                default_value: 0.0,
+                min: -12.0,
+                max: 24.0,
+                unit: "dB",
+            },
+            ParamDescriptor {
+                id: "mix",
+                name: "Mix",
+                default_value: 100.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+            ParamDescriptor {
+                id: "color",
+                name: "Color",
+                default_value: 12.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+        ],
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Dsp {
+    params: Params,
+    compressor: SoftKneeCompressor,
+    output_gain: f32,
+}
+
+impl Dsp {
+    pub fn new(sample_rate: f32) -> Self {
+        let mut dsp = Self {
+            params: default_params(),
+            compressor: SoftKneeCompressor::new(sample_rate),
+            output_gain: 1.0,
+        };
+        dsp.apply_params();
+        dsp
+    }
+
+    pub fn params(&self) -> &Params {
+        &self.params
+    }
+
+    pub fn gain_reduction_db(&self) -> f32 {
+        self.compressor.gain_reduction_db()
+    }
+
+    pub fn set_params(&mut self, params: Params) {
+        self.params = Params {
+            power: params.power,
+            peak_reduction: clamp(params.peak_reduction, 0.0, 100.0),
+            gain_db: clamp(params.gain_db, -12.0, 24.0),
+            mode: params.mode,
+            emphasis: clamp(params.emphasis, 0.0, 100.0),
+            mix: clamp(params.mix, 0.0, 100.0),
+            color: clamp(params.color, 0.0, 100.0),
+            sidechain_low_cut_hz: clamp(params.sidechain_low_cut_hz, 20.0, 500.0),
+            output_trim_db: clamp(params.output_trim_db, -12.0, 12.0),
+        };
+        self.apply_params();
+    }
+
+    fn apply_params(&mut self) {
+        let model = optical_model_from_params(&self.params);
+        self.compressor.set_curve(
+            model.threshold_db,
+            model.ratio,
+            model.knee_db,
+            self.params.gain_db,
+        );
+        self.compressor
+            .set_timing(model.attack_sec, model.release_sec);
+        self.compressor
+            .set_sidechain_hpf(self.params.sidechain_low_cut_hz);
+        self.output_gain = db_to_linear(self.params.output_trim_db);
+    }
+
+    #[inline]
+    fn apply_color(sample: f32, drive: f32) -> f32 {
+        if drive <= 0.0 {
+            return sample;
+        }
+        let amount = 1.0 + drive * 4.0;
+        (sample * amount).tanh() / amount.tanh().max(0.001)
+    }
+}
+
+impl StereoEffect for Dsp {
+    fn reset(&mut self) {
+        self.compressor.reset();
+    }
+
+    fn set_sample_rate(&mut self, sample_rate: f32) {
+        self.compressor.set_sample_rate(sample_rate);
+        self.apply_params();
+    }
+
+    fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32) {
+        if !self.params.power {
+            return (left, right);
+        }
+        let (mut wet_l, mut wet_r) = self.compressor.process_stereo_linked(left, right);
+        let drive = self.params.color / 100.0;
+        wet_l = Self::apply_color(wet_l, drive) * self.output_gain;
+        wet_r = Self::apply_color(wet_r, drive) * self.output_gain;
+        let amount = self.params.mix / 100.0;
+        (mix(left, wet_l, amount), mix(right, wet_r, amount))
+    }
 }
 
 #[cfg(test)]
@@ -7,8 +236,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn optical_model_limit_is_harder() {
+        let mut compress = default_params();
+        compress.mode = Mode::Compress;
+        let mut limit = default_params();
+        limit.mode = Mode::Limit;
+        let c = optical_model_from_params(&compress);
+        let l = optical_model_from_params(&limit);
+        assert!(l.ratio > c.ratio);
+        assert!(l.knee_db < c.knee_db);
+    }
+
+    #[test]
+    fn processes_audio() {
+        let mut dsp = Dsp::new(48_000.0);
+        let (l, r) = dsp.process_stereo(0.8, -0.8);
+        assert!(l.is_finite() && r.is_finite());
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/fa76/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/crates/fa76/Cargo.toml
@@ -1,6 +1,13 @@
 [package]
 name = "fa76"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "FA-76 — FET compressor DSP core (1176-style)"
 
 [dependencies]
+builtin-dsp-core.workspace = true
+
+[lints]
+workspace = true

--- a/crates/BuiltinAudioPlugins/crates/fa76/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/fa76/src/lib.rs
@@ -1,5 +1,220 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+//! FA-76 — FET / ultra-fast compressor (1176-style).
+//!
+//! Phase 2 (medium). Ratio buttons map to classic 4 / 8 / 12 / 20 / All curves.
+//! Dynamics use `SoftKneeCompressor` (sidechain HPF via [`biquad`]).
+
+use builtin_dsp_core::{
+    clamp, db_to_linear, mix, ParamDescriptor, PluginCategory, PluginDescriptor,
+    SoftKneeCompressor, StereoEffect,
+};
+
+pub const PLUGIN_ID: &str = "futureboard.fa76";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RatioButton {
+    R4,
+    R8,
+    R12,
+    R20,
+    /// "All buttons in" — aggressive limiting curve.
+    All,
+}
+
+impl RatioButton {
+    pub fn ratio(self) -> f32 {
+        match self {
+            Self::R4 => 4.0,
+            Self::R8 => 8.0,
+            Self::R12 => 12.0,
+            Self::R20 => 20.0,
+            Self::All => 100.0,
+        }
+    }
+
+    pub fn knee_db(self) -> f32 {
+        match self {
+            Self::R4 => 4.0,
+            Self::R8 => 3.0,
+            Self::R12 => 2.0,
+            Self::R20 => 1.0,
+            Self::All => 8.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Params {
+    pub power: bool,
+    pub input_db: f32,
+    pub output_db: f32,
+    pub attack_us: f32,
+    pub release_ms: f32,
+    pub ratio: RatioButton,
+    pub mix: f32,
+    pub sidechain_hpf_hz: f32,
+}
+
+pub fn default_params() -> Params {
+    Params {
+        power: true,
+        input_db: 18.0,
+        output_db: -12.0,
+        attack_us: 20.0,
+        release_ms: 100.0,
+        ratio: RatioButton::R4,
+        mix: 100.0,
+        sidechain_hpf_hz: 60.0,
+    }
+}
+
+pub fn descriptor() -> PluginDescriptor {
+    PluginDescriptor {
+        id: PLUGIN_ID,
+        name: "FA-76",
+        vendor: "Futureboard",
+        category: PluginCategory::Effect,
+        version: env!("CARGO_PKG_VERSION"),
+        params: &[
+            ParamDescriptor {
+                id: "power",
+                name: "Power",
+                default_value: 1.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
+            ParamDescriptor {
+                id: "inputDb",
+                name: "Input",
+                default_value: 18.0,
+                min: -12.0,
+                max: 36.0,
+                unit: "dB",
+            },
+            ParamDescriptor {
+                id: "outputDb",
+                name: "Output",
+                default_value: -12.0,
+                min: -36.0,
+                max: 12.0,
+                unit: "dB",
+            },
+            ParamDescriptor {
+                id: "attackUs",
+                name: "Attack",
+                default_value: 20.0,
+                min: 20.0,
+                max: 800.0,
+                unit: "µs",
+            },
+            ParamDescriptor {
+                id: "releaseMs",
+                name: "Release",
+                default_value: 100.0,
+                min: 50.0,
+                max: 1_100.0,
+                unit: "ms",
+            },
+            ParamDescriptor {
+                id: "mix",
+                name: "Mix",
+                default_value: 100.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+        ],
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Dsp {
+    params: Params,
+    compressor: SoftKneeCompressor,
+    input_gain: f32,
+    output_gain: f32,
+}
+
+impl Dsp {
+    pub fn new(sample_rate: f32) -> Self {
+        let mut dsp = Self {
+            params: default_params(),
+            compressor: SoftKneeCompressor::new(sample_rate),
+            input_gain: 1.0,
+            output_gain: 1.0,
+        };
+        dsp.apply_params();
+        dsp
+    }
+
+    pub fn params(&self) -> &Params {
+        &self.params
+    }
+
+    pub fn gain_reduction_db(&self) -> f32 {
+        self.compressor.gain_reduction_db()
+    }
+
+    pub fn set_params(&mut self, params: Params) {
+        self.params = Params {
+            power: params.power,
+            input_db: clamp(params.input_db, -12.0, 36.0),
+            output_db: clamp(params.output_db, -36.0, 12.0),
+            attack_us: clamp(params.attack_us, 20.0, 800.0),
+            release_ms: clamp(params.release_ms, 50.0, 1_100.0),
+            ratio: params.ratio,
+            mix: clamp(params.mix, 0.0, 100.0),
+            sidechain_hpf_hz: clamp(params.sidechain_hpf_hz, 0.0, 500.0),
+        };
+        self.apply_params();
+    }
+
+    fn apply_params(&mut self) {
+        // FET units are threshold-fixed; "input" drives into a fixed knee.
+        let threshold_db = if self.params.ratio == RatioButton::All {
+            -18.0
+        } else {
+            -24.0
+        };
+        self.compressor.set_curve(
+            threshold_db,
+            self.params.ratio.ratio(),
+            self.params.ratio.knee_db(),
+            0.0,
+        );
+        self.compressor.set_timing(
+            self.params.attack_us * 1.0e-6,
+            self.params.release_ms * 0.001,
+        );
+        self.compressor
+            .set_sidechain_hpf(self.params.sidechain_hpf_hz);
+        self.input_gain = db_to_linear(self.params.input_db);
+        self.output_gain = db_to_linear(self.params.output_db);
+    }
+}
+
+impl StereoEffect for Dsp {
+    fn reset(&mut self) {
+        self.compressor.reset();
+    }
+
+    fn set_sample_rate(&mut self, sample_rate: f32) {
+        self.compressor.set_sample_rate(sample_rate);
+        self.apply_params();
+    }
+
+    fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32) {
+        if !self.params.power {
+            return (left, right);
+        }
+        let driven_l = left * self.input_gain;
+        let driven_r = right * self.input_gain;
+        let (mut wet_l, mut wet_r) = self.compressor.process_stereo_linked(driven_l, driven_r);
+        wet_l *= self.output_gain;
+        wet_r *= self.output_gain;
+        let amount = self.params.mix / 100.0;
+        (mix(left, wet_l, amount), mix(right, wet_r, amount))
+    }
 }
 
 #[cfg(test)]
@@ -7,8 +222,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn all_buttons_has_highest_ratio() {
+        assert!(RatioButton::All.ratio() > RatioButton::R20.ratio());
+    }
+
+    #[test]
+    fn fast_attack_compresses() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.ratio = RatioButton::R20;
+        params.attack_us = 20.0;
+        params.input_db = 24.0;
+        params.output_db = -18.0;
+        dsp.set_params(params);
+        let mut peak = 0.0f32;
+        for _ in 0..2_000 {
+            let (l, _) = dsp.process_stereo(0.8, 0.8);
+            peak = peak.max(l.abs());
+        }
+        assert!(peak.is_finite());
+        assert!(dsp.gain_reduction_db() >= 0.0);
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/meowsyn/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/crates/meowsyn/Cargo.toml
@@ -1,6 +1,14 @@
 [package]
 name = "meowsyn"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "MeowSyn — polyphonic soft-synth DSP core (fundsp)"
 
 [dependencies]
+builtin-dsp-core.workspace = true
+fundsp = { workspace = true, default-features = false }
+
+[lints]
+workspace = true

--- a/crates/BuiltinAudioPlugins/crates/meowsyn/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/meowsyn/src/lib.rs
@@ -1,5 +1,387 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+//! MeowSyn — compact polyphonic soft-synth.
+//!
+//! Phase 3 (hard). Oscillators come from the MIT/Apache [`fundsp`] crate
+//! (`default-features = false`). Voice graphs are rebuilt on note-on (control
+//! path); the audio callback only ticks prebuilt units.
+
+use std::fmt;
+
+use builtin_dsp_core::{
+    clamp, db_to_linear, Instrument, ParamDescriptor, PluginCategory, PluginDescriptor,
+};
+use fundsp::prelude32::*;
+
+pub const PLUGIN_ID: &str = "futureboard.meowsyn";
+pub const MAX_VOICES: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OscShape {
+    SoftSaw,
+    Square,
+    Sine,
+}
+
+#[derive(Debug, Clone)]
+pub struct Params {
+    pub power: bool,
+    pub shape: OscShape,
+    pub cutoff_hz: f32,
+    pub resonance: f32,
+    pub attack_ms: f32,
+    pub decay_ms: f32,
+    pub sustain: f32,
+    pub release_ms: f32,
+    pub detune_cents: f32,
+    pub gain_db: f32,
+}
+
+pub fn default_params() -> Params {
+    Params {
+        power: true,
+        shape: OscShape::SoftSaw,
+        cutoff_hz: 2_400.0,
+        resonance: 0.2,
+        attack_ms: 5.0,
+        decay_ms: 120.0,
+        sustain: 0.7,
+        release_ms: 180.0,
+        detune_cents: 6.0,
+        gain_db: -6.0,
+    }
+}
+
+pub fn descriptor() -> PluginDescriptor {
+    PluginDescriptor {
+        id: PLUGIN_ID,
+        name: "MeowSyn",
+        vendor: "Futureboard",
+        category: PluginCategory::Instrument,
+        version: env!("CARGO_PKG_VERSION"),
+        params: &[
+            ParamDescriptor {
+                id: "power",
+                name: "Power",
+                default_value: 1.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
+            ParamDescriptor {
+                id: "cutoffHz",
+                name: "Cutoff",
+                default_value: 2_400.0,
+                min: 80.0,
+                max: 16_000.0,
+                unit: "Hz",
+            },
+            ParamDescriptor {
+                id: "resonance",
+                name: "Resonance",
+                default_value: 0.2,
+                min: 0.0,
+                max: 1.0,
+                unit: "",
+            },
+            ParamDescriptor {
+                id: "attackMs",
+                name: "Attack",
+                default_value: 5.0,
+                min: 0.5,
+                max: 2_000.0,
+                unit: "ms",
+            },
+            ParamDescriptor {
+                id: "releaseMs",
+                name: "Release",
+                default_value: 180.0,
+                min: 5.0,
+                max: 5_000.0,
+                unit: "ms",
+            },
+            ParamDescriptor {
+                id: "gainDb",
+                name: "Gain",
+                default_value: -6.0,
+                min: -24.0,
+                max: 6.0,
+                unit: "dB",
+            },
+        ],
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Stage {
+    Idle,
+    Attack,
+    Decay,
+    Sustain,
+    Release,
+}
+
+struct Voice {
+    active: bool,
+    note: u8,
+    velocity: f32,
+    stage: Stage,
+    env: f32,
+    unit: Box<dyn AudioUnit>,
+}
+
+impl Voice {
+    fn silent(sample_rate: f32) -> Self {
+        let mut unit: Box<dyn AudioUnit> = Box::new(soft_saw_hz(440.0));
+        unit.set_sample_rate(f64::from(sample_rate));
+        Self {
+            active: false,
+            note: 0,
+            velocity: 0.0,
+            stage: Stage::Idle,
+            env: 0.0,
+            unit,
+        }
+    }
+}
+
+fn build_unit(shape: OscShape, freq_hz: f32, detune_cents: f32, sample_rate: f32) -> Box<dyn AudioUnit> {
+    let detune = 2.0f32.powf(detune_cents / 1200.0);
+    let f1 = freq_hz;
+    let f2 = freq_hz * detune;
+    let mut unit: Box<dyn AudioUnit> = match shape {
+        OscShape::SoftSaw => Box::new((soft_saw_hz(f1) + soft_saw_hz(f2)) * 0.5),
+        OscShape::Square => Box::new((square_hz(f1) + square_hz(f2)) * 0.5),
+        OscShape::Sine => Box::new((sine_hz(f1) + sine_hz(f2)) * 0.5),
+    };
+    unit.set_sample_rate(f64::from(sample_rate));
+    unit
+}
+
+pub struct Dsp {
+    sample_rate: f32,
+    params: Params,
+    voices: [Voice; MAX_VOICES],
+    lp_z_l: f32,
+    lp_z_r: f32,
+    lp_coeff: f32,
+    output_gain: f32,
+    attack_step: f32,
+    decay_step: f32,
+    release_step: f32,
+}
+
+impl fmt::Debug for Dsp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Dsp")
+            .field("sample_rate", &self.sample_rate)
+            .field("params", &self.params)
+            .field(
+                "active_voices",
+                &self.voices.iter().filter(|v| v.active).count(),
+            )
+            .finish()
+    }
+}
+
+impl Dsp {
+    pub fn new(sample_rate: f32) -> Self {
+        let sr = sample_rate.max(1.0);
+        let voices = std::array::from_fn(|_| Voice::silent(sr));
+        let mut dsp = Self {
+            sample_rate: sr,
+            params: default_params(),
+            voices,
+            lp_z_l: 0.0,
+            lp_z_r: 0.0,
+            lp_coeff: 0.0,
+            output_gain: 1.0,
+            attack_step: 0.0,
+            decay_step: 0.0,
+            release_step: 0.0,
+        };
+        dsp.apply_params();
+        dsp
+    }
+
+    pub fn params(&self) -> &Params {
+        &self.params
+    }
+
+    pub fn set_params(&mut self, params: Params) {
+        self.params = Params {
+            power: params.power,
+            shape: params.shape,
+            cutoff_hz: clamp(params.cutoff_hz, 80.0, 16_000.0),
+            resonance: clamp(params.resonance, 0.0, 1.0),
+            attack_ms: clamp(params.attack_ms, 0.5, 2_000.0),
+            decay_ms: clamp(params.decay_ms, 1.0, 2_000.0),
+            sustain: clamp(params.sustain, 0.0, 1.0),
+            release_ms: clamp(params.release_ms, 5.0, 5_000.0),
+            detune_cents: clamp(params.detune_cents, 0.0, 50.0),
+            gain_db: clamp(params.gain_db, -24.0, 6.0),
+        };
+        self.apply_params();
+    }
+
+    fn apply_params(&mut self) {
+        self.output_gain = db_to_linear(self.params.gain_db);
+        self.attack_step = 1.0 / (self.sample_rate * self.params.attack_ms * 0.001).max(1.0);
+        self.decay_step = 1.0 / (self.sample_rate * self.params.decay_ms * 0.001).max(1.0);
+        self.release_step = 1.0 / (self.sample_rate * self.params.release_ms * 0.001).max(1.0);
+        let x = (-std::f32::consts::TAU * self.params.cutoff_hz / self.sample_rate).exp();
+        self.lp_coeff = clamp(1.0 - x, 0.0, 1.0);
+    }
+
+    fn alloc_voice(&mut self, note: u8) -> usize {
+        if let Some((idx, _)) = self
+            .voices
+            .iter()
+            .enumerate()
+            .find(|(_, v)| v.active && v.note == note)
+        {
+            return idx;
+        }
+        if let Some((idx, _)) = self.voices.iter().enumerate().find(|(_, v)| !v.active) {
+            return idx;
+        }
+        self.voices
+            .iter()
+            .enumerate()
+            .min_by(|(_, a), (_, b)| {
+                a.env
+                    .partial_cmp(&b.env)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(i, _)| i)
+            .unwrap_or(0)
+    }
+
+    #[inline]
+    fn advance_env(&mut self, index: usize) -> f32 {
+        let sustain = self.params.sustain;
+        let attack_step = self.attack_step;
+        let decay_step = self.decay_step;
+        let release_step = self.release_step;
+        let voice = &mut self.voices[index];
+        match voice.stage {
+            Stage::Idle => {
+                voice.env = 0.0;
+                voice.active = false;
+            }
+            Stage::Attack => {
+                voice.env += attack_step;
+                if voice.env >= 1.0 {
+                    voice.env = 1.0;
+                    voice.stage = Stage::Decay;
+                }
+            }
+            Stage::Decay => {
+                voice.env -= decay_step * (1.0 - sustain).max(0.001);
+                if voice.env <= sustain {
+                    voice.env = sustain;
+                    voice.stage = Stage::Sustain;
+                }
+            }
+            Stage::Sustain => {
+                voice.env = sustain;
+            }
+            Stage::Release => {
+                voice.env -= release_step;
+                if voice.env <= 0.0 {
+                    voice.env = 0.0;
+                    voice.stage = Stage::Idle;
+                    voice.active = false;
+                }
+            }
+        }
+        voice.env
+    }
+}
+
+fn midi_to_hz(note: u8) -> f32 {
+    440.0 * 2.0f32.powf((f32::from(note) - 69.0) / 12.0)
+}
+
+impl Instrument for Dsp {
+    fn reset(&mut self) {
+        for voice in &mut self.voices {
+            voice.active = false;
+            voice.stage = Stage::Idle;
+            voice.env = 0.0;
+            voice.unit.reset();
+        }
+        self.lp_z_l = 0.0;
+        self.lp_z_r = 0.0;
+    }
+
+    fn set_sample_rate(&mut self, sample_rate: f32) {
+        self.sample_rate = sample_rate.max(1.0);
+        for voice in &mut self.voices {
+            voice.unit.set_sample_rate(f64::from(self.sample_rate));
+        }
+        self.apply_params();
+    }
+
+    fn note_on(&mut self, note: u8, velocity: u8) {
+        if !self.params.power || velocity == 0 {
+            self.note_off(note);
+            return;
+        }
+        let idx = self.alloc_voice(note);
+        let unit = build_unit(
+            self.params.shape,
+            midi_to_hz(note),
+            self.params.detune_cents,
+            self.sample_rate,
+        );
+        let voice = &mut self.voices[idx];
+        voice.active = true;
+        voice.note = note;
+        voice.velocity = f32::from(velocity) / 127.0;
+        voice.stage = Stage::Attack;
+        voice.env = 0.0;
+        voice.unit = unit;
+    }
+
+    fn note_off(&mut self, note: u8) {
+        for voice in &mut self.voices {
+            if voice.active && voice.note == note && voice.stage != Stage::Release {
+                voice.stage = Stage::Release;
+            }
+        }
+    }
+
+    fn process_stereo(&mut self) -> (f32, f32) {
+        if !self.params.power {
+            return (0.0, 0.0);
+        }
+
+        let mut mix_l = 0.0f32;
+        let mut mix_r = 0.0f32;
+        for i in 0..MAX_VOICES {
+            if !self.voices[i].active {
+                continue;
+            }
+            let env = self.advance_env(i);
+            if !self.voices[i].active {
+                continue;
+            }
+            let sample = self.voices[i].unit.get_mono() * env * self.voices[i].velocity;
+            mix_l += sample;
+            mix_r += sample;
+        }
+
+        let res = 1.0 + self.params.resonance * 2.5;
+        mix_l *= res;
+        mix_r *= res;
+
+        self.lp_z_l += self.lp_coeff * (mix_l - self.lp_z_l);
+        self.lp_z_r += self.lp_coeff * (mix_r - self.lp_z_r);
+
+        (
+            (self.lp_z_l * self.output_gain).clamp(-1.5, 1.5),
+            (self.lp_z_r * self.output_gain).clamp(-1.5, 1.5),
+        )
+    }
 }
 
 #[cfg(test)]
@@ -7,8 +389,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn note_renders_nonzero() {
+        let mut dsp = Dsp::new(48_000.0);
+        dsp.note_on(60, 100);
+        let mut peak = 0.0f32;
+        for _ in 0..2_000 {
+            let (l, r) = dsp.process_stereo();
+            peak = peak.max(l.abs()).max(r.abs());
+        }
+        assert!(peak > 0.01);
+    }
+
+    #[test]
+    fn note_off_releases() {
+        let mut dsp = Dsp::new(48_000.0);
+        dsp.note_on(64, 90);
+        for _ in 0..1_000 {
+            let _ = dsp.process_stereo();
+        }
+        dsp.note_off(64);
+        for _ in 0..20_000 {
+            let _ = dsp.process_stereo();
+        }
+        let (l, r) = dsp.process_stereo();
+        assert!(l.abs() < 0.05 && r.abs() < 0.05);
     }
 }

--- a/crates/BuiltinAudioPlugins/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/src/lib.rs
@@ -1,14 +1,83 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+//! BuiltinAudioPlugins — umbrella for Futureboard stock DSP cores.
+//!
+//! These processors are intentionally **engine-agnostic**. Do not depend on
+//! `SphereDirectAudioEngine` here; integrate later through the host / insert
+//! façade (`SphereAudioPlugins` or a dedicated bridge).
+//!
+//! ## Phase map
+//! - Phase 1 (easy): `equz8`, `compresser`, `fa2a`
+//! - Phase 2 (medium): `echospace`, `fa76`
+//! - Phase 3 (hard): `c1073`, `meowsyn`
+
+pub use builtin_dsp_core as core;
+
+pub use c1073;
+pub use compresser;
+pub use echospace;
+pub use equz8;
+pub use fa2a;
+pub use fa76;
+pub use meowsyn;
+
+use builtin_dsp_core::PluginDescriptor;
+
+/// Descriptors for the implemented focus set (integration can register these later).
+pub fn focus_descriptors() -> Vec<PluginDescriptor> {
+    vec![
+        equz8::descriptor(),
+        compresser::descriptor(),
+        fa2a::descriptor(),
+        echospace::descriptor(),
+        fa76::descriptor(),
+        c1073::descriptor(),
+        meowsyn::descriptor(),
+    ]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use builtin_dsp_core::{Instrument, StereoEffect};
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn focus_set_is_complete() {
+        let ids: Vec<_> = focus_descriptors().into_iter().map(|d| d.id).collect();
+        assert!(ids.contains(&equz8::PLUGIN_ID));
+        assert!(ids.contains(&compresser::PLUGIN_ID));
+        assert!(ids.contains(&fa2a::PLUGIN_ID));
+        assert!(ids.contains(&echospace::PLUGIN_ID));
+        assert!(ids.contains(&fa76::PLUGIN_ID));
+        assert!(ids.contains(&c1073::PLUGIN_ID));
+        assert!(ids.contains(&meowsyn::PLUGIN_ID));
+    }
+
+    #[test]
+    fn effects_process_finite() {
+        let mut eq = equz8::Dsp::new(48_000.0);
+        let mut comp = compresser::Dsp::new(48_000.0);
+        let mut optical = fa2a::Dsp::new(48_000.0);
+        let mut delay = echospace::Dsp::new(48_000.0);
+        let mut fet = fa76::Dsp::new(48_000.0);
+        let mut channel = c1073::Dsp::new(48_000.0);
+
+        for dsp in [
+            &mut eq as &mut dyn StereoEffect,
+            &mut comp,
+            &mut optical,
+            &mut delay,
+            &mut fet,
+            &mut channel,
+        ] {
+            let (l, r) = dsp.process_stereo(0.2, -0.1);
+            assert!(l.is_finite() && r.is_finite());
+        }
+    }
+
+    #[test]
+    fn meowsyn_instrument_smoke() {
+        let mut syn = meowsyn::Dsp::new(48_000.0);
+        syn.note_on(60, 100);
+        let (l, r) = syn.process_stereo();
+        assert!(l.is_finite() && r.is_finite());
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the focus set of **engine-agnostic** BuiltinAudioPlugins DSP cores, split easy → hard, using MIT/Apache-2.0 third-party DSP libraries. **Does not touch** `SphereDirectAudioEngine` or the main app — integration is deferred.

### Phase map

| Phase | Crate | Role | 3rd-party |
| --- | --- | --- | --- |
| 1 easy | `equz8` | 8-band parametric EQ | `biquad` |
| 1 easy | `compresser` | Soft-knee VCA compressor | `biquad` (SC HPF via shared core) |
| 1 easy | `fa2a` | Optical compressor (FB2AComp param model) | `biquad` |
| 2 medium | `echospace` | Stereo / ping-pong delay | `biquad` (feedback HP/LP) |
| 2 medium | `fa76` | FET compressor (1176-style ratios) | `biquad` |
| 3 hard | `c1073` | 3-band channel EQ + preamp drive | `biquad` |
| 3 hard | `meowsyn` | 8-voice soft-synth | `fundsp` (`std` only) |

Also adds `builtin_dsp_core` (`StereoEffect` / `Instrument`, descriptors, `SoftKneeCompressor`, EQ biquad helpers) and wires the focus crates as workspace members. Other stubs (`ampstage`, `verbspace`, …) stay untouched.

## Contract

Each effect exposes: `Params` / `default_params()` / `descriptor()` / `Dsp::new` / `set_params` / `reset` / allocation-free `process_stereo`. `meowsyn` adds MIDI `note_on` / `note_off`.

## Validation

```bash
cargo test -p BuiltinAudioPlugins -p builtin_dsp_core -p equz8 -p compresser -p fa2a -p echospace -p fa76 -p c1073 -p meowsyn
cargo clippy -p BuiltinAudioPlugins -p builtin_dsp_core -p equz8 -p compresser -p fa2a -p echospace -p fa76 -p c1073 -p meowsyn -- -D warnings
```

Both passed.

## Out of scope / next

- DAUx / `SphereAudioPlugins` insert registration
- Plugin editor UI
- Remaining stubs (`verbspace`, `nuadee`, samplers, …)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bc6e6da-3645-4773-9421-71460c742616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bc6e6da-3645-4773-9421-71460c742616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

