### PR TITLE
fix(linux): host VST3 plugin editors in GTK4 with IRunLoop

### DIFF
--- a/crates/SphereDirectAudioEngine/vst3bridge/include/sphere_daux_editor_bridge.h
+++ b/crates/SphereDirectAudioEngine/vst3bridge/include/sphere_daux_editor_bridge.h
@@ -22,6 +22,12 @@ void sphere_daux_editor_set_error(const char* msg);
 /// Return and increment the global editor-handle counter (1-based, never 0).
 unsigned long long sphere_daux_editor_next_handle(void);
 
+/// Mark that the user closed the (host-owned) editor window via its own
+/// titlebar. The external plugin-host process polls this via
+/// sphere_daux_vst3_embed_take_user_close() to report EditorClosed. Safe no-op
+/// when the processor has no such state. Called from the GTK/AppKit UI thread.
+void sphere_daux_editor_signal_user_close(SphereDauxVst3Processor* proc);
+
 // ── IPlugView lifecycle ───────────────────────────────────────────────────────
 
 /// Ask the IEditController to create a native view and query the plugin's
@@ -61,6 +67,18 @@ void sphere_daux_editor_notify_resize(
 /// Detach and release the IPlugView (calls IPlugView::removed()).
 /// Safe to call even when no view is currently attached.
 void sphere_daux_editor_detach_view(SphereDauxVst3Processor* proc);
+
+/// Install (frame != NULL) or clear (frame == NULL) the host IPlugFrame on the
+/// current IPlugView via IPlugView::setFrame().
+///
+/// `frame` is an opaque Steinberg::IPlugFrame* (passed as void* to keep this
+/// bridge free of SDK headers). On Linux the frame MUST also implement
+/// Steinberg::Linux::IRunLoop — without it most VST3 editors never repaint.
+///
+/// Contract: call with a valid frame AFTER create_view and BEFORE attach_view;
+/// call with NULL before detach_view (mirrors the SDK editorhost teardown).
+/// Returns 1 on success, 0 if there is no view or setFrame() was rejected.
+int sphere_daux_editor_set_frame(SphereDauxVst3Processor* proc, void* frame);
 
 // ── Native window state storage ───────────────────────────────────────────────
 

--- a/crates/SphereDirectAudioEngine/vst3bridge/include/vst3_processor_internal.hpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/include/vst3_processor_internal.hpp
@@ -492,6 +492,11 @@ struct SphereDauxVst3Processor {
   int editor_requested_width{0};
   int editor_requested_height{0};
   bool editor_attached{false};
+  // Host-owned top-level editor (Linux/macOS): set when the user closes the
+  // editor window via its own titlebar so the external plugin-host process can
+  // poll it (sphere_daux_vst3_embed_take_user_close), report EditorClosed, and
+  // detach — while keeping the audio instance alive. Read-and-reset on poll.
+  std::atomic<bool> editor_user_closed{false};
   std::atomic<bool> processor_valid{true};
 #endif
 

--- a/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
@@ -22,8 +22,10 @@
 #include <cstring>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 #include <gtk/gtk.h>
+#include <glib-unix.h>
 
 #ifdef GDK_WINDOWING_X11
 #  include <gdk/x11/gdkx.h>
@@ -32,7 +34,21 @@
 #  include <gdk/wayland/gdkwayland.h>
 #endif
 
+#include "pluginterfaces/base/funknown.h"
+#include "pluginterfaces/gui/iplugview.h"
+
 #include "sphere_daux_editor_bridge.h"
+
+// The Linux run-loop interfaces are GUI-layer IIDs that the SDK IID TUs we
+// compile (coreiids.cpp / vstinitiids.cpp) do not emit. Our IRunLoop frame's
+// queryInterface references IRunLoop::iid, so define the symbol here (exactly
+// once, in this the only Linux TU). IPlugFrame::iid is defined in
+// vst3_processor.cpp and referenced here as extern.
+namespace Steinberg {
+namespace Linux {
+DEF_CLASS_IID(IRunLoop)
+} // namespace Linux
+} // namespace Steinberg
 
 // ── Forward declarations ──────────────────────────────────────────────────────
 
@@ -78,6 +94,158 @@ bool ensure_gtk() {
                               [] { return s_gtk_ready; });
 }
 
+// ── IPlugFrame + Linux::IRunLoop ─────────────────────────────────────────────
+//
+// VST3 on Linux has no global event loop, so the host must hand the plug-in an
+// IRunLoop (queried off the IPlugFrame). The plug-in registers its X11 socket
+// file descriptor and repaint timers through it; the host drives them from its
+// own main loop. Here we bridge those registrations onto the GTK thread's GLib
+// main context. Without this the editor window attaches but never repaints.
+//
+// All methods run on the GTK thread: the plug-in calls them from attached() /
+// removed() / its own event and timer callbacks, all of which we dispatch on
+// the GTK thread. No locking is therefore required for the registration list.
+class LinuxRunLoopFrame final : public Steinberg::IPlugFrame,
+                                public Steinberg::Linux::IRunLoop {
+public:
+    LinuxRunLoopFrame(SphereDauxVst3Processor* proc, GtkWindow* window)
+        : proc_(proc), window_(window) {}
+
+    ~LinuxRunLoopFrame() {
+        // Defensive: drop any GLib sources the plug-in failed to unregister.
+        for (auto* reg : regs_) {
+            if (reg->source_id) g_source_remove(reg->source_id);
+            if (reg->handler)   reg->handler->release();
+            delete reg;
+        }
+        regs_.clear();
+    }
+
+    // ── IPlugFrame ───────────────────────────────────────────────────────────
+    Steinberg::tresult PLUGIN_API resizeView(Steinberg::IPlugView* view,
+                                             Steinberg::ViewRect* newSize) override {
+        if (!view || !newSize) return Steinberg::kInvalidArgument;
+        const int w = newSize->right - newSize->left;
+        const int h = newSize->bottom - newSize->top;
+        if (window_ && w > 0 && h > 0 && !resizing_) {
+            resizing_ = true;
+            gtk_window_set_default_size(window_, w, h);
+            Steinberg::ViewRect local{0, 0, w, h};
+            view->onSize(&local); // let the plug-in fit its child to the new rect
+            resizing_ = false;
+        }
+        return Steinberg::kResultTrue;
+    }
+
+    // ── Linux::IRunLoop ────────────────────────────────────────────────────────
+    Steinberg::tresult PLUGIN_API registerEventHandler(
+        Steinberg::Linux::IEventHandler* handler,
+        Steinberg::Linux::FileDescriptor fd) override {
+        if (!handler) return Steinberg::kInvalidArgument;
+        handler->addRef();
+        auto* reg = new Reg{handler, nullptr, fd, 0};
+        reg->source_id = g_unix_fd_add_full(
+            G_PRIORITY_DEFAULT, fd,
+            static_cast<GIOCondition>(G_IO_IN | G_IO_ERR | G_IO_HUP),
+            &LinuxRunLoopFrame::fd_cb, reg, nullptr);
+        regs_.push_back(reg);
+        return Steinberg::kResultTrue;
+    }
+
+    Steinberg::tresult PLUGIN_API unregisterEventHandler(
+        Steinberg::Linux::IEventHandler* handler) override {
+        return remove_reg([&](Reg* r) { return r->handler == handler; });
+    }
+
+    Steinberg::tresult PLUGIN_API registerTimer(
+        Steinberg::Linux::ITimerHandler* handler,
+        Steinberg::Linux::TimerInterval milliseconds) override {
+        if (!handler) return Steinberg::kInvalidArgument;
+        if (milliseconds == 0) milliseconds = 1; // GLib requires a non-zero period
+        handler->addRef();
+        auto* reg = new Reg{handler, nullptr, -1, 0};
+        reg->source_id = g_timeout_add_full(
+            G_PRIORITY_DEFAULT, static_cast<guint>(milliseconds),
+            &LinuxRunLoopFrame::timer_cb, reg, nullptr);
+        regs_.push_back(reg);
+        return Steinberg::kResultTrue;
+    }
+
+    Steinberg::tresult PLUGIN_API unregisterTimer(
+        Steinberg::Linux::ITimerHandler* handler) override {
+        return remove_reg(
+            [&](Reg* r) { return r->handler == handler; });
+    }
+
+    // ── FUnknown (shared final overrider for both interface paths) ──────────────
+    Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid,
+                                                 void** obj) override {
+        if (Steinberg::FUnknownPrivate::iidEqual(iid,
+                                                 Steinberg::Linux::IRunLoop::iid)) {
+            *obj = static_cast<Steinberg::Linux::IRunLoop*>(this);
+            addRef();
+            return Steinberg::kResultTrue;
+        }
+        if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::IPlugFrame::iid) ||
+            Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid)) {
+            *obj = static_cast<Steinberg::IPlugFrame*>(this);
+            addRef();
+            return Steinberg::kResultTrue;
+        }
+        *obj = nullptr;
+        return Steinberg::kNoInterface;
+    }
+    // Lifetime is owned by the editor window, not the plug-in: a plug-in
+    // release() must not destroy us (matches the Windows PluginEditorFrame).
+    Steinberg::uint32 PLUGIN_API addRef() override { return 1000; }
+    Steinberg::uint32 PLUGIN_API release() override { return 1000; }
+
+private:
+    // One registration record; `handler` is stored as FUnknown* so a single
+    // list holds both event- and timer-handlers (they share addRef/release).
+    struct Reg {
+        Steinberg::FUnknown* handler{nullptr};
+        void*                unused{nullptr};
+        int                  fd{-1};
+        guint                source_id{0};
+    };
+
+    static gboolean fd_cb(gint fd, GIOCondition, gpointer ud) {
+        auto* reg = static_cast<Reg*>(ud);
+        static_cast<Steinberg::Linux::IEventHandler*>(
+            static_cast<void*>(reg->handler))
+            ->onFDIsSet(fd);
+        return G_SOURCE_CONTINUE;
+    }
+
+    static gboolean timer_cb(gpointer ud) {
+        auto* reg = static_cast<Reg*>(ud);
+        static_cast<Steinberg::Linux::ITimerHandler*>(
+            static_cast<void*>(reg->handler))
+            ->onTimer();
+        return G_SOURCE_CONTINUE;
+    }
+
+    template <typename Pred>
+    Steinberg::tresult remove_reg(Pred pred) {
+        for (auto it = regs_.begin(); it != regs_.end(); ++it) {
+            if (pred(*it)) {
+                if ((*it)->source_id) g_source_remove((*it)->source_id);
+                if ((*it)->handler)   (*it)->handler->release();
+                delete *it;
+                regs_.erase(it);
+                return Steinberg::kResultTrue;
+            }
+        }
+        return Steinberg::kResultFalse;
+    }
+
+    SphereDauxVst3Processor* proc_{nullptr};
+    GtkWindow*               window_{nullptr};
+    bool                     resizing_{false};
+    std::vector<Reg*>        regs_;
+};
+
 // ── Resize callback ────────────────────────────────────────────────────────
 
 struct ResizeCtx {
@@ -95,6 +263,37 @@ static void on_surface_layout(GdkSurface* /*surface*/,
     }
 }
 #endif
