### PR TITLE
feat(stem): MDX-NET Stem Extractor dialog + Audio Processor surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "SphereFBStemExtractor"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "SphereMidiService"
 version = "0.1.0"
 dependencies = [
@@ -6947,6 +6956,7 @@ dependencies = [
 name = "sphere-audio-processor"
 version = "0.1.0"
 dependencies = [
+ "SphereFBStemExtractor",
  "cc",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/SpherePackageInstaller",
     "apps/native/apakinstaller",
     "crates/SphereAudioProcessor",
+    "crates/SphereStemExtractor",
     "crates/SphereMidiService",
     "crates/SphereDiscordRPC",
     "crates/SpherePlatform",
@@ -53,7 +54,6 @@ exclude = [
     "crates/SphereMediaUtils",
     "crates/SphereNoiseRemover",
     "crates/SphereSettings",
-    "crates/SphereStemExtractor",
     "crates/SphereVoiceTune",
 ]
 
@@ -73,6 +73,7 @@ publish = false
 sphere_ui_components = { path = "crates/SphereUIComponents", default-features = false }
 sphere_directaudioengine = { path = "crates/SphereDirectAudioEngine", default-features = false }
 sphere-audio-processor = { path = "crates/SphereAudioProcessor" }
+sphere-stem-extractor = { path = "crates/SphereStemExtractor", package = "SphereFBStemExtractor" }
 sphere-audio-editor = { path = "crates/SphereAudioEditor" }
 sphere-audio-plugins = { path = "crates/SphereAudioPlugins" }
 sphere-encoder = { path = "crates/SphereEncoder" }

--- a/crates/SphereAudioProcessor/Cargo.toml
+++ b/crates/SphereAudioProcessor/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["rlib", "cdylib"]
 serde.workspace = true
 thiserror.workspace = true
 log.workspace = true
+sphere-stem-extractor.workspace = true
 
 [build-dependencies]
 cc.workspace = true

--- a/crates/SphereAudioProcessor/src/lib.rs
+++ b/crates/SphereAudioProcessor/src/lib.rs
@@ -3,10 +3,21 @@
 //! This crate owns shared, serializable stretch parameters and pure ratio /
 //! backend-selection math so UI, playback, export, waveform cache, and timeline
 //! length can converge on one source of truth.
+//!
+//! It also re-exports the offline MDX-NET stem-extraction params/model/device
+//! surface from `SphereStemExtractor` for the Stem Extractor dialog and jobs.
 
 pub mod ffi;
+pub mod stem;
 pub mod stretching;
 
+pub use stem::{
+    create_mdx_net_backend, default_stem_extract_params, extract_stems, gpu_available,
+    mdx_net_gpu_params, resolve_device, InferBackendKind, InferDevice, StemExtractCancelToken,
+    StemExtractError, StemExtractInput, StemExtractOutput, StemExtractParams, StemExtractProgress,
+    StemExtractQuality, StemExtractResult, StemExtractStage, StemInferBackend, StemKind, StemModel,
+    StemModelInfo, StemSet, STEM_MODELS,
+};
 pub use stretching::{
     StretchAlgorithm, StretchBackend, StretchError, StretchMode, StretchParams, StretchProcessor,
     create_stretch_processor, effective_pitch_ratio, effective_time_ratio,

--- a/crates/SphereAudioProcessor/src/stem/mod.rs
+++ b/crates/SphereAudioProcessor/src/stem/mod.rs
@@ -1,0 +1,53 @@
+//! Stem extraction surface for SphereAudioProcessor.
+//!
+//! Re-exports the MDX-NET offline stem API from `SphereStemExtractor` so UI,
+//! export, and future engine tooling share one params/model/device contract.
+//!
+//! Classification: offline / control path only — never call from the realtime
+//! audio callback.
+
+pub use sphere_stem_extractor::{
+    create_mdx_net_backend, extract_stems, gpu_available, resolve_device, InferBackendKind,
+    InferDevice, StemExtractCancelToken, StemExtractError, StemExtractInput, StemExtractOutput,
+    StemExtractParams, StemExtractProgress, StemExtractQuality, StemExtractResult, StemExtractStage,
+    StemInferBackend, StemKind, StemModel, StemModelInfo, StemSet, STEM_MODELS,
+};
+
+/// Convenience constructor matching the Stem Extractor dialog defaults:
+/// MDX-NET · CPU · all 4 stems · balanced quality · CPU fallback enabled.
+pub fn default_stem_extract_params() -> StemExtractParams {
+    StemExtractParams::mdx_net_cpu()
+}
+
+/// Convenience constructor for MDX-NET on GPU (falls back to CPU when allowed).
+pub fn mdx_net_gpu_params() -> StemExtractParams {
+    StemExtractParams::mdx_net_gpu()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_use_mdx_net_cpu() {
+        let params = default_stem_extract_params();
+        assert_eq!(params.model, StemModel::MdxNet);
+        assert_eq!(params.device, InferDevice::Cpu);
+        assert_eq!(params.stems.len(), 4);
+        params.validate().unwrap();
+    }
+
+    #[test]
+    fn extract_via_audio_processor_surface() {
+        let input = StemExtractInput::new(44_100, 1, vec![0.25; 1024]);
+        let result = extract_stems(
+            &input,
+            &default_stem_extract_params(),
+            &StemExtractCancelToken::new(),
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(result.stems.len(), 4);
+        assert_eq!(result.model, StemModel::MdxNet);
+    }
+}

--- a/crates/SphereDirectAudioEngine/src/lib.rs
+++ b/crates/SphereDirectAudioEngine/src/lib.rs
@@ -56,9 +56,9 @@ pub mod vst3_processor;
 // without reaching into the NAPI-flavored modules. Both this facade and
 // the `SphereDirectAudioEngine` NAPI class wrap the same `EngineInner`.
 pub use crate::audio_file::{
-    generate_audio_peaks, probe_audio_file, AudioFileFormat, AudioFileInfo, AudioPeak,
-    AudioPeakFile, AudioPeakLod, MAX_IN_MEMORY_DECODE_BYTES, PEAK_LOD_LEVELS,
-    STREAMING_WAV_THRESHOLD_BYTES,
+    generate_audio_peaks, load_audio_file, probe_audio_file, AudioFileBuffer, AudioFileFormat,
+    AudioFileInfo, AudioPeak, AudioPeakFile, AudioPeakLod, MAX_IN_MEMORY_DECODE_BYTES,
+    PEAK_LOD_LEVELS, STREAMING_WAV_THRESHOLD_BYTES,
 };
 pub use crate::audio_graph::{
     plan_runtime_audio_graph, AudioGraphNode, AudioGraphNodeKind, GraphRouteIssue, GraphRouteKind,

--- a/crates/SphereStemExtractor/Cargo.toml
+++ b/crates/SphereStemExtractor/Cargo.toml
@@ -3,5 +3,19 @@ name = "SphereFBStemExtractor"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+description = "Offline MDX-NET stem extraction API for Futureboard Studio"
+publish.workspace = true
+
+[lib]
+name = "SphereStemExtractor"
+path = "src/lib.rs"
 
 [dependencies]
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/SphereStemExtractor/src/backend/mod.rs
+++ b/crates/SphereStemExtractor/src/backend/mod.rs
@@ -1,0 +1,65 @@
+mod spectral_stub;
+
+use crate::device::InferDevice;
+use crate::error::StemExtractError;
+use crate::model::StemModel;
+use crate::params::StemExtractParams;
+use crate::progress::{StemExtractCancelToken, StemExtractProgress};
+use crate::stems::StemKind;
+
+pub use spectral_stub::SpectralStubBackend;
+
+/// Which concrete inference backend will run the job.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InferBackendKind {
+    /// Deterministic offline spectral split used until ONNX MDX-NET weights land.
+    SpectralStub,
+}
+
+impl InferBackendKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SpectralStub => "spectral-stub",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::SpectralStub => "MDX-NET spectral stub",
+        }
+    }
+}
+
+/// One separated stem buffer (interleaved f32, same layout as the input).
+#[derive(Clone, Debug)]
+pub struct SeparatedStem {
+    pub kind: StemKind,
+    pub samples: Vec<f32>,
+}
+
+pub trait StemInferBackend: Send {
+    fn kind(&self) -> InferBackendKind;
+    fn model(&self) -> StemModel;
+    fn device(&self) -> InferDevice;
+
+    fn separate(
+        &self,
+        interleaved: &[f32],
+        channels: usize,
+        sample_rate: u32,
+        params: &StemExtractParams,
+        cancel: &StemExtractCancelToken,
+        on_progress: &mut dyn FnMut(StemExtractProgress),
+    ) -> Result<Vec<SeparatedStem>, StemExtractError>;
+}
+
+/// Build the MDX-NET backend for the resolved device.
+///
+/// Today this always returns the spectral stub. When ONNX weights are present
+/// this factory will select the real MDX-NET runtime for CPU/GPU.
+pub fn create_mdx_net_backend(
+    model: StemModel,
+    device: InferDevice,
+) -> Result<Box<dyn StemInferBackend>, StemExtractError> {
+    Ok(Box::new(SpectralStubBackend::new(model, device)))
+}

--- a/crates/SphereStemExtractor/src/backend/spectral_stub.rs
+++ b/crates/SphereStemExtractor/src/backend/spectral_stub.rs
@@ -1,0 +1,231 @@
+//! Deterministic spectral / mid-side stem split.
+//!
+//! This is an offline, allocation-friendly approximation used to exercise the
+//! Stem Extractor UI and Audio Processor surface until real MDX-NET ONNX
+//! weights are wired. It is **not** claimed to be MDX-NET quality.
+
+use super::{InferBackendKind, SeparatedStem, StemInferBackend};
+use crate::device::InferDevice;
+use crate::error::StemExtractError;
+use crate::model::StemModel;
+use crate::params::StemExtractParams;
+use crate::progress::{StemExtractCancelToken, StemExtractProgress, StemExtractStage};
+use crate::stems::StemKind;
+
+pub struct SpectralStubBackend {
+    model: StemModel,
+    device: InferDevice,
+}
+
+impl SpectralStubBackend {
+    pub fn new(model: StemModel, device: InferDevice) -> Self {
+        Self { model, device }
+    }
+}
+
+impl StemInferBackend for SpectralStubBackend {
+    fn kind(&self) -> InferBackendKind {
+        InferBackendKind::SpectralStub
+    }
+
+    fn model(&self) -> StemModel {
+        self.model
+    }
+
+    fn device(&self) -> InferDevice {
+        self.device
+    }
+
+    fn separate(
+        &self,
+        interleaved: &[f32],
+        channels: usize,
+        _sample_rate: u32,
+        params: &StemExtractParams,
+        cancel: &StemExtractCancelToken,
+        on_progress: &mut dyn FnMut(StemExtractProgress),
+    ) -> Result<Vec<SeparatedStem>, StemExtractError> {
+        if channels == 0 || channels > 2 {
+            return Err(StemExtractError::UnsupportedChannels(channels));
+        }
+        if interleaved.is_empty() {
+            return Err(StemExtractError::EmptyInput);
+        }
+
+        on_progress(StemExtractProgress::new(
+            StemExtractStage::LoadingModel,
+            5.0,
+            format!(
+                "Preparing {} on {}",
+                self.model.label(),
+                self.device.label()
+            ),
+        ));
+        if cancel.is_cancelled() {
+            return Err(StemExtractError::Cancelled);
+        }
+
+        let frames = interleaved.len() / channels;
+        let selected: Vec<StemKind> = params.stems.iter().collect();
+        let total = selected.len().max(1);
+        let mut outputs = Vec::with_capacity(selected.len());
+
+        for (index, stem) in selected.into_iter().enumerate() {
+            if cancel.is_cancelled() {
+                return Err(StemExtractError::Cancelled);
+            }
+            let percent = 10.0 + (index as f32 / total as f32) * 80.0;
+            on_progress(
+                StemExtractProgress::new(
+                    StemExtractStage::Separating,
+                    percent,
+                    format!("Separating {}", stem.label()),
+                )
+                .with_stem(stem),
+            );
+
+            let samples = match stem {
+                StemKind::Vocals => mid_channel(interleaved, channels, frames, 1.0, 0.15),
+                StemKind::Instrumental => side_channel(interleaved, channels, frames, 0.85),
+                StemKind::Drums => band_emphasis(interleaved, channels, frames, 0.55, 0.35),
+                StemKind::Bass => low_emphasis(interleaved, channels, frames),
+                StemKind::Other => residual_other(interleaved, channels, frames),
+            };
+            outputs.push(SeparatedStem { kind: stem, samples });
+        }
+
+        on_progress(StemExtractProgress::new(
+            StemExtractStage::Separating,
+            95.0,
+            "Separation complete",
+        ));
+        Ok(outputs)
+    }
+}
+
+fn sample_at(interleaved: &[f32], channels: usize, frame: usize, ch: usize) -> f32 {
+    interleaved[frame * channels + ch.min(channels - 1)]
+}
+
+fn mid_channel(
+    interleaved: &[f32],
+    channels: usize,
+    frames: usize,
+    mid_gain: f32,
+    side_leak: f32,
+) -> Vec<f32> {
+    let mut out = vec![0.0; frames * channels];
+    for frame in 0..frames {
+        let l = sample_at(interleaved, channels, frame, 0);
+        let r = sample_at(interleaved, channels, frame, 1);
+        let mid = 0.5 * (l + r) * mid_gain;
+        let side = 0.5 * (l - r) * side_leak;
+        let left = (mid + side).clamp(-1.0, 1.0);
+        let right = (mid - side).clamp(-1.0, 1.0);
+        out[frame * channels] = left;
+        if channels > 1 {
+            out[frame * channels + 1] = right;
+        }
+    }
+    out
+}
+
+fn side_channel(interleaved: &[f32], channels: usize, frames: usize, gain: f32) -> Vec<f32> {
+    let mut out = vec![0.0; frames * channels];
+    for frame in 0..frames {
+        let l = sample_at(interleaved, channels, frame, 0);
+        let r = sample_at(interleaved, channels, frame, 1);
+        let mid = 0.5 * (l + r);
+        let side = 0.5 * (l - r);
+        // Instrumental ≈ original minus center vocal emphasis.
+        let left = ((l - mid * 0.65) + side * 0.25) * gain;
+        let right = ((r - mid * 0.65) - side * 0.25) * gain;
+        out[frame * channels] = left.clamp(-1.0, 1.0);
+        if channels > 1 {
+            out[frame * channels + 1] = right.clamp(-1.0, 1.0);
+        }
+    }
+    out
+}
+
+fn band_emphasis(
+    interleaved: &[f32],
+    channels: usize,
+    frames: usize,
+    high: f32,
+    low: f32,
+) -> Vec<f32> {
+    let mut out = vec![0.0; frames * channels];
+    let mut prev = [0.0_f32; 2];
+    for frame in 0..frames {
+        for ch in 0..channels {
+            let x = sample_at(interleaved, channels, frame, ch);
+            let hp = x - prev[ch];
+            prev[ch] = x;
+            let y = (hp * high + x * low).clamp(-1.0, 1.0);
+            out[frame * channels + ch] = y;
+        }
+    }
+    out
+}
+
+fn low_emphasis(interleaved: &[f32], channels: usize, frames: usize) -> Vec<f32> {
+    let mut out = vec![0.0; frames * channels];
+    let mut state = [0.0_f32; 2];
+    let alpha = 0.05_f32;
+    for frame in 0..frames {
+        for ch in 0..channels {
+            let x = sample_at(interleaved, channels, frame, ch);
+            state[ch] += alpha * (x - state[ch]);
+            out[frame * channels + ch] = (state[ch] * 1.35).clamp(-1.0, 1.0);
+        }
+    }
+    out
+}
+
+fn residual_other(interleaved: &[f32], channels: usize, frames: usize) -> Vec<f32> {
+    // Mild high-shelf residual so "other" is distinct from vocals/drums/bass.
+    let mut out = vec![0.0; frames * channels];
+    let mut prev = [0.0_f32; 2];
+    for frame in 0..frames {
+        for ch in 0..channels {
+            let x = sample_at(interleaved, channels, frame, ch);
+            let hp = x - prev[ch];
+            prev[ch] = x;
+            out[frame * channels + ch] = (x * 0.45 + hp * 0.35).clamp(-1.0, 1.0);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::params::StemExtractParams;
+    use crate::stems::StemSet;
+
+    #[test]
+    fn stub_produces_requested_mdx_net_stems() {
+        let backend = SpectralStubBackend::new(StemModel::MdxNet, InferDevice::Cpu);
+        let mut params = StemExtractParams::mdx_net_cpu();
+        params.stems = StemSet::new([StemKind::Vocals, StemKind::Bass]);
+        let input = vec![0.2_f32, -0.1, 0.3, -0.2, 0.0, 0.1, -0.05, 0.05];
+        let mut last_pct = 0.0;
+        let stems = backend
+            .separate(
+                &input,
+                2,
+                48_000,
+                &params,
+                &StemExtractCancelToken::new(),
+                &mut |p| {
+                    assert!(p.percent >= last_pct);
+                    last_pct = p.percent;
+                },
+            )
+            .unwrap();
+        assert_eq!(stems.len(), 2);
+        assert_eq!(stems[0].samples.len(), input.len());
+        assert_eq!(stems[1].samples.len(), input.len());
+    }
+}

--- a/crates/SphereStemExtractor/src/device.rs
+++ b/crates/SphereStemExtractor/src/device.rs
@@ -1,0 +1,104 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::StemExtractError;
+
+/// Inference device for MDX-NET stem extraction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum InferDevice {
+    #[default]
+    Cpu,
+    Gpu,
+}
+
+impl InferDevice {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cpu => "cpu",
+            Self::Gpu => "gpu",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Cpu => "CPU",
+            Self::Gpu => "GPU",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "cpu" | "CPU" => Some(Self::Cpu),
+            "gpu" | "GPU" | "cuda" | "directml" | "metal" => Some(Self::Gpu),
+            _ => None,
+        }
+    }
+}
+
+/// Best-effort GPU availability probe for the Stem Extractor dialog.
+///
+/// Returns true when a known accelerator hint is present. Absence does not
+/// prove a GPU cannot work after the ONNX/DirectML/CUDA runtime is installed;
+/// the UI still offers GPU and falls back with a clear error when unavailable.
+pub fn gpu_available() -> bool {
+    if std::env::var_os("FUTUREBOARD_STEM_FORCE_GPU").is_some() {
+        return true;
+    }
+    if std::env::var_os("FUTUREBOARD_STEM_FORCE_NO_GPU").is_some() {
+        return false;
+    }
+    // Lightweight hints only — no CUDA/DirectML library load on the UI path.
+    std::path::Path::new("/dev/nvidia0").exists()
+        || std::path::Path::new("/dev/dxg").exists()
+        || std::env::var_os("CUDA_PATH").is_some()
+        || std::env::var_os("CUDA_VISIBLE_DEVICES").is_some_and(|v| !v.is_empty())
+}
+
+/// Resolve the requested device, optionally falling back to CPU when GPU is
+/// unavailable and `allow_cpu_fallback` is true.
+pub fn resolve_device(
+    requested: InferDevice,
+    allow_cpu_fallback: bool,
+) -> Result<InferDevice, StemExtractError> {
+    match requested {
+        InferDevice::Cpu => Ok(InferDevice::Cpu),
+        InferDevice::Gpu if gpu_available() => Ok(InferDevice::Gpu),
+        InferDevice::Gpu if allow_cpu_fallback => Ok(InferDevice::Cpu),
+        InferDevice::Gpu => Err(StemExtractError::DeviceUnavailable {
+            device: InferDevice::Gpu,
+            reason: "no GPU accelerator was detected for MDX-NET inference".into(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_always_resolves() {
+        assert_eq!(
+            resolve_device(InferDevice::Cpu, false).unwrap(),
+            InferDevice::Cpu
+        );
+    }
+
+    #[test]
+    fn gpu_falls_back_when_allowed() {
+        // Isolate from host GPU hints for a deterministic assertion.
+        // SAFETY: test-only env mutation; this suite runs single-threaded here.
+        unsafe {
+            std::env::set_var("FUTUREBOARD_STEM_FORCE_NO_GPU", "1");
+            std::env::remove_var("FUTUREBOARD_STEM_FORCE_GPU");
+        }
+        assert_eq!(
+            resolve_device(InferDevice::Gpu, true).unwrap(),
+            InferDevice::Cpu
+        );
+        let err = resolve_device(InferDevice::Gpu, false).unwrap_err();
+        assert!(matches!(err, StemExtractError::DeviceUnavailable { .. }));
+        unsafe {
+            std::env::remove_var("FUTUREBOARD_STEM_FORCE_NO_GPU");
+        }
+    }
+}

--- a/crates/SphereStemExtractor/src/error.rs
+++ b/crates/SphereStemExtractor/src/error.rs
@@ -1,0 +1,38 @@
+use thiserror::Error;
+
+use crate::device::InferDevice;
+use crate::model::StemModel;
+use crate::stems::StemKind;
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum StemExtractError {
+    #[error("no input audio frames were provided")]
+    EmptyInput,
+
+    #[error("channel count must be 1 or 2 (got {0})")]
+    UnsupportedChannels(usize),
+
+    #[error("sample rate must be non-zero")]
+    InvalidSampleRate,
+
+    #[error("no output stems were selected")]
+    NoStemsSelected,
+
+    #[error("stem `{}` is not produced by model {}", stem.label(), model.label())]
+    StemNotSupported { model: StemModel, stem: StemKind },
+
+    #[error("device {} unavailable: {reason}", device.label())]
+    DeviceUnavailable { device: InferDevice, reason: String },
+
+    #[error("extraction cancelled")]
+    Cancelled,
+
+    #[error("{0}")]
+    Backend(String),
+}
+
+impl StemExtractError {
+    pub fn user_message(&self) -> String {
+        self.to_string()
+    }
+}

--- a/crates/SphereStemExtractor/src/extractor.rs
+++ b/crates/SphereStemExtractor/src/extractor.rs
@@ -1,0 +1,153 @@
+use crate::backend::{create_mdx_net_backend, InferBackendKind, SeparatedStem};
+use crate::device::resolve_device;
+use crate::error::StemExtractError;
+use crate::params::StemExtractParams;
+use crate::progress::{StemExtractCancelToken, StemExtractProgress, StemExtractStage};
+use crate::stems::StemKind;
+
+/// Interleaved PCM input for offline stem extraction.
+#[derive(Clone, Debug)]
+pub struct StemExtractInput {
+    pub sample_rate: u32,
+    pub channels: usize,
+    pub samples: Vec<f32>,
+}
+
+impl StemExtractInput {
+    pub fn new(sample_rate: u32, channels: usize, samples: Vec<f32>) -> Self {
+        Self {
+            sample_rate,
+            channels,
+            samples,
+        }
+    }
+
+    pub fn frames(&self) -> usize {
+        self.samples
+            .len()
+            .checked_div(self.channels)
+            .unwrap_or(0)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct StemExtractOutput {
+    pub kind: StemKind,
+    pub sample_rate: u32,
+    pub channels: usize,
+    pub samples: Vec<f32>,
+}
+
+#[derive(Clone, Debug)]
+pub struct StemExtractResult {
+    pub model: crate::model::StemModel,
+    pub device: crate::device::InferDevice,
+    pub backend: InferBackendKind,
+    pub stems: Vec<StemExtractOutput>,
+}
+
+/// Run offline stem extraction on interleaved PCM.
+///
+/// Safe for worker threads only — never call from the realtime audio callback.
+pub fn extract_stems(
+    input: &StemExtractInput,
+    params: &StemExtractParams,
+    cancel: &StemExtractCancelToken,
+    mut on_progress: impl FnMut(StemExtractProgress),
+) -> Result<StemExtractResult, StemExtractError> {
+    params.validate()?;
+    if input.sample_rate == 0 {
+        return Err(StemExtractError::InvalidSampleRate);
+    }
+    if input.channels == 0 || input.channels > 2 {
+        return Err(StemExtractError::UnsupportedChannels(input.channels));
+    }
+    if input.samples.is_empty() || input.frames() == 0 {
+        return Err(StemExtractError::EmptyInput);
+    }
+    if cancel.is_cancelled() {
+        return Err(StemExtractError::Cancelled);
+    }
+
+    on_progress(StemExtractProgress::new(
+        StemExtractStage::Preparing,
+        1.0,
+        format!(
+            "Preparing {} ({})",
+            params.model.label(),
+            params.device.label()
+        ),
+    ));
+
+    let device = resolve_device(params.device, params.allow_cpu_fallback)?;
+    let mut effective = params.clone();
+    effective.device = device;
+
+    let backend = create_mdx_net_backend(effective.model, device)?;
+    let separated = backend.separate(
+        &input.samples,
+        input.channels,
+        input.sample_rate,
+        &effective,
+        cancel,
+        &mut on_progress,
+    )?;
+
+    if cancel.is_cancelled() {
+        return Err(StemExtractError::Cancelled);
+    }
+
+    on_progress(StemExtractProgress::new(
+        StemExtractStage::Complete,
+        100.0,
+        format!("Extracted {} stem(s)", separated.len()),
+    ));
+
+    Ok(StemExtractResult {
+        model: effective.model,
+        device,
+        backend: backend.kind(),
+        stems: separated
+            .into_iter()
+            .map(|SeparatedStem { kind, samples }| StemExtractOutput {
+                kind,
+                sample_rate: input.sample_rate,
+                channels: input.channels,
+                samples,
+            })
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::InferDevice;
+    use crate::model::StemModel;
+    use crate::params::StemExtractParams;
+
+    #[test]
+    fn extract_mdx_net_cpu_returns_four_stems() {
+        let input = StemExtractInput::new(48_000, 2, vec![0.1; 48_000 * 2]);
+        let params = StemExtractParams::mdx_net_cpu();
+        let result = extract_stems(&input, &params, &StemExtractCancelToken::new(), |_| {}).unwrap();
+        assert_eq!(result.model, StemModel::MdxNet);
+        assert_eq!(result.device, InferDevice::Cpu);
+        assert_eq!(result.stems.len(), 4);
+    }
+
+    #[test]
+    fn cancel_before_start_errors() {
+        let input = StemExtractInput::new(48_000, 1, vec![0.1; 128]);
+        let cancel = StemExtractCancelToken::new();
+        cancel.cancel();
+        let err = extract_stems(
+            &input,
+            &StemExtractParams::default(),
+            &cancel,
+            |_| {},
+        )
+        .unwrap_err();
+        assert_eq!(err, StemExtractError::Cancelled);
+    }
+}

--- a/crates/SphereStemExtractor/src/lib.rs
+++ b/crates/SphereStemExtractor/src/lib.rs
@@ -1,0 +1,30 @@
+//! Offline stem extraction for Futureboard Studio.
+//!
+//! This crate owns the MDX-NET model catalog, CPU/GPU device selection, stem
+//! slot selection, and a buffer-in / stems-out extraction API. It does **not**
+//! perform filesystem I/O or touch the realtime audio callback.
+//!
+//! Classification: scanner/offline path (worker thread only).
+//!
+//! The current default backend is a deterministic spectral stub used to wire
+//! the UI/job pipeline until ONNX MDX-NET weights are installed. Real MDX-NET
+//! inference will replace [`backend::SpectralStubBackend`] without changing the
+//! public params surface.
+
+pub mod backend;
+pub mod device;
+pub mod error;
+pub mod extractor;
+pub mod model;
+pub mod params;
+pub mod progress;
+pub mod stems;
+
+pub use backend::{create_mdx_net_backend, InferBackendKind, StemInferBackend};
+pub use device::{gpu_available, resolve_device, InferDevice};
+pub use error::StemExtractError;
+pub use extractor::{extract_stems, StemExtractInput, StemExtractOutput, StemExtractResult};
+pub use model::{StemModel, StemModelInfo, STEM_MODELS};
+pub use params::{StemExtractParams, StemExtractQuality};
+pub use progress::{StemExtractCancelToken, StemExtractProgress, StemExtractStage};
+pub use stems::{StemKind, StemSet};

--- a/crates/SphereStemExtractor/src/main.rs
+++ b/crates/SphereStemExtractor/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/crates/SphereStemExtractor/src/model.rs
+++ b/crates/SphereStemExtractor/src/model.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+
+use crate::stems::StemKind;
+
+/// Offline source-separation model identifiers exposed in the Stem Extractor UI.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum StemModel {
+    /// Classic MDX-NET 4-stem separator (vocals / drums / bass / other).
+    #[default]
+    MdxNet,
+    /// MDX-NET karaoke variant (vocals + instrumental).
+    MdxNetKaraoke,
+}
+
+impl StemModel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::MdxNet => "mdx-net",
+            Self::MdxNetKaraoke => "mdx-net-karaoke",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::MdxNet => "MDX-NET",
+            Self::MdxNetKaraoke => "MDX-NET Karaoke",
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::MdxNet => "4-stem separation: vocals, drums, bass, other",
+            Self::MdxNetKaraoke => "2-stem separation: vocals and instrumental",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "mdx-net" | "mdxnet" | "MDX-NET" => Some(Self::MdxNet),
+            "mdx-net-karaoke" | "mdxnet-karaoke" | "MDX-NET Karaoke" => Some(Self::MdxNetKaraoke),
+            _ => None,
+        }
+    }
+
+    pub fn default_stems(self) -> &'static [StemKind] {
+        match self {
+            Self::MdxNet => &[
+                StemKind::Vocals,
+                StemKind::Drums,
+                StemKind::Bass,
+                StemKind::Other,
+            ],
+            Self::MdxNetKaraoke => &[StemKind::Vocals, StemKind::Instrumental],
+        }
+    }
+
+    pub fn supports_stem(self, stem: StemKind) -> bool {
+        self.default_stems().contains(&stem)
+    }
+}
+
+/// Static catalog entry for the Stem Extractor model dropdown.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StemModelInfo {
+    pub model: StemModel,
+    pub id: &'static str,
+    pub label: &'static str,
+    pub description: &'static str,
+}
+
+/// Ordered model list shown in the Stem Extractor dialog.
+pub const STEM_MODELS: &[StemModelInfo] = &[
+    StemModelInfo {
+        model: StemModel::MdxNet,
+        id: "mdx-net",
+        label: "MDX-NET",
+        description: "4-stem separation: vocals, drums, bass, other",
+    },
+    StemModelInfo {
+        model: StemModel::MdxNetKaraoke,
+        id: "mdx-net-karaoke",
+        label: "MDX-NET Karaoke",
+        description: "2-stem separation: vocals and instrumental",
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mdx_net_is_default_and_round_trips() {
+        assert_eq!(StemModel::default(), StemModel::MdxNet);
+        assert_eq!(StemModel::parse("mdx-net"), Some(StemModel::MdxNet));
+        assert_eq!(StemModel::MdxNet.as_str(), "mdx-net");
+        assert!(StemModel::MdxNet.supports_stem(StemKind::Vocals));
+        assert!(!StemModel::MdxNet.supports_stem(StemKind::Instrumental));
+        assert!(StemModel::MdxNetKaraoke.supports_stem(StemKind::Instrumental));
+    }
+}

--- a/crates/SphereStemExtractor/src/params.rs
+++ b/crates/SphereStemExtractor/src/params.rs
@@ -1,0 +1,130 @@
+use serde::{Deserialize, Serialize};
+
+use crate::device::InferDevice;
+use crate::error::StemExtractError;
+use crate::model::StemModel;
+use crate::stems::{StemKind, StemSet};
+
+/// Offline quality hint for MDX-NET extraction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum StemExtractQuality {
+    Draft,
+    #[default]
+    Balanced,
+    High,
+}
+
+impl StemExtractQuality {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Draft => "draft",
+            Self::Balanced => "balanced",
+            Self::High => "high",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Draft => "Draft",
+            Self::Balanced => "Balanced",
+            Self::High => "High",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "draft" => Some(Self::Draft),
+            "balanced" => Some(Self::Balanced),
+            "high" => Some(Self::High),
+            _ => None,
+        }
+    }
+}
+
+/// Serializable stem-extraction settings shared by UI, Audio Processor, and jobs.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StemExtractParams {
+    pub model: StemModel,
+    pub device: InferDevice,
+    /// When true and GPU is unavailable, fall back to CPU instead of failing.
+    pub allow_cpu_fallback: bool,
+    pub stems: StemSet,
+    pub quality: StemExtractQuality,
+}
+
+impl Default for StemExtractParams {
+    fn default() -> Self {
+        Self {
+            model: StemModel::MdxNet,
+            device: InferDevice::Cpu,
+            allow_cpu_fallback: true,
+            stems: StemSet::default(),
+            quality: StemExtractQuality::Balanced,
+        }
+    }
+}
+
+impl StemExtractParams {
+    pub fn mdx_net_cpu() -> Self {
+        Self::default()
+    }
+
+    pub fn mdx_net_gpu() -> Self {
+        Self {
+            device: InferDevice::Gpu,
+            ..Self::default()
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), StemExtractError> {
+        if self.stems.is_empty() {
+            return Err(StemExtractError::NoStemsSelected);
+        }
+        for stem in self.stems.iter() {
+            if !self.model.supports_stem(stem) {
+                return Err(StemExtractError::StemNotSupported {
+                    model: self.model,
+                    stem,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub fn set_stem(&mut self, stem: StemKind, enabled: bool) {
+        if self.model.supports_stem(stem) {
+            self.stems.toggle(stem, enabled);
+        }
+    }
+
+    pub fn set_model(&mut self, model: StemModel) {
+        self.model = model;
+        // Model changes reset the stem checklist to that model's full default
+        // set so Karaoke ↔ 4-stem switches stay obvious in the dialog.
+        self.stems = StemSet::all_for_model(model);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn switching_to_karaoke_drops_unsupported_stems() {
+        let mut params = StemExtractParams::default();
+        params.set_model(StemModel::MdxNetKaraoke);
+        assert!(params.stems.contains(StemKind::Vocals));
+        assert!(params.stems.contains(StemKind::Instrumental));
+        assert!(!params.stems.contains(StemKind::Drums));
+        params.validate().unwrap();
+    }
+
+    #[test]
+    fn serde_round_trip_defaults_to_mdx_net_cpu() {
+        let json = serde_json::to_string(&StemExtractParams::default()).unwrap();
+        let parsed: StemExtractParams = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.model, StemModel::MdxNet);
+        assert_eq!(parsed.device, InferDevice::Cpu);
+    }
+}

--- a/crates/SphereStemExtractor/src/progress.rs
+++ b/crates/SphereStemExtractor/src/progress.rs
@@ -1,0 +1,72 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::stems::StemKind;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StemExtractStage {
+    Preparing,
+    LoadingModel,
+    Separating,
+    Writing,
+    Complete,
+}
+
+impl StemExtractStage {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Preparing => "Preparing",
+            Self::LoadingModel => "Loading model",
+            Self::Separating => "Separating stems",
+            Self::Writing => "Writing stems",
+            Self::Complete => "Complete",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StemExtractProgress {
+    pub stage: StemExtractStage,
+    /// 0.0 … 100.0
+    pub percent: f32,
+    pub current_stem: Option<StemKind>,
+    pub detail: String,
+}
+
+impl StemExtractProgress {
+    pub fn new(stage: StemExtractStage, percent: f32, detail: impl Into<String>) -> Self {
+        Self {
+            stage,
+            percent: percent.clamp(0.0, 100.0),
+            current_stem: None,
+            detail: detail.into(),
+        }
+    }
+
+    pub fn with_stem(mut self, stem: StemKind) -> Self {
+        self.current_stem = Some(stem);
+        self
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct StemExtractCancelToken {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl StemExtractCancelToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+}

--- a/crates/SphereStemExtractor/src/stems.rs
+++ b/crates/SphereStemExtractor/src/stems.rs
@@ -1,0 +1,105 @@
+use serde::{Deserialize, Serialize};
+
+/// One output stem slot produced by MDX-NET (or karaoke) separation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StemKind {
+    Vocals,
+    Drums,
+    Bass,
+    Other,
+    Instrumental,
+}
+
+impl StemKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Vocals => "vocals",
+            Self::Drums => "drums",
+            Self::Bass => "bass",
+            Self::Other => "other",
+            Self::Instrumental => "instrumental",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Vocals => "Vocals",
+            Self::Drums => "Drums",
+            Self::Bass => "Bass",
+            Self::Other => "Other",
+            Self::Instrumental => "Instrumental",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "vocals" | "vocal" => Some(Self::Vocals),
+            "drums" | "drum" => Some(Self::Drums),
+            "bass" => Some(Self::Bass),
+            "other" => Some(Self::Other),
+            "instrumental" | "inst" => Some(Self::Instrumental),
+            _ => None,
+        }
+    }
+
+    pub fn file_stem_suffix(self) -> &'static str {
+        self.as_str()
+    }
+}
+
+/// Selected output stems for an extract job.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StemSet {
+    stems: Vec<StemKind>,
+}
+
+impl StemSet {
+    pub fn new(stems: impl IntoIterator<Item = StemKind>) -> Self {
+        let mut stems: Vec<StemKind> = stems.into_iter().collect();
+        stems.sort_by_key(|s| s.as_str());
+        stems.dedup();
+        Self { stems }
+    }
+
+    pub fn all_for_model(model: crate::model::StemModel) -> Self {
+        Self::new(model.default_stems().iter().copied())
+    }
+
+    pub fn contains(&self, stem: StemKind) -> bool {
+        self.stems.contains(&stem)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = StemKind> + '_ {
+        self.stems.iter().copied()
+    }
+
+    pub fn as_slice(&self) -> &[StemKind] {
+        &self.stems
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.stems.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.stems.len()
+    }
+
+    pub fn toggle(&mut self, stem: StemKind, enabled: bool) {
+        if enabled {
+            if !self.contains(stem) {
+                self.stems.push(stem);
+                self.stems.sort_by_key(|s| s.as_str());
+            }
+        } else {
+            self.stems.retain(|s| *s != stem);
+        }
+    }
+}
+
+impl Default for StemSet {
+    fn default() -> Self {
+        Self::all_for_model(crate::model::StemModel::MdxNet)
+    }
+}

--- a/crates/SphereUIComponents/src/components/mod.rs
+++ b/crates/SphereUIComponents/src/components/mod.rs
@@ -67,6 +67,7 @@ pub mod soundfont_player_mdi;
 pub mod soundfont_player_window;
 mod status_bar;
 mod status_bar_view;
+pub mod stem_extractor_dialog;
 pub mod text_input;
 pub mod timeline;
 pub mod title_bar;
@@ -177,6 +178,10 @@ pub use status_bar::{
 };
 pub(crate) use status_bar_view::status_content_signature;
 pub(crate) use status_bar_view::StatusBarView;
+pub use stem_extractor_dialog::{
+    open_stem_extractor_window, StemExtractJobState, StemExtractJobSummary,
+    StemExtractorDialogDefaults, StemExtractorWindow, STEM_EXTRACTOR_WINDOW_WIDTH,
+};
 pub use text_input::{text_field, TextInputAction, TextInputState};
 pub use virtual_keyboard::{
     VirtualKeyboardEventSink, VirtualKeyboardPanel, VirtualKeyboardPanelState,

--- a/crates/SphereUIComponents/src/components/stem_extractor_dialog.rs
+++ b/crates/SphereUIComponents/src/components/stem_extractor_dialog.rs
@@ -1,0 +1,1143 @@
+//! Native Stem Extractor dialog.
+//!
+//! Compact Futureboard dialog for offline MDX-NET stem separation (CPU/GPU).
+//! Owns serializable [`StemExtractParams`] from SphereAudioProcessor, edits them
+//! in the UI, and runs a cancellable background job that never leases GPUI
+//! entities during decode/separate/encode work.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use gpui::{
+    div, px, size, App, AppContext, Bounds, Context, FocusHandle, InteractiveElement, IntoElement,
+    KeyDownEvent, ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Window,
+    WindowBackgroundAppearance, WindowBounds, WindowHandle, WindowKind,
+};
+use sphere_encoder::{
+    create_encoder, AudioEncodeOptions, AudioEncodeSpec, AudioFileFormat, AudioSampleFormat,
+};
+
+use crate::components::controls::{fb_button, fb_checkbox, FbButtonKind};
+use crate::components::form::select::{select, SelectOption};
+use crate::components::progress_dialog::{progress_bar, ProgressBarValue};
+use crate::components::title_bar::{external_window_titlebar_compact, TITLEBAR_HEIGHT};
+use crate::theme::{self, Colors};
+use crate::window_position::{apply_owner_display, centered_window_bounds};
+
+pub const STEM_EXTRACTOR_WINDOW_WIDTH: f32 = 520.0;
+const STEM_EXTRACTOR_WINDOW_HEIGHT: f32 = 520.0;
+const BODY_PAD: f32 = 14.0;
+const ROW_GAP: f32 = 9.0;
+const LABEL_W: f32 = 96.0;
+const CONTROL_H: f32 = 28.0;
+const BUTTON_H: f32 = 28.0;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SelectField {
+    Model,
+    Device,
+    Quality,
+}
+
+pub enum StemExtractJobState {
+    Editing,
+    Running(SphereAudioProcessor::StemExtractProgress),
+    Complete(StemExtractJobSummary),
+    Failed(String),
+    Cancelled,
+}
+
+#[derive(Clone, Debug)]
+pub struct StemExtractJobSummary {
+    pub model: SphereAudioProcessor::StemModel,
+    pub device: SphereAudioProcessor::InferDevice,
+    pub backend: SphereAudioProcessor::InferBackendKind,
+    pub output_paths: Vec<PathBuf>,
+}
+
+#[derive(Default)]
+struct SharedJob {
+    progress: Option<SphereAudioProcessor::StemExtractProgress>,
+    done: Option<Result<StemExtractJobSummary, String>>,
+}
+
+struct ActiveJob {
+    shared: Arc<Mutex<SharedJob>>,
+    cancel: SphereAudioProcessor::StemExtractCancelToken,
+}
+
+/// Plain data captured when the dialog opens — never a live entity borrow.
+#[derive(Clone, Debug, Default)]
+pub struct StemExtractorDialogDefaults {
+    pub project_name: String,
+    pub suggested_source: Option<PathBuf>,
+    pub suggested_output_dir: Option<PathBuf>,
+    pub selected_clip_label: Option<String>,
+}
+
+pub struct StemExtractorWindow {
+    defaults: StemExtractorDialogDefaults,
+    params: SphereAudioProcessor::StemExtractParams,
+    source_path: Option<PathBuf>,
+    output_dir: Option<PathBuf>,
+    state: StemExtractJobState,
+    open_select: Option<SelectField>,
+    job: Option<ActiveJob>,
+    focus_handle: FocusHandle,
+    gpu_available: bool,
+}
+
+impl StemExtractorWindow {
+    pub fn new(defaults: StemExtractorDialogDefaults, cx: &mut Context<Self>) -> Self {
+        let source_path = defaults.suggested_source.clone();
+        let output_dir = defaults.suggested_output_dir.clone().or_else(|| {
+            source_path
+                .as_ref()
+                .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        });
+        Self {
+            defaults,
+            params: SphereAudioProcessor::default_stem_extract_params(),
+            source_path,
+            output_dir,
+            state: StemExtractJobState::Editing,
+            open_select: None,
+            job: None,
+            focus_handle: cx.focus_handle(),
+            gpu_available: SphereAudioProcessor::gpu_available(),
+        }
+    }
+
+    fn close(&mut self, window: &mut Window, _cx: &mut Context<Self>) {
+        if let Some(job) = &self.job {
+            job.cancel.cancel();
+        }
+        window.remove_window();
+    }
+
+    fn handle_key(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let key = event.keystroke.key.as_str();
+        match key {
+            "escape" => {
+                if self.open_select.is_some() {
+                    self.open_select = None;
+                    cx.notify();
+                } else if matches!(self.state, StemExtractJobState::Running(_)) {
+                    self.request_cancel(cx);
+                } else {
+                    self.close(window, cx);
+                }
+                true
+            }
+            "enter" if matches!(self.state, StemExtractJobState::Editing) => {
+                self.start_extract(cx);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn request_cancel(&mut self, cx: &mut Context<Self>) {
+        if let Some(job) = &self.job {
+            job.cancel.cancel();
+        }
+        cx.notify();
+    }
+
+    fn can_extract(&self) -> bool {
+        self.source_path.is_some()
+            && self.output_dir.is_some()
+            && self.params.validate().is_ok()
+            && !self.params.stems.is_empty()
+    }
+
+    fn browse_source(&mut self, cx: &mut Context<Self>) {
+        #[cfg(feature = "native-dialogs")]
+        {
+            let entity = cx.entity().clone();
+            let start = self
+                .source_path
+                .as_ref()
+                .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+                .or_else(|| self.output_dir.clone())
+                .unwrap_or_else(std::env::temp_dir);
+            cx.spawn(async move |_this, cx| {
+                let result = rfd::AsyncFileDialog::new()
+                    .set_title("Choose Source Audio")
+                    .set_directory(&start)
+                    .add_filter(
+                        "Audio",
+                        &["wav", "flac", "mp3", "aiff", "aif", "ogg", "m4a", "rauf"],
+                    )
+                    .pick_file()
+                    .await;
+                if let Some(handle) = result {
+                    let path = handle.path().to_path_buf();
+                    let _ = entity.update(cx, |this, cx| {
+                        this.source_path = Some(path.clone());
+                        if this.output_dir.is_none() {
+                            this.output_dir = path.parent().map(|d| d.to_path_buf());
+                        }
+                        if matches!(this.state, StemExtractJobState::Failed(_)) {
+                            this.state = StemExtractJobState::Editing;
+                        }
+                        cx.notify();
+                    });
+                }
+            })
+            .detach();
+        }
+        #[cfg(not(feature = "native-dialogs"))]
+        {
+            self.state = StemExtractJobState::Failed(
+                "Native file dialogs are unavailable in this build.".into(),
+            );
+            cx.notify();
+        }
+    }
+
+    fn browse_output(&mut self, cx: &mut Context<Self>) {
+        #[cfg(feature = "native-dialogs")]
+        {
+            let entity = cx.entity().clone();
+            let start = self
+                .output_dir
+                .clone()
+                .unwrap_or_else(std::env::temp_dir);
+            cx.spawn(async move |_this, cx| {
+                let result = rfd::AsyncFileDialog::new()
+                    .set_title("Choose Stem Output Folder")
+                    .set_directory(&start)
+                    .pick_folder()
+                    .await;
+                if let Some(handle) = result {
+                    let _ = entity.update(cx, |this, cx| {
+                        this.output_dir = Some(handle.path().to_path_buf());
+                        if matches!(this.state, StemExtractJobState::Failed(_)) {
+                            this.state = StemExtractJobState::Editing;
+                        }
+                        cx.notify();
+                    });
+                }
+            })
+            .detach();
+        }
+        #[cfg(not(feature = "native-dialogs"))]
+        {
+            self.state = StemExtractJobState::Failed(
+                "Native file dialogs are unavailable in this build.".into(),
+            );
+            cx.notify();
+        }
+    }
+
+    fn start_extract(&mut self, cx: &mut Context<Self>) {
+        self.open_select = None;
+        if let Err(err) = self.params.validate() {
+            self.state = StemExtractJobState::Failed(err.user_message());
+            cx.notify();
+            return;
+        }
+        let Some(source_path) = self.source_path.clone() else {
+            self.state = StemExtractJobState::Failed("Choose a source audio file.".into());
+            cx.notify();
+            return;
+        };
+        let Some(output_dir) = self.output_dir.clone() else {
+            self.state = StemExtractJobState::Failed("Choose an output folder.".into());
+            cx.notify();
+            return;
+        };
+
+        let shared = Arc::new(Mutex::new(SharedJob::default()));
+        let cancel = SphereAudioProcessor::StemExtractCancelToken::new();
+        self.job = Some(ActiveJob {
+            shared: shared.clone(),
+            cancel: cancel.clone(),
+        });
+        self.state = StemExtractJobState::Running(SphereAudioProcessor::StemExtractProgress::new(
+            SphereAudioProcessor::StemExtractStage::Preparing,
+            0.0,
+            "Preparing…",
+        ));
+
+        let params = self.params.clone();
+        let source_stem = source_path
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "stem".to_string());
+        let worker_shared = shared.clone();
+        std::thread::Builder::new()
+            .name("fb-stem-extract".to_string())
+            .spawn(move || {
+                let progress_shared = worker_shared.clone();
+                let mut on_progress = move |progress: SphereAudioProcessor::StemExtractProgress| {
+                    if let Ok(mut guard) = progress_shared.lock() {
+                        guard.progress = Some(progress);
+                    }
+                };
+
+                let result = (|| -> Result<StemExtractJobSummary, String> {
+                    on_progress(SphereAudioProcessor::StemExtractProgress::new(
+                        SphereAudioProcessor::StemExtractStage::Preparing,
+                        2.0,
+                        "Decoding source audio…",
+                    ));
+                    if cancel.is_cancelled() {
+                        return Err("cancelled".into());
+                    }
+                    let buffer = DirectAudio::load_audio_file(&source_path.to_string_lossy())
+                        .map_err(|e| e.to_string())?;
+                    let channels = buffer.channels.max(1);
+                    let input = SphereAudioProcessor::StemExtractInput::new(
+                        buffer.sample_rate,
+                        channels,
+                        buffer.samples,
+                    );
+                    let extracted = SphereAudioProcessor::extract_stems(
+                        &input,
+                        &params,
+                        &cancel,
+                        &mut on_progress,
+                    )
+                    .map_err(|e| e.user_message())?;
+
+                    if cancel.is_cancelled() {
+                        return Err("cancelled".into());
+                    }
+
+                    std::fs::create_dir_all(&output_dir).map_err(|e| e.to_string())?;
+                    let total = extracted.stems.len().max(1);
+                    let mut output_paths = Vec::with_capacity(extracted.stems.len());
+                    for (index, stem) in extracted.stems.iter().enumerate() {
+                        if cancel.is_cancelled() {
+                            return Err("cancelled".into());
+                        }
+                        let percent = 90.0 + (index as f32 / total as f32) * 9.0;
+                        on_progress(
+                            SphereAudioProcessor::StemExtractProgress::new(
+                                SphereAudioProcessor::StemExtractStage::Writing,
+                                percent,
+                                format!("Writing {}.wav", stem.kind.as_str()),
+                            )
+                            .with_stem(stem.kind),
+                        );
+                        let path = output_dir.join(format!(
+                            "{}_{}.wav",
+                            sanitize_file_stem(&source_stem),
+                            stem.kind.file_stem_suffix()
+                        ));
+                        write_stem_wav(&path, stem)?;
+                        output_paths.push(path);
+                    }
+
+                    Ok(StemExtractJobSummary {
+                        model: extracted.model,
+                        device: extracted.device,
+                        backend: extracted.backend,
+                        output_paths,
+                    })
+                })();
+
+                if let Ok(mut guard) = worker_shared.lock() {
+                    guard.done = Some(result);
+                }
+            })
+            .ok();
+
+        cx.spawn(async move |this, cx| {
+            let executor = cx.background_executor().clone();
+            loop {
+                if crate::shutdown::ShutdownState::global().is_shutting_down() {
+                    break;
+                }
+                executor.timer(std::time::Duration::from_millis(50)).await;
+                let keep_going = this
+                    .update(cx, |this, cx| this.poll_job(cx))
+                    .unwrap_or(false);
+                if !keep_going {
+                    break;
+                }
+            }
+        })
+        .detach();
+
+        cx.notify();
+    }
+
+    fn poll_job(&mut self, cx: &mut Context<Self>) -> bool {
+        let Some(job) = &self.job else {
+            return false;
+        };
+        let (progress, done) = {
+            let Ok(mut guard) = job.shared.lock() else {
+                return true;
+            };
+            (guard.progress.take(), guard.done.take())
+        };
+        if let Some(done) = done {
+            self.state = match done {
+                Ok(summary) => StemExtractJobState::Complete(summary),
+                Err(message)
+                    if job.cancel.is_cancelled()
+                        || message.to_ascii_lowercase().contains("cancel") =>
+                {
+                    StemExtractJobState::Cancelled
+                }
+                Err(message) => StemExtractJobState::Failed(message),
+            };
+            self.job = None;
+            cx.notify();
+            return false;
+        }
+        if let Some(progress) = progress {
+            self.state = StemExtractJobState::Running(progress);
+            cx.notify();
+        }
+        true
+    }
+
+    fn apply_select(&mut self, field: SelectField, value: &str) {
+        match field {
+            SelectField::Model => {
+                if let Some(model) = SphereAudioProcessor::StemModel::parse(value) {
+                    self.params.set_model(model);
+                }
+            }
+            SelectField::Device => {
+                if let Some(device) = SphereAudioProcessor::InferDevice::parse(value) {
+                    self.params.device = device;
+                }
+            }
+            SelectField::Quality => {
+                if let Some(quality) = SphereAudioProcessor::StemExtractQuality::parse(value) {
+                    self.params.quality = quality;
+                }
+            }
+        }
+    }
+}
+
+impl Render for StemExtractorWindow {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let _ = window;
+        let target = cx.entity().clone();
+        let body = match &self.state {
+            StemExtractJobState::Editing | StemExtractJobState::Failed(_) => {
+                self.render_editing(target.clone())
+            }
+            StemExtractJobState::Running(progress) => {
+                self.render_progress(progress.clone(), target.clone())
+            }
+            StemExtractJobState::Complete(summary) => {
+                self.render_complete(summary.clone(), target.clone())
+            }
+            StemExtractJobState::Cancelled => self.render_terminal(
+                "Extraction cancelled.",
+                Colors::text_secondary(),
+                target.clone(),
+            ),
+        };
+
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .font(theme::ui_font())
+            .bg(Colors::surface_base())
+            .overflow_hidden()
+            .rounded_md()
+            .border(px(1.0))
+            .border_color(Colors::border_subtle())
+            .shadow(vec![gpui::BoxShadow {
+                color: Colors::surface_overlay().into(),
+                offset: gpui::point(px(0.0), px(6.0)),
+                blur_radius: px(20.0),
+                spread_radius: px(0.0),
+                inset: false,
+            }])
+            .capture_key_down({
+                let target = target.clone();
+                move |event, window, cx| {
+                    let _ = target.update(cx, |this, cx| this.handle_key(event, window, cx));
+                }
+            })
+            .child(div().w(px(0.0)).h(px(0.0)).track_focus(&self.focus_handle))
+            .child(external_window_titlebar_compact(
+                "Stem Extractor".to_string(),
+                "stem-extractor-close",
+                {
+                    let target = target.clone();
+                    move |window, cx| {
+                        let _ = target.update(cx, |this, cx| this.close(window, cx));
+                    }
+                },
+            ))
+            .child(
+                div()
+                    .px(px(BODY_PAD))
+                    .pt(px(6.0))
+                    .text_size(px(11.0))
+                    .text_color(Colors::text_muted())
+                    .truncate()
+                    .child(self.subtitle()),
+            )
+            .child(body)
+    }
+}
+
+impl StemExtractorWindow {
+    fn subtitle(&self) -> String {
+        if let Some(label) = &self.defaults.selected_clip_label {
+            format!("Source clip · {label}")
+        } else if let Some(path) = &self.source_path {
+            format!(
+                "MDX-NET stem separation · {}",
+                path.file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| path.display().to_string())
+            )
+        } else {
+            "MDX-NET stem separation · CPU / GPU".to_string()
+        }
+    }
+
+    fn render_editing(&self, target: gpui::Entity<Self>) -> gpui::AnyElement {
+        let mut col = div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .px(px(BODY_PAD))
+            .py(px(BODY_PAD))
+            .gap(px(ROW_GAP))
+            .child(section_label("SOURCE"))
+            .child(self.path_row(
+                "Source",
+                self.source_path
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "No file selected".to_string()),
+                "stem-source-browse",
+                {
+                    let target = target.clone();
+                    move |_window, cx| {
+                        let _ = target.update(cx, |this, cx| this.browse_source(cx));
+                    }
+                },
+            ))
+            .child(self.path_row(
+                "Output",
+                self.output_dir
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| "No folder selected".to_string()),
+                "stem-output-browse",
+                {
+                    let target = target.clone();
+                    move |_window, cx| {
+                        let _ = target.update(cx, |this, cx| this.browse_output(cx));
+                    }
+                },
+            ))
+            .child(section_label("MODEL"))
+            .child(self.model_row(target.clone()))
+            .child(self.device_row(target.clone()))
+            .child(self.quality_row(target.clone()))
+            .child(section_label("STEMS"))
+            .child(self.stems_row(target.clone()))
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(Colors::text_faint())
+                    .child(model_hint(&self.params)),
+            )
+            .child(div().flex_1());
+
+        if let StemExtractJobState::Failed(message) = &self.state {
+            col = col.child(error_banner(message.clone()));
+        } else if !self.can_extract() {
+            col = col.child(hint_banner(
+                "Choose a source file, output folder, and at least one stem.".into(),
+            ));
+        }
+
+        col = col.child(self.footer(self.can_extract(), target));
+        col.into_any_element()
+    }
+
+    fn model_row(&self, target: gpui::Entity<Self>) -> impl IntoElement {
+        let options = SphereAudioProcessor::STEM_MODELS
+            .iter()
+            .map(|info| SelectOption::new(info.id, info.label))
+            .collect::<Vec<_>>();
+        let control = self.dropdown(
+            SelectField::Model,
+            "stem-model",
+            self.params.model.as_str().to_string(),
+            options,
+            target,
+        );
+        self.labeled("Model", control)
+    }
+
+    fn device_row(&self, target: gpui::Entity<Self>) -> impl IntoElement {
+        let options = vec![
+            SelectOption::new("cpu", "CPU"),
+            SelectOption::new("gpu", "GPU").disabled(!self.gpu_available),
+        ];
+        let control = self.dropdown(
+            SelectField::Device,
+            "stem-device",
+            self.params.device.as_str().to_string(),
+            options,
+            target,
+        );
+        self.labeled("Device", control)
+    }
+
+    fn quality_row(&self, target: gpui::Entity<Self>) -> impl IntoElement {
+        let options = vec![
+            SelectOption::new("draft", "Draft"),
+            SelectOption::new("balanced", "Balanced"),
+            SelectOption::new("high", "High"),
+        ];
+        let control = self.dropdown(
+            SelectField::Quality,
+            "stem-quality",
+            self.params.quality.as_str().to_string(),
+            options,
+            target,
+        );
+        self.labeled("Quality", control)
+    }
+
+    fn stems_row(&self, target: gpui::Entity<Self>) -> impl IntoElement {
+        let stems = self.params.model.default_stems();
+        div()
+            .flex()
+            .flex_row()
+            .flex_wrap()
+            .gap(px(10.0))
+            .children(stems.iter().copied().map(|stem| {
+                let checked = self.params.stems.contains(stem);
+                let target = target.clone();
+                fb_checkbox(
+                    format!("stem-toggle-{}", stem.as_str()),
+                    stem.label(),
+                    checked,
+                    true,
+                    move |_, _window, cx| {
+                        let _ = target.update(cx, |this, cx| {
+                            this.params.set_stem(stem, !this.params.stems.contains(stem));
+                            if matches!(this.state, StemExtractJobState::Failed(_)) {
+                                this.state = StemExtractJobState::Editing;
+                            }
+                            cx.notify();
+                        });
+                    },
+                )
+            }))
+    }
+
+    fn dropdown(
+        &self,
+        field: SelectField,
+        id: &'static str,
+        selected: String,
+        options: Vec<SelectOption>,
+        target: gpui::Entity<Self>,
+    ) -> impl IntoElement {
+        let open = self.open_select == Some(field);
+        let toggle_target = target.clone();
+        let change_target = target;
+        let selected_value = selected.clone();
+        select(
+            id,
+            Some(selected.as_str()),
+            selected_value,
+            options,
+            open,
+            false,
+            Arc::new(move |_, _window, cx| {
+                let _ = toggle_target.update(cx, |this, cx| {
+                    this.open_select = if this.open_select == Some(field) {
+                        None
+                    } else {
+                        Some(field)
+                    };
+                    cx.notify();
+                });
+            }),
+            Arc::new(move |value, _window, cx| {
+                let value = value.clone();
+                let _ = change_target.update(cx, |this, cx| {
+                    this.apply_select(field, &value);
+                    this.open_select = None;
+                    if matches!(this.state, StemExtractJobState::Failed(_)) {
+                        this.state = StemExtractJobState::Editing;
+                    }
+                    cx.notify();
+                });
+            }),
+        )
+    }
+
+    fn labeled<E: IntoElement>(&self, label: &str, control: E) -> gpui::Stateful<gpui::Div> {
+        div()
+            .id(SharedString::from(format!("stem-row-{label}")))
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(10.0))
+            .child(
+                div()
+                    .w(px(LABEL_W))
+                    .flex_none()
+                    .text_size(px(11.0))
+                    .text_color(Colors::text_secondary())
+                    .child(label.to_string()),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .child(control.into_any_element()),
+            )
+    }
+
+    fn path_row(
+        &self,
+        label: &str,
+        path_label: String,
+        browse_id: &'static str,
+        on_browse: impl Fn(&mut Window, &mut App) + 'static,
+    ) -> impl IntoElement {
+        let control = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(6.0))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .h(px(CONTROL_H))
+                    .px(px(8.0))
+                    .flex()
+                    .items_center()
+                    .rounded_md()
+                    .border(px(1.0))
+                    .border_color(Colors::border_subtle())
+                    .bg(Colors::surface_input())
+                    .text_size(px(11.0))
+                    .text_color(Colors::text_primary())
+                    .truncate()
+                    .child(path_label),
+            )
+            .child(
+                div()
+                    .id(browse_id)
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .h(px(BUTTON_H))
+                    .px(px(10.0))
+                    .rounded(px(5.0))
+                    .border(px(1.0))
+                    .border_color(Colors::border_subtle())
+                    .text_size(px(11.0))
+                    .text_color(Colors::text_secondary())
+                    .cursor(gpui::CursorStyle::PointingHand)
+                    .hover(|s| s.bg(Colors::surface_control_hover()))
+                    .on_click(move |_, window, cx| on_browse(window, cx))
+                    .child("Browse…"),
+            );
+        self.labeled(label, control)
+    }
+
+    fn footer(&self, can_extract: bool, target: gpui::Entity<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_end()
+            .gap(px(8.0))
+            .pt(px(8.0))
+            .border_t(px(1.0))
+            .border_color(Colors::border_subtle())
+            .child(fb_button(
+                "stem-cancel",
+                "Cancel",
+                FbButtonKind::Default,
+                true,
+                {
+                    let target = target.clone();
+                    move |_, window, cx| {
+                        let _ = target.update(cx, |this, cx| this.close(window, cx));
+                    }
+                },
+            ))
+            .child(fb_button(
+                "stem-extract",
+                "Extract",
+                FbButtonKind::Primary,
+                can_extract,
+                {
+                    let target = target.clone();
+                    move |_, _window, cx| {
+                        let _ = target.update(cx, |this, cx| this.start_extract(cx));
+                    }
+                },
+            ))
+    }
+
+    fn render_progress(
+        &self,
+        progress: SphereAudioProcessor::StemExtractProgress,
+        target: gpui::Entity<Self>,
+    ) -> gpui::AnyElement {
+        let percent = format!("{:.0}%", progress.percent);
+        let detail = if let Some(stem) = progress.current_stem {
+            format!("{} · {}", progress.detail, stem.label())
+        } else {
+            progress.detail.clone()
+        };
+        div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .px(px(BODY_PAD))
+            .py(px(BODY_PAD))
+            .gap(px(10.0))
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .justify_between()
+                    .child(
+                        div()
+                            .text_size(px(12.0))
+                            .font_weight(gpui::FontWeight::SEMIBOLD)
+                            .text_color(Colors::text_primary())
+                            .child(progress.stage.as_str().to_string()),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(11.0))
+                            .font_weight(gpui::FontWeight::SEMIBOLD)
+                            .text_color(Colors::accent_primary())
+                            .child(percent),
+                    ),
+            )
+            .child(progress_bar(ProgressBarValue::value(
+                progress.percent / 100.0,
+            )))
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(Colors::text_muted())
+                    .child(detail),
+            )
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(Colors::text_faint())
+                    .child(format!(
+                        "{} · {}",
+                        self.params.model.label(),
+                        self.params.device.label()
+                    )),
+            )
+            .child(div().flex_1())
+            .child(
+                div().flex().flex_row().justify_end().child(fb_button(
+                    "stem-cancel-run",
+                    "Cancel",
+                    FbButtonKind::Default,
+                    true,
+                    {
+                        let target = target.clone();
+                        move |_, _window, cx| {
+                            let _ = target.update(cx, |this, cx| this.request_cancel(cx));
+                        }
+                    },
+                )),
+            )
+            .into_any_element()
+    }
+
+    fn render_complete(
+        &self,
+        summary: StemExtractJobSummary,
+        target: gpui::Entity<Self>,
+    ) -> gpui::AnyElement {
+        let count = summary.output_paths.len();
+        let first = summary
+            .output_paths
+            .first()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default();
+        let folder = summary
+            .output_paths
+            .first()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()));
+        div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .px(px(BODY_PAD))
+            .py(px(BODY_PAD))
+            .gap(px(10.0))
+            .child(
+                div()
+                    .text_size(px(12.0))
+                    .font_weight(gpui::FontWeight::SEMIBOLD)
+                    .text_color(Colors::accent_primary())
+                    .child("Extraction complete"),
+            )
+            .child(
+                div()
+                    .text_size(px(11.0))
+                    .text_color(Colors::text_primary())
+                    .child(format!(
+                        "{count} stem file(s) · {} · {}",
+                        summary.model.label(),
+                        summary.device.label()
+                    )),
+            )
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(Colors::text_muted())
+                    .truncate()
+                    .child(first),
+            )
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(Colors::text_faint())
+                    .child(format!("Backend · {}", summary.backend.label())),
+            )
+            .child(div().flex_1())
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .justify_end()
+                    .gap(px(8.0))
+                    .child(fb_button(
+                        "stem-reveal",
+                        "Open Folder",
+                        FbButtonKind::Default,
+                        folder.is_some(),
+                        move |_, _window, _cx| {
+                            if let Some(dir) = &folder {
+                                let _ = open_in_file_manager(dir);
+                            }
+                        },
+                    ))
+                    .child(fb_button(
+                        "stem-close",
+                        "Close",
+                        FbButtonKind::Primary,
+                        true,
+                        {
+                            let target = target.clone();
+                            move |_, window, cx| {
+                                let _ = target.update(cx, |this, cx| this.close(window, cx));
+                            }
+                        },
+                    )),
+            )
+            .into_any_element()
+    }
+
+    fn render_terminal(
+        &self,
+        message: &str,
+        color: gpui::Rgba,
+        target: gpui::Entity<Self>,
+    ) -> gpui::AnyElement {
+        div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .px(px(BODY_PAD))
+            .py(px(BODY_PAD))
+            .gap(px(10.0))
+            .child(
+                div()
+                    .text_size(px(12.0))
+                    .text_color(color)
+                    .child(message.to_string()),
+            )
+            .child(div().flex_1())
+            .child(div().flex().flex_row().justify_end().child(fb_button(
+                "stem-close-term",
+                "Close",
+                FbButtonKind::Primary,
+                true,
+                {
+                    let target = target.clone();
+                    move |_, window, cx| {
+                        let _ = target.update(cx, |this, cx| this.close(window, cx));
+                    }
+                },
+            )))
+            .into_any_element()
+    }
+}
+
+fn model_hint(params: &SphereAudioProcessor::StemExtractParams) -> String {
+    let device = if params.device == SphereAudioProcessor::InferDevice::Gpu {
+        if SphereAudioProcessor::gpu_available() {
+            "GPU"
+        } else if params.allow_cpu_fallback {
+            "GPU (falls back to CPU if unavailable)"
+        } else {
+            "GPU (unavailable)"
+        }
+    } else {
+        "CPU"
+    };
+    format!(
+        "{} · {device} · {}",
+        params.model.description(),
+        params.quality.label()
+    )
+}
+
+fn section_label(label: &'static str) -> impl IntoElement {
+    div()
+        .mt(px(2.0))
+        .pb(px(2.0))
+        .border_b(px(1.0))
+        .border_color(Colors::border_subtle())
+        .text_size(px(9.0))
+        .font_weight(gpui::FontWeight::SEMIBOLD)
+        .text_color(Colors::text_faint())
+        .child(label)
+}
+
+fn error_banner(message: String) -> impl IntoElement {
+    banner(message, Colors::status_error())
+}
+
+fn hint_banner(message: String) -> impl IntoElement {
+    banner(message, Colors::text_muted())
+}
+
+fn banner(message: String, color: gpui::Rgba) -> impl IntoElement {
+    div()
+        .px(px(10.0))
+        .py(px(6.0))
+        .rounded(px(5.0))
+        .bg(Colors::surface_panel_alt())
+        .text_size(px(10.0))
+        .text_color(color)
+        .child(message)
+}
+
+fn write_stem_wav(
+    path: &std::path::Path,
+    stem: &SphereAudioProcessor::StemExtractOutput,
+) -> Result<(), String> {
+    let channels = stem.channels.max(1) as u16;
+    let spec = AudioEncodeSpec {
+        sample_rate: stem.sample_rate,
+        channels,
+        sample_format: AudioSampleFormat::F32,
+    };
+    let options = AudioEncodeOptions {
+        format: AudioFileFormat::Wav,
+        ..AudioEncodeOptions::default()
+    };
+    let mut encoder = create_encoder(path, spec, options).map_err(|e| e.to_string())?;
+    encoder
+        .write_interleaved_f32(&stem.samples)
+        .map_err(|e| e.to_string())?;
+    encoder.finalize().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn sanitize_file_stem(name: &str) -> String {
+    let sanitized: String = name
+        .trim()
+        .chars()
+        .map(|character| {
+            if matches!(
+                character,
+                '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|'
+            ) {
+                '_'
+            } else {
+                character
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "stem".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn open_in_file_manager(dir: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("explorer").arg(dir).spawn()?;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open").arg(dir).spawn()?;
+    }
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+    {
+        std::process::Command::new("xdg-open").arg(dir).spawn()?;
+    }
+    Ok(())
+}
+
+/// Open the Stem Extractor dialog centered over `owner_bounds`.
+pub fn open_stem_extractor_window(
+    owner_bounds: Option<Bounds<gpui::Pixels>>,
+    defaults: StemExtractorDialogDefaults,
+    cx: &mut App,
+) -> Result<WindowHandle<StemExtractorWindow>, String> {
+    let height = TITLEBAR_HEIGHT + STEM_EXTRACTOR_WINDOW_HEIGHT;
+    let window_bounds = centered_window_bounds(
+        owner_bounds,
+        size(px(STEM_EXTRACTOR_WINDOW_WIDTH), px(height)),
+        cx,
+    );
+
+    let mut options = crate::platform_chrome::external_dialog_window_options_partial();
+    options.window_bounds = Some(WindowBounds::Windowed(window_bounds));
+    options.kind = WindowKind::Dialog;
+    options.is_resizable = false;
+    options.is_minimizable = false;
+    options.window_background = WindowBackgroundAppearance::Transparent;
+    apply_owner_display(&mut options, owner_bounds, cx);
+
+    cx.open_window(options, move |_window, cx| {
+        cx.new(|cx| StemExtractorWindow::new(defaults, cx))
+    })
+    .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_illegal_path_chars() {
+        assert_eq!(sanitize_file_stem("Lead/Vox:A"), "Lead_Vox_A");
+        assert_eq!(sanitize_file_stem("   "), "stem");
+    }
+}

--- a/crates/SphereUIComponents/src/layout.rs
+++ b/crates/SphereUIComponents/src/layout.rs
@@ -45,6 +45,7 @@ mod context_menu_ops;
 pub(crate) mod engine_snapshot;
 mod export_ops;
 mod frame_diagnostics;
+mod stem_extract_ops;
 mod helpers;
 mod input_ops;
 mod inspector_ops;
@@ -1977,6 +1978,9 @@ impl StudioLayout {
             }
             "file:export-arrangement" => {
                 self.open_export_arrangement_external_window(owner_bounds, cx)
+            }
+            "audio:stem-extractor" | "tools:stem-extractor" => {
+                self.open_stem_extractor_external_window(owner_bounds, cx)
             }
             "track:rename" => {
                 if let Some(track_id) = self.context_track_id_or_selected(cx) {

--- a/crates/SphereUIComponents/src/layout/stem_extract_ops.rs
+++ b/crates/SphereUIComponents/src/layout/stem_extract_ops.rs
@@ -1,0 +1,84 @@
+//! StudioLayout integration for the Stem Extractor dialog.
+//!
+//! Captures a plain source path / output folder suggestion from the current
+//! selection, then opens the external Stem Extractor window. The window owns
+//! the background MDX-NET job — StudioLayout holds only the window handle.
+
+use gpui::{Bounds, Context};
+
+use super::StudioLayout;
+use crate::components::timeline::timeline_state::ClipType;
+use crate::components::{open_stem_extractor_window, StemExtractorDialogDefaults};
+
+impl StudioLayout {
+    pub(super) fn open_stem_extractor_external_window(
+        &mut self,
+        owner_bounds: Option<Bounds<gpui::Pixels>>,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(handle) = self.external_windows.stem_extractor.clone() {
+            if handle
+                .update(cx, |_w, window, _cx| window.activate_window())
+                .is_ok()
+            {
+                return;
+            }
+            self.external_windows.stem_extractor = None;
+        }
+
+        self.menu_bar.open_menu_id = None;
+        self.menu_bar.submenu_path.clear();
+        self.overlay.open_popover = None;
+        self.overlay.text_context_menu = None;
+
+        let tl_state = self.timeline.read(cx).state.clone();
+        let project_name = self.project_session.name.clone();
+        let project_root = self
+            .project_session
+            .folder_path
+            .as_ref()
+            .map(|p| p.to_path_buf());
+
+        let mut suggested_source = None;
+        let mut selected_clip_label = None;
+        if let Some(clip_id) = tl_state.selection.selected_clip_ids.first() {
+            if let Some((_track, clip)) = tl_state.find_clip(clip_id) {
+                selected_clip_label = Some(clip.name.clone());
+                if let ClipType::Audio {
+                    source_path: Some(path),
+                    ..
+                } = &clip.clip_type
+                {
+                    let path = std::path::PathBuf::from(path);
+                    if path.exists() {
+                        suggested_source = Some(path);
+                    }
+                }
+            }
+        }
+
+        let suggested_output_dir = project_root.as_ref().map(|root| {
+            let dir = root.join("Rendered").join("Stems");
+            let _ = std::fs::create_dir_all(&dir);
+            dir
+        });
+
+        let defaults = StemExtractorDialogDefaults {
+            project_name,
+            suggested_source,
+            suggested_output_dir,
+            selected_clip_label,
+        };
+
+        let owner_bounds = crate::window_position::resolve_owner_bounds_with_preferred(
+            owner_bounds,
+            self.studio_window_bounds(cx),
+            cx,
+        );
+
+        match open_stem_extractor_window(owner_bounds, defaults, cx) {
+            Ok(handle) => self.external_windows.stem_extractor = Some(handle),
+            Err(err) => eprintln!("[stem-extractor] failed to open window: {err}"),
+        }
+    }
+}

--- a/crates/SphereUIComponents/src/layout/window_ops.rs
+++ b/crates/SphereUIComponents/src/layout/window_ops.rs
@@ -186,6 +186,9 @@ pub(crate) struct ExternalWindows {
         Option<gpui::WindowHandle<crate::components::plugin_manager::PluginManagerWindow>>,
     /// Export Arrangement window.
     pub export_arrangement: Option<gpui::WindowHandle<crate::export::ExportArrangementWindow>>,
+    /// Stem Extractor (MDX-NET) dialog window.
+    pub stem_extractor:
+        Option<gpui::WindowHandle<crate::components::stem_extractor_dialog::StemExtractorWindow>>,
     /// Keymap / keyboard shortcuts editor window.
     pub keymap: Option<gpui::WindowHandle<crate::components::keymap_window::KeymapWindow>>,
     /// Built-in Soundfont Player MDI window.

--- a/packages/shared/generated/native-menu.json
+++ b/packages/shared/generated/native-menu.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-07-18T09:23:58.407Z",
+  "generatedAt": "2026-07-19T04:35:19.637Z",
   "menus": [
     {
       "id": "file",
@@ -907,6 +907,27 @@
           "checked": false,
           "danger": false,
           "description": "Scan for installed VST3 and CLAP plug-ins",
+          "children": []
+        },
+        {
+          "id": "audio.sep.tools",
+          "kind": "separator",
+          "enabled": true,
+          "visible": true
+        },
+        {
+          "id": "audio.stem_extractor",
+          "kind": "normal",
+          "label": "Stem Extractor...",
+          "icon": "audio-lines",
+          "shortcut": null,
+          "command": "audio:stem-extractor",
+          "role": null,
+          "enabled": true,
+          "visible": true,
+          "checked": false,
+          "danger": false,
+          "description": "Separate a mix into stems with MDX-NET (CPU/GPU)",
           "children": []
         },
         {

--- a/packages/shared/src/menu/menuItems.ts
+++ b/packages/shared/src/menu/menuItems.ts
@@ -496,6 +496,17 @@ export const APP_MENUS: AppMenuGroup[] = [
       },
       {
         type: "separator",
+        id: "audio.sep.tools",
+      },
+      {
+        id: "audio.stem_extractor",
+        label: "Stem Extractor...",
+        icon: "audio-lines",
+        action: "audio:stem-extractor",
+        description: "Separate a mix into stems with MDX-NET (CPU/GPU)",
+      },
+      {
+        type: "separator",
         id: "audio.sep.routing",
       },
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds the first Stem Extractor slice for Futureboard Studio:

- Promotes `SphereStemExtractor` from a quarantined stub to a real offline library with **MDX-NET** model catalog, **CPU/GPU** device selection, stem checklist, progress/cancel tokens, and a buffer-in / stems-out extract API.
- Updates `SphereAudioProcessor` with a `stem` module that re-exports the shared params/model/device surface (`default_stem_extract_params`, `mdx_net_gpu_params`, `extract_stems`, etc.).
- Adds a native GPUI **Stem Extractor** dialog (source/output browse, MDX-NET model, CPU/GPU device, quality, stem toggles, progress, cancel) matching the compact Export / Add Track dialog language.
- Wires **Audio ▸ Stem Extractor…** (`audio:stem-extractor`) through the shared menu manifest.

## Computer-use UI test
Ran FutureboardNative under nested Weston (software GL + PulseAudio null sink). Verified:

- Dialog opens from **Audio → Stem Extractor…**
- Controls visible: Source/Output Browse, Model, Device, Quality, stem checkboxes, Cancel/Extract
- Model switch MDX-NET → MDX-NET Karaoke updates stems to Vocals + Instrumental
- Device dropdown shows CPU; GPU present but disabled in this VM (expected)
- Stem checkbox toggle works
- Extract stays disabled until source + output are chosen (expected)
- Escape closes the dialog (fixed + retested)
- Dialog reopens cleanly

[Stem Extractor MDX-NET default](https://cursor.com/agents/bc-b21f16de-b6b4-4ee1-beda-024d6a61279e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstem-extractor-mdx-net.webp)
[Model dropdown](https://cursor.com/agents/bc-b21f16de-b6b4-4ee1-beda-024d6a61279e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstem-extractor-model-dropdown.webp)
[Karaoke stems](https://cursor.com/agents/bc-b21f16de-b6b4-4ee1-beda-024d6a61279e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstem-extractor-karaoke.webp)
[Device CPU/GPU](https://cursor.com/agents/bc-b21f16de-b6b4-4ee1-beda-024d6a61279e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstem-extractor-device.webp)

## Notes
- Inference currently uses a deterministic spectral stub backend so the UI/job pipeline is end-to-end without ONNX weights. The public params/model/device API is stable for swapping in real MDX-NET ONNX later via `create_mdx_net_backend`.
- Offline worker path only — no realtime audio-callback involvement.

## Validation
- `cargo test -p SphereFBStemExtractor -p sphere-audio-processor --lib` — pass
- `cargo clippy -p SphereFBStemExtractor -p sphere-audio-processor --all-targets -- -D warnings` — pass
- `cargo check -p sphere_ui_components` / `futureboard_native` — pass
- Computer-use GUI test of Stem Extractor dialog — pass (Escape fix included)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b21f16de-b6b4-4ee1-beda-024d6a61279e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b21f16de-b6b4-4ee1-beda-024d6a61279e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

