### PR TITLE
fix(linux): VST3 GTK editor X11Embed + host-owned IPC for Surge XT

### DIFF
--- a/crates/SphereDirectAudioEngine/vst3bridge/include/sphere_daux_editor_bridge.h
+++ b/crates/SphereDirectAudioEngine/vst3bridge/include/sphere_daux_editor_bridge.h
@@ -33,7 +33,7 @@ void sphere_daux_editor_signal_user_close(SphereDauxVst3Processor* proc);
 /// Ask the IEditController to create a native view and query the plugin's
 /// preferred window size.
 ///
-/// platform_type  "NSView" on macOS | "XcbWindow" on Linux.
+/// platform_type  "NSView" on macOS | "X11EmbedWindowID" on Linux.
 /// out_width / out_height  updated to the plugin's preferred size when
 ///   available; left unchanged if the plugin has no preference.
 ///

--- a/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
@@ -112,10 +112,27 @@ public:
         : proc_(proc), window_(window) {}
 
     ~LinuxRunLoopFrame() {
-        // Defensive: drop any GLib sources the plug-in failed to unregister.
+        // Drop leftover GLib sources. Do NOT release handlers here: after
+        // IPlugView::removed() many plugins (JUCE / Surge XT) destroy their
+        // ITimerHandler / IEventHandler objects without unregistering, so
+        // handler->release() is a use-after-free (host SIGSEGV on editor close).
+        // Clean plugins already called unregister* and emptied regs_.
+        disarm_sources(/*release_handlers=*/false);
+    }
+
+    /// Remove every GLib fd/timer source. When `release_handlers` is false the
+    /// COM refs are abandoned (safe after removed()); when true they are
+    /// released (only safe while the plug-in still owns the handlers).
+    void disarm_sources(bool release_handlers) {
         for (auto* reg : regs_) {
-            if (reg->source_id) g_source_remove(reg->source_id);
-            if (reg->handler)   reg->handler->release();
+            if (reg->source_id) {
+                g_source_remove(reg->source_id);
+                reg->source_id = 0;
+            }
+            if (release_handlers && reg->handler) {
+                reg->handler->release();
+            }
+            reg->handler = nullptr;
             delete reg;
         }
         regs_.clear();
@@ -281,15 +298,24 @@ static void close_editor_on_gtk_thread(SphereDauxVst3Processor* proc) {
         sphere_daux_editor_get_native_embed(proc));
 
     sphere_daux_editor_clear_native(proc);       // zero first to prevent re-entrancy
-    sphere_daux_editor_set_frame(proc, nullptr); // setFrame(nullptr) before removed()
-    sphere_daux_editor_detach_view(proc);        // IPlugView::removed()
+    // Steinberg order: setFrame(nullptr) then removed(). Plug-ins that clean up
+    // unregister their IRunLoop handlers during these calls.
+    sphere_daux_editor_set_frame(proc, nullptr);
+    sphere_daux_editor_detach_view(proc);
+
+    // Disarm leftover GLib sources BEFORE destroying the GTK window / deleting
+    // the frame. Never release leftover handlers — they may already be freed
+    // inside removed() (JUCE/Surge).
+    if (frame) {
+        frame->disarm_sources(/*release_handlers=*/false);
+    }
 
     GtkWidget* window = static_cast<GtkWidget*>(win_ptr);
+    // clear_native() above makes a re-entrant close-request a no-op
+    // (get_native_window returns null), so destroy is safe from this handler.
     gtk_window_destroy(GTK_WINDOW(window));
     g_object_unref(window); // matches the g_object_ref in idle_open_editor
 
-    // Destroy the frame last — its dtor drops any leftover GLib fd/timer
-    // sources the plug-in did not unregister in removed().
     delete frame;
 
     std::fprintf(stderr, "[SphereVST3/linux] editor closed\n");

--- a/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
@@ -289,6 +289,37 @@ static void on_surface_layout(GdkSurface* /*surface*/,
 // close_editor_linux() from the close-request handler, which would g_idle_add()
 // and then block-wait on the GTK thread for an idle source that can only run
 // once the handler returns (self-deadlock). Idempotent.
+struct DestroyWindowTask {
+    GtkWidget*         window{nullptr};
+    LinuxRunLoopFrame* frame{nullptr};
+};
+
+// Idle destroy: never call gtk_window_destroy from inside close-request.
+// GTK4/GDK asserts if the surface still has an EGL native window (common when
+// a GL/XEmbed plug-in like Surge XT just detached) — flushing the main context
+// after removed() lets the plug-in drop its GL child first.
+static gboolean idle_destroy_editor_window(gpointer user_data) {
+    auto* task = static_cast<DestroyWindowTask*>(user_data);
+    // Let pending X11/unmap/GL teardown from IPlugView::removed() settle.
+    for (int i = 0; i < 8; ++i) {
+        if (!g_main_context_iteration(nullptr, FALSE)) break;
+    }
+    if (task->window) {
+        gtk_widget_set_visible(task->window, FALSE);
+        for (int i = 0; i < 4; ++i) {
+            if (!g_main_context_iteration(nullptr, FALSE)) break;
+        }
+        gtk_window_destroy(GTK_WINDOW(task->window));
+        g_object_unref(task->window); // matches g_object_ref in idle_open_editor
+        task->window = nullptr;
+    }
+    delete task->frame;
+    task->frame = nullptr;
+    delete task;
+    std::fprintf(stderr, "[SphereVST3/linux] editor closed\n");
+    return G_SOURCE_REMOVE;
+}
+
 static void close_editor_on_gtk_thread(SphereDauxVst3Processor* proc) {
     void* win_ptr = sphere_daux_editor_get_native_window(proc);
     if (!win_ptr) return;
@@ -297,28 +328,22 @@ static void close_editor_on_gtk_thread(SphereDauxVst3Processor* proc) {
     auto* frame = static_cast<LinuxRunLoopFrame*>(
         sphere_daux_editor_get_native_embed(proc));
 
-    sphere_daux_editor_clear_native(proc);       // zero first to prevent re-entrancy
+    sphere_daux_editor_clear_native(proc); // zero first to prevent re-entrancy
     // Steinberg order: setFrame(nullptr) then removed(). Plug-ins that clean up
     // unregister their IRunLoop handlers during these calls.
     sphere_daux_editor_set_frame(proc, nullptr);
     sphere_daux_editor_detach_view(proc);
 
-    // Disarm leftover GLib sources BEFORE destroying the GTK window / deleting
-    // the frame. Never release leftover handlers — they may already be freed
-    // inside removed() (JUCE/Surge).
+    // Disarm leftover GLib sources. Never release leftover handlers — they may
+    // already be freed inside removed() (JUCE/Surge).
     if (frame) {
         frame->disarm_sources(/*release_handlers=*/false);
     }
 
-    GtkWidget* window = static_cast<GtkWidget*>(win_ptr);
-    // clear_native() above makes a re-entrant close-request a no-op
-    // (get_native_window returns null), so destroy is safe from this handler.
-    gtk_window_destroy(GTK_WINDOW(window));
-    g_object_unref(window); // matches the g_object_ref in idle_open_editor
-
-    delete frame;
-
-    std::fprintf(stderr, "[SphereVST3/linux] editor closed\n");
+    // Defer GTK destroy off the close-request stack and after removed() so
+    // GDK's egl_native_window can clear (avoids gdksurface.c assertion abort).
+    auto* task = new DestroyWindowTask{static_cast<GtkWidget*>(win_ptr), frame};
+    g_idle_add(idle_destroy_editor_window, task);
 }
 
 // ── Open-task (executed on the GTK thread via g_idle_add) ─────────────────

--- a/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
@@ -1,6 +1,6 @@
 // editor_linux.cpp — GTK4 + X11 IPlugView embedding for Linux
 //
-// VST3 on Linux uses kPlatformTypeX11EmbedWindowID ("XcbWindow"):
+// VST3 on Linux uses kPlatformTypeX11EmbedWindowID ("X11EmbedWindowID"):
 // the host provides an X11 Window ID; the plugin uses the XEmbed protocol
 // to reparent its own window inside ours.
 //
@@ -15,7 +15,7 @@
 //    with a clear error message — VST3 Wayland embedding is not yet standard.
 //
 // VST3 spec reference:
-//   pluginterfaces/gui/iplugview.h — kPlatformTypeX11EmbedWindowID = "XcbWindow"
+//   pluginterfaces/gui/iplugview.h — kPlatformTypeX11EmbedWindowID = "X11EmbedWindowID"
 
 #include <condition_variable>
 #include <cstdio>
@@ -345,10 +345,18 @@ static gboolean idle_open_editor(gpointer user_data) {
     int editor_width  = task->width  > 0 ? task->width  : 820;
     int editor_height = task->height > 0 ? task->height : 560;
 
-    if (!sphere_daux_editor_create_view(proc, "XcbWindow",
+    // Official VST3 platform type string (NOT the incorrect "XcbWindow" alias
+    // some hosts historically used). Surge XT / VSTGUI / SDK editorhost all
+    // check isPlatformTypeSupported("X11EmbedWindowID").
+    // Use the literal: Steinberg::kPlatformTypeX11EmbedWindowID is a non-
+    // constexpr FIDString (= const char*) in the SDK headers.
+    const char* kLinuxPlatformType = Steinberg::kPlatformTypeX11EmbedWindowID;
+
+    if (!sphere_daux_editor_create_view(proc, kLinuxPlatformType,
                                         &editor_width, &editor_height)) {
         std::fprintf(stderr,
-                     "[SphereVST3/linux] create_view('XcbWindow') failed\n");
+                     "[SphereVST3/linux] create_view('%s') failed\n",
+                     kLinuxPlatformType);
         gtk_window_destroy(GTK_WINDOW(window));
         goto done;
     }
@@ -367,7 +375,7 @@ static gboolean idle_open_editor(gpointer user_data) {
 #endif
             sphere_daux_editor_set_error(
                 "DAUx VST3 editor: GDK backend is not X11 — "
-                "VST3 XEmbed requires an X11 display");
+                "VST3 XEmbed requires an X11 display (set GDK_BACKEND=x11)");
             std::fprintf(stderr,
                          "[SphereVST3/linux] GDK backend is not X11; "
                          "cannot obtain XID for VST3 embed\n");
@@ -382,8 +390,8 @@ static gboolean idle_open_editor(gpointer user_data) {
         // some GDK versions; gdk_x11_surface_get_xid forces it).
         Window xid = gdk_x11_surface_get_xid(surface);
         std::fprintf(stderr,
-                     "[SphereVST3/linux] X11 XID=0x%lx w=%d h=%d\n",
-                     xid, editor_width, editor_height);
+                     "[SphereVST3/linux] X11 XID=0x%lx w=%d h=%d platform=%s\n",
+                     xid, editor_width, editor_height, kLinuxPlatformType);
 
         // ── Install IPlugFrame + IRunLoop BEFORE attached() ───────────────
         // The plug-in queries the frame for Linux::IRunLoop during attached()
@@ -392,15 +400,19 @@ static gboolean idle_open_editor(gpointer user_data) {
         auto* frame = new LinuxRunLoopFrame(proc, GTK_WINDOW(window));
         sphere_daux_editor_set_frame(proc, frame);
 
+        // Map the host window before attach — Steinberg editorhost and VSTGUI
+        // XEmbed expect a mapped parent XID when the plug-in reparents.
+        gtk_window_present(GTK_WINDOW(window));
+
         // ── Attach IPlugView ──────────────────────────────────────────────
-        // kPlatformTypeX11EmbedWindowID = "XcbWindow"
-        // Pass the X11 Window ID cast to void*.
+        // Pass the X11 Window ID cast to void* (XEmbed parent).
         if (!sphere_daux_editor_attach_view(proc,
                                             reinterpret_cast<void*>(
                                                 static_cast<uintptr_t>(xid)),
-                                            "XcbWindow")) {
+                                            kLinuxPlatformType)) {
             std::fprintf(stderr,
-                         "[SphereVST3/linux] attach_view('XcbWindow') failed\n");
+                         "[SphereVST3/linux] attach_view('%s') failed\n",
+                         kLinuxPlatformType);
             sphere_daux_editor_set_frame(proc, nullptr);
             delete frame;
             gtk_window_destroy(GTK_WINDOW(window));
@@ -452,9 +464,6 @@ static gboolean idle_open_editor(gpointer user_data) {
             close_ctx,
             [](gpointer data, GClosure*) { delete static_cast<CloseCtx*>(data); },
             G_CONNECT_DEFAULT);
-
-        // ── Show the window ───────────────────────────────────────────────
-        gtk_window_present(GTK_WINDOW(window));
 
         std::fprintf(stderr,
                      "[SphereVST3/linux] editor opened handle=%llu "

--- a/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
+++ b/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
@@ -2168,12 +2168,24 @@ fn schedule_unified_editor_attach(
     eprintln!(
         "[editor-open] 06 instance_lookup ok insert_id={plugin_instance_id} plugin={display_title}"
     );
-    if !platform::is_window(parent_hwnd) {
+    // Host-owned / detached: `parent_hwnd` is only an optional owner/DPI
+    // reference for the host's own top-level window — never a SetParent target.
+    // On Linux the GTK editor ignores it entirely, so 0 (or a stale XID from a
+    // pure-Wayland GPUI surface) must not block OpenEditorWithParentHwnd →
+    // embed_editor → open_editor_linux. Legacy main-owned child embedding still
+    // requires a real parent window.
+    let detached_owner = editor_mode_prefers_async_attach(&editor_mode);
+    if !detached_owner && !platform::is_window(parent_hwnd) {
         eprintln!(
             "[editor-open] shell/parent invalid plugin={display_title} insert={plugin_instance_id} hwnd=0x{parent_hwnd:x} result=failed"
         );
         emit_attach_failed(out, plugin_instance_id, "parent_hwnd is not a valid window");
         return;
+    }
+    if detached_owner && parent_hwnd != 0 && !platform::is_window(parent_hwnd) {
+        eprintln!(
+            "[editor-open] host-owned owner_ref 0x{parent_hwnd:x} not a live window; continuing with host-owned top-level (Linux GTK / Win32 detached)"
+        );
     }
     if width < MIN_EDITOR_ATTACH_SIZE || height < MIN_EDITOR_ATTACH_SIZE {
         eprintln!(

--- a/crates/SpherePluginHost/src/plugin_host_client.rs
+++ b/crates/SpherePluginHost/src/plugin_host_client.rs
@@ -105,7 +105,60 @@ fn sanitize_child_env(command: &mut Command) {
     command.env("FUTUREBOARD_PLUGIN_EDITOR_MODE", editor_mode);
     eprintln!("[plugin-bridge] child_env_set FUTUREBOARD_PROCESS_ROLE=plugin_host");
     eprintln!("[plugin-bridge] child_env_set FUTUREBOARD_PLUGIN_EDITOR_MODE={editor_mode}");
+
+    // Linux VST3 editors need an X11/XEmbed parent (GTK4 + GDK X11 backend).
+    // The GPUI studio may run under pure Wayland (`env -u DISPLAY`), but the
+    // plugin-host child must still reach an X11 display (often the outer nested
+    // compositor's X server, or XWayland). Force GDK onto X11 and restore a
+    // DISPLAY when the parent cleared it.
+    #[cfg(target_os = "linux")]
+    {
+        configure_linux_plugin_host_display(command);
+    }
+
     eprintln!("[plugin-host-env] sanitized=true");
+}
+
+/// Ensure the Linux plugin-host child can open GTK4/X11 VST3 editors.
+#[cfg(target_os = "linux")]
+fn configure_linux_plugin_host_display(command: &mut Command) {
+    command.env("GDK_BACKEND", "x11");
+    eprintln!("[plugin-bridge] child_env_set GDK_BACKEND=x11");
+
+    // Prefer the parent's DISPLAY when present; otherwise pick the first live
+    // X11 socket under /tmp/.X11-unix (e.g. X1 → :1) so a Wayland-only GPUI
+    // process can still spawn an X11 editor host.
+    let display = std::env::var("DISPLAY").ok().filter(|d| !d.trim().is_empty());
+    let display = display.or_else(discover_x11_display);
+    match display {
+        Some(d) => {
+            command.env("DISPLAY", &d);
+            eprintln!("[plugin-bridge] child_env_set DISPLAY={d}");
+        }
+        None => {
+            eprintln!(
+                "[plugin-bridge] WARNING no DISPLAY for plugin host; VST3 X11 editors will fail"
+            );
+        }
+    }
+
+    // Keep GTK from preferring Wayland when both sockets are visible.
+    command.env_remove("WAYLAND_DISPLAY");
+    eprintln!("[plugin-bridge] child_env_remove WAYLAND_DISPLAY");
+}
+
+#[cfg(target_os = "linux")]
+fn discover_x11_display() -> Option<String> {
+    let dir = std::fs::read_dir("/tmp/.X11-unix").ok()?;
+    let mut sockets: Vec<u32> = dir
+        .filter_map(|entry| {
+            let name = entry.ok()?.file_name().into_string().ok()?;
+            let num = name.strip_prefix('X')?.parse::<u32>().ok()?;
+            Some(num)
+        })
+        .collect();
+    sockets.sort_unstable();
+    sockets.first().map(|n| format!(":{n}"))
 }
 
 fn binary_name(dir: &Path) -> PathBuf {

--- a/crates/SphereUIComponents/src/components/add_track_dialog.rs
+++ b/crates/SphereUIComponents/src/components/add_track_dialog.rs
@@ -521,15 +521,51 @@ fn instrument_plugin_options(plugins: &[RegistryPlugin]) -> Vec<SelectOption> {
         return vec![SelectOption::new("", "No Instrument")
             .description("Open Plugin Manager to scan instruments")];
     }
-    let mut options = vec![SelectOption::new("", "No Instrument")];
-    options.extend(plugins.iter().map(|plugin| {
-        let vendor = plugin.vendor.trim();
-        let description = if vendor.is_empty() {
-            plugin_format_label(plugin.format).to_string()
-        } else {
-            format!("{} / {}", vendor, plugin_format_label(plugin.format))
+    // Prefer VST3 when the same instrument ships as CLAP/LV2 too — native
+    // host-owned editors are VST3-only today, and identical display names made
+    // the dropdown pick CLAP first during Surge XT testing.
+    let mut sorted: Vec<&RegistryPlugin> = plugins.iter().collect();
+    sorted.sort_by(|a, b| {
+        let fmt_rank = |f: PluginFormat| match f {
+            PluginFormat::Vst3 => 0u8,
+            PluginFormat::Clap => 1,
+            PluginFormat::Au => 2,
+            PluginFormat::Lv2 => 3,
+            PluginFormat::Unknown => 4,
         };
-        SelectOption::new(plugin.id.clone(), plugin.name.clone()).description(description)
+        a.name
+            .to_ascii_lowercase()
+            .cmp(&b.name.to_ascii_lowercase())
+            .then_with(|| fmt_rank(a.format).cmp(&fmt_rank(b.format)))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    let mut name_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for plugin in &sorted {
+        *name_counts
+            .entry(plugin.name.to_ascii_lowercase())
+            .or_default() += 1;
+    }
+    let mut options = vec![SelectOption::new("", "No Instrument")];
+    options.extend(sorted.into_iter().map(|plugin| {
+        let vendor = plugin.vendor.trim();
+        let fmt = plugin_format_label(plugin.format);
+        let description = if vendor.is_empty() {
+            fmt.to_string()
+        } else {
+            format!("{vendor} / {fmt}")
+        };
+        let label = if name_counts
+            .get(&plugin.name.to_ascii_lowercase())
+            .copied()
+            .unwrap_or(0)
+            > 1
+        {
+            format!("{} ({fmt})", plugin.name)
+        } else {
+            plugin.name.clone()
+        };
+        SelectOption::new(plugin.id.clone(), label).description(description)
     }));
     options
 }

--- a/crates/SphereUIComponents/src/layout/plugin_ops.rs
+++ b/crates/SphereUIComponents/src/layout/plugin_ops.rs
@@ -993,28 +993,29 @@ impl StudioLayout {
             // GetWindowRect / GetDpiForWindow are non-blocking cross-process
             // queries) — never a parent, so no input-queue coupling. One
             // non-blocking IPC frame; the host replies EditorAttached async.
+            //
+            // On Linux the host opens a top-level GTK/X11 editor and ignores
+            // parent_hwnd as a real parent. Allow owner_ref=0 when the GPUI
+            // window has no X11 handle (pure Wayland) so IPC still reaches the
+            // host; the GTK path reports a clear error if X11 is unavailable.
             let dpi = shell.shell_dpi();
-            match owner_hwnd {
-                Some(parent) => {
-                    eprintln!(
-                        "[plugin-bridge] sending OpenEditorWithParentHwnd (host-owned) instance={instance_id} owner_ref=0x{parent:x} size={content_w}x{content_h} dpi={dpi}"
-                    );
-                    runtime
-                        .lock()
-                        .map_err(|_| "bridge runtime lock poisoned".to_string())
-                        .and_then(|mut r| {
-                            r.open_editor_with_parent(
-                                instance_id.to_string(),
-                                parent,
-                                content_w as u32,
-                                content_h as u32,
-                                dpi,
-                            )
-                            .map_err(|e| e.to_string())
-                        })
-                }
-                None => Err("host-owned editor open requires the main window handle".to_string()),
-            }
+            let parent = owner_hwnd.unwrap_or(0);
+            eprintln!(
+                "[plugin-bridge] sending OpenEditorWithParentHwnd (host-owned) instance={instance_id} owner_ref=0x{parent:x} size={content_w}x{content_h} dpi={dpi}"
+            );
+            runtime
+                .lock()
+                .map_err(|_| "bridge runtime lock poisoned".to_string())
+                .and_then(|mut r| {
+                    r.open_editor_with_parent(
+                        instance_id.to_string(),
+                        parent,
+                        content_w as u32,
+                        content_h as u32,
+                        dpi,
+                    )
+                    .map_err(|e| e.to_string())
+                })
         } else {
             eprintln!(
                 "[plugin-bridge] sending PrepareEditorView instance={instance_id} shell_content=0x{content_hwnd:x} size={cw}x{ch}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Linux VST3 editors (GTK host-owned window → Rust IPC) failed for real plugins like Surge XT: wrong platform type, host-owned open gated on an X11 owner handle, and editor close crashed the plugin host (blocking reopen).

### Fixes
- Use official VST3 `kPlatformTypeX11EmbedWindowID` (`"X11EmbedWindowID"`) instead of `"XcbWindow"` (Surge/VSTGUI reject the old string).
- Map the GTK window before `IPlugView::attached()`.
- Allow host-owned `OpenEditorWithParentHwnd` with `owner_ref=0` when GPUI has no X11 handle.
- Skip detached-mode `parent_hwnd` validity rejection (Linux GTK ignores it as a parent).
- Spawn plugin host with `GDK_BACKEND=x11`, restore `DISPLAY` from `/tmp/.X11-unix` if cleared, drop `WAYLAND_DISPLAY`.
- Close path: do not `release()` leftover IRunLoop handlers after `removed()` (JUCE/Surge UAF); defer `gtk_window_destroy` to a GLib idle after flushing so GDK does not abort on `egl_native_window`.
- Add Track: label duplicate instruments as `Name (VST3)` / `Name (CLAP)` and sort VST3 first.

### Validation (manual, this VM)
- Surge XT 1.3.4 `.deb` installed
- Built `futureboard_native` + `FutureboardPluginHostX64`
- Audio → Audio Plug-in Manager → Scan → Surge XT found
- Instrument Track → **Surge XT (VST3)** → editor opened and painted
- Close via window menu → host stayed alive (`Sl+`, not zombie)
- Inspector Open → editor reopened and painted
- Logs: `platform=X11EmbedWindowID`, `attached` ok, `GDK_BACKEND=x11`, no `egl_native_window` / `Aborted`

[Surge XT VST3 editor open](https://cursor.com/agents/bc-0156cc59-188d-4a1a-a4a4-d95ab1926e02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsurge-open.png)
[Surge XT VST3 editor reopen after close](https://cursor.com/agents/bc-0156cc59-188d-4a1a-a4a4-d95ab1926e02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsurge-reopen.png)
[Inspector Format VST3](https://cursor.com/agents/bc-0156cc59-188d-4a1a-a4a4-d95ab1926e02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsurge-xt-inspector-vst3.png)

### Notes
- Realtime hot path untouched
- CLAP editors remain out of scope (bridge editor path is VST3-only)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0156cc59-188d-4a1a-a4a4-d95ab1926e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0156cc59-188d-4a1a-a4a4-d95ab1926e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