+
+// ── Teardown (must run on the GTK thread) ─────────────────────────────────
+//
+// Shared by idle_close_editor (cross-thread close request) and the window's
+// own close-request handler (user pressed the titlebar X). Both already run on
+// the GTK thread, so this runs the teardown inline — it must NOT go through
+// close_editor_linux() from the close-request handler, which would g_idle_add()
+// and then block-wait on the GTK thread for an idle source that can only run
+// once the handler returns (self-deadlock). Idempotent.
+static void close_editor_on_gtk_thread(SphereDauxVst3Processor* proc) {
+    void* win_ptr = sphere_daux_editor_get_native_window(proc);
+    if (!win_ptr) return;
+
+    // Grab the IRunLoop frame (stored in native_embed) before clearing.
+    auto* frame = static_cast<LinuxRunLoopFrame*>(
+        sphere_daux_editor_get_native_embed(proc));
+
+    sphere_daux_editor_clear_native(proc);       // zero first to prevent re-entrancy
+    sphere_daux_editor_set_frame(proc, nullptr); // setFrame(nullptr) before removed()
+    sphere_daux_editor_detach_view(proc);        // IPlugView::removed()
+
+    GtkWidget* window = static_cast<GtkWidget*>(win_ptr);
+    gtk_window_destroy(GTK_WINDOW(window));
+    g_object_unref(window); // matches the g_object_ref in idle_open_editor
+
+    // Destroy the frame last — its dtor drops any leftover GLib fd/timer
+    // sources the plug-in did not unregister in removed().
+    delete frame;
+
+    std::fprintf(stderr, "[SphereVST3/linux] editor closed\n");
+}
 
 // ── Open-task (executed on the GTK thread via g_idle_add) ─────────────────
 
@@ -186,6 +385,13 @@ static gboolean idle_open_editor(gpointer user_data) {
                      "[SphereVST3/linux] X11 XID=0x%lx w=%d h=%d\n",
                      xid, editor_width, editor_height);
 
+        // ── Install IPlugFrame + IRunLoop BEFORE attached() ───────────────
+        // The plug-in queries the frame for Linux::IRunLoop during attached()
+        // to register its X11 fd and repaint timers. Owned here (deleted in
+        // idle_close_editor); stored in the otherwise-unused native_embed slot.
+        auto* frame = new LinuxRunLoopFrame(proc, GTK_WINDOW(window));
+        sphere_daux_editor_set_frame(proc, frame);
+
         // ── Attach IPlugView ──────────────────────────────────────────────
         // kPlatformTypeX11EmbedWindowID = "XcbWindow"
         // Pass the X11 Window ID cast to void*.
@@ -195,6 +401,8 @@ static gboolean idle_open_editor(gpointer user_data) {
                                             "XcbWindow")) {
             std::fprintf(stderr,
                          "[SphereVST3/linux] attach_view('XcbWindow') failed\n");
+            sphere_daux_editor_set_frame(proc, nullptr);
+            delete frame;
             gtk_window_destroy(GTK_WINDOW(window));
             goto done;
         }
@@ -217,7 +425,7 @@ static gboolean idle_open_editor(gpointer user_data) {
         sphere_daux_editor_store_native(
             proc,
             window,      // native_window  (GtkWidget*, g_object_ref'd)
-            nullptr,     // native_embed   (unused on Linux)
+            frame,       // native_embed   (reused on Linux to hold the IRunLoop frame)
             nullptr,     // native_delegate
             handle,
             task->window_id ? task->window_id : "",
@@ -233,8 +441,13 @@ static gboolean idle_open_editor(gpointer user_data) {
             window, "close-request",
             G_CALLBACK(+[](GtkWindow*, gpointer ud) -> gboolean {
                 auto* ctx = static_cast<CloseCtx*>(ud);
-                if (ctx->proc) close_editor_linux(ctx->proc);
-                return TRUE; // prevent default GTK close behaviour
+                if (ctx->proc) {
+                    // Signal the host (host-owned mode) so it reports
+                    // EditorClosed, then tear down inline on this (GTK) thread.
+                    sphere_daux_editor_signal_user_close(ctx->proc);
+                    close_editor_on_gtk_thread(ctx->proc);
+                }
+                return TRUE; // we destroyed the window ourselves
             }),
             close_ctx,
             [](gpointer data, GClosure*) { delete static_cast<CloseCtx*>(data); },
@@ -273,19 +486,7 @@ struct CloseTask {
 
 static gboolean idle_close_editor(gpointer user_data) {
     auto* task = static_cast<CloseTask*>(user_data);
-    SphereDauxVst3Processor* proc = task->proc;
-
-    void* win_ptr = sphere_daux_editor_get_native_window(proc);
-    if (win_ptr) {
-        sphere_daux_editor_clear_native(proc);   // zero first to prevent re-entrancy
-        sphere_daux_editor_detach_view(proc);    // IPlugView::removed()
-
-        GtkWidget* window = static_cast<GtkWidget*>(win_ptr);
-        gtk_window_destroy(GTK_WINDOW(window));
-        g_object_unref(window); // matches the g_object_ref in idle_open_editor
-
-        std::fprintf(stderr, "[SphereVST3/linux] editor closed\n");
-    }
+    close_editor_on_gtk_thread(task->proc);
 
     {
         std::lock_guard<std::mutex> lk(task->done_mutex);

--- a/crates/SphereDirectAudioEngine/vst3bridge/src/vst3_processor.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/vst3_processor.cpp
@@ -744,6 +744,23 @@ extern "C" int sphere_daux_editor_attach_view(SphereDauxVst3Processor *proc,
   return 1;
 }
 
+extern "C" void
+sphere_daux_editor_signal_user_close(SphereDauxVst3Processor *proc) {
+  if (proc)
+    proc->editor_user_closed.store(true, std::memory_order_release);
+}
+
+extern "C" int sphere_daux_editor_set_frame(SphereDauxVst3Processor *proc,
+                                            void *frame) {
+  if (!proc || !proc->editor_view)
+    return 0;
+  auto *plug_frame = static_cast<Steinberg::IPlugFrame *>(frame);
+  const auto res = proc->editor_view->setFrame(plug_frame);
+  std::fprintf(stderr, "[SphereVST3] IPlugView::setFrame(%p) result=%d\n", frame,
+               (int)res);
+  return (res == Steinberg::kResultTrue || res == Steinberg::kResultOk) ? 1 : 0;
+}
+
 extern "C" void sphere_daux_editor_notify_resize(SphereDauxVst3Processor *proc,
                                                  int width, int height) {
   if (!proc || !proc->editor_view)
@@ -3696,6 +3713,22 @@ sphere_daux_vst3_embed_editor(SphereDauxVst3Processor *processor,
                static_cast<void *>(top), static_cast<void *>(content), editor_w,
                editor_h);
   return processor->editor_handle;
+#elif defined(__linux__)
+  // Host-owned model on Linux: the external plugin-host process owns a
+  // top-level GTK4/X11 window. `parent_hwnd` is only a DPI/position/owner
+  // reference cross-process — never a real parent (XEmbed across processes is
+  // exactly what host-owned mode avoids), so we ignore it and create our own
+  // top-level window via the standalone editor path (open_editor_linux), which
+  // attaches the IPlugView with a Linux::IRunLoop so the editor actually paints.
+  (void)parent_hwnd;
+  (void)x;
+  (void)y;
+  processor->editor_user_closed.store(false, std::memory_order_release);
+  std::string title_copy = processor->editor_title;
+  std::string window_id_copy = processor->editor_window_id;
+  return open_editor_linux(
+      processor, window_id_copy.c_str(),
+      title_copy.empty() ? "Plugin Editor" : title_copy.c_str(), width, height);
 #else
   (void)processor;
   (void)parent_hwnd;
@@ -3818,6 +3851,10 @@ sphere_daux_vst3_embed_detach(SphereDauxVst3Processor *processor) {
   if (!processor || !processor->embed_mode)
     return;
   processor->close_embed_editor("embed_detach");
+#elif defined(__linux__)
+  // Host-owned top-level: close the GTK window + detach the view. The audio
+  // instance stays alive (close_editor_linux only tears down the editor).
+  close_editor_linux(processor);
 #else
   (void)processor;
 #endif
@@ -3843,6 +3880,13 @@ sphere_daux_vst3_embed_attach_hwnd(SphereDauxVst3Processor *processor) {
     return reinterpret_cast<unsigned long long>(processor->editor_attach_hwnd);
   }
   return 0;
+#elif defined(__linux__)
+  // No cross-process HWND on Linux; the host-owned window lives in this
+  // process. Return the opaque editor handle so the host records a non-zero
+  // host_hwnd (its message-pump calls are no-ops on Linux).
+  if (!processor)
+    return 0;
+  return processor->editor_native_window ? processor->editor_handle : 0;
 #else
   (void)processor;
   return 0;
@@ -3856,6 +3900,8 @@ sphere_daux_vst3_embed_is_valid(SphereDauxVst3Processor *processor) {
           IsWindow(processor->editor_attach_hwnd))
              ? 1
              : 0;
+#elif defined(__linux__)
+  return (processor && processor->editor_native_window) ? 1 : 0;
 #else
   (void)processor;
   return 0;
@@ -3866,6 +3912,8 @@ extern "C" int
 sphere_daux_vst3_embed_has_visible_ui(SphereDauxVst3Processor *processor) {
 #ifdef _WIN32
   return daux_embed_has_visible_ui(processor) ? 1 : 0;
+#elif defined(__linux__)
+  return (processor && processor->editor_attached) ? 1 : 0;
 #else
   (void)processor;
   return 0;
@@ -3878,6 +3926,9 @@ sphere_daux_vst3_embed_host_kind(SphereDauxVst3Processor *processor) {
   if (!processor || !processor->embed_mode)
     return -1;
   return processor->embed_host_kind; // 0 child, 1 tool, 2 detached
+#elif defined(__linux__)
+  // Always a detached top-level window on Linux (host-owned model).
+  return (processor && processor->editor_native_window) ? 2 : -1;
 #else
   (void)processor;
   return -1;
@@ -3892,6 +3943,12 @@ sphere_daux_vst3_embed_take_user_close(SphereDauxVst3Processor *processor) {
   if (!processor)
     return 0;
   return processor->embed_user_closed.exchange(false, std::memory_order_acq_rel)
+             ? 1
+             : 0;
+#elif defined(__linux__)
+  if (!processor)
+    return 0;
+  return processor->editor_user_closed.exchange(false, std::memory_order_acq_rel)
              ? 1
              : 0;
 #else
@@ -3925,6 +3982,10 @@ sphere_daux_vst3_embed_set_instance_label(SphereDauxVst3Processor *processor,
   if (!processor)
     return;
   processor->embed_instance_label = instance_id ? instance_id : "";
+#elif defined(__linux__)
+  if (!processor)
+    return;
+  processor->editor_window_id = instance_id ? instance_id : "";
 #else
   (void)processor;
   (void)instance_id;
@@ -3938,6 +3999,10 @@ extern "C" void
 sphere_daux_vst3_set_editor_title(SphereDauxVst3Processor *processor,
                                   const char *title) {
 #ifdef _WIN32
+  if (!processor)
+    return;
+  processor->editor_title = title ? title : "";
+#elif defined(__linux__)
   if (!processor)
     return;
   processor->editor_title = title ? title : "";

--- a/crates/SphereUIComponents/src/layout/plugin_ops.rs
+++ b/crates/SphereUIComponents/src/layout/plugin_ops.rs
@@ -3771,9 +3771,20 @@ fn studio_native_hwnd(window: &Window) -> Option<u64> {
     }
 }
 
+// On Linux the external plugin host owns a top-level GTK4/X11 editor window;
+// the returned X11 window id is a read-only owner/DPI reference (never a real
+// cross-process parent). Under XWayland GPUI uses the X11 backend so this
+// resolves; on pure Wayland there is no X11 owner and VST3 X11 embedding is not
+// available, so this returns None (the caller surfaces a clear error).
 #[cfg(not(target_os = "windows"))]
-fn studio_native_hwnd(_window: &Window) -> Option<u64> {
-    None
+fn studio_native_hwnd(window: &Window) -> Option<u64> {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    let handle = HasWindowHandle::window_handle(window).ok()?;
+    match handle.as_raw() {
+        RawWindowHandle::Xcb(w) => Some(w.window.get() as u64),
+        RawWindowHandle::Xlib(w) => Some(w.window as u64),
+        _ => None,
+    }
 }
 
 /// Emit paint-instrumentation counters for a native editor shell (spec Part 6).


### PR DESCRIPTION
Linux VST3 editors never rendered: on Linux the host attached IPlugView with no IPlugFrame and, critically, no Steinberg::Linux::IRunLoop, so the plug-in's X11 fd/repaint timers were never driven (blank editor). The external plugin-host's embed_* C ABI was also Windows-only, and the Studio refused to send the open request because studio_native_hwnd() returned None on non-Windows ("host-owned editor open requires the main window handle").

- editor_linux.cpp: add LinuxRunLoopFrame (IPlugFrame + Linux::IRunLoop) bridged onto the GTK/GLib main loop; setFrame() before attached(); fix a self-deadlock where the close-request handler called close_editor_linux() (g_idle_add + wait) from the GTK thread.
- vst3_processor.cpp: implement the embed_* C ABI for Linux by delegating to the host-owned top-level GTK window (open_editor_linux); add sphere_daux_editor_signal_user_close for titlebar-close reporting.
- plugin_ops.rs: studio_native_hwnd returns the X11 XID (Xcb/Xlib) so the host-owned bridge editor open proceeds (XWayland ok; pure Wayland unsupported, surfaces a clear error).

Realtime hot path untouched; editor code runs on the host IPC/GTK threads.