### PR TITLE
feat(stem): select Stem Extractor source from audio clips on tracks

### DIFF
--- a/crates/SphereUIComponents/src/components/mod.rs
+++ b/crates/SphereUIComponents/src/components/mod.rs
@@ -180,7 +180,7 @@ pub(crate) use status_bar_view::status_content_signature;
 pub(crate) use status_bar_view::StatusBarView;
 pub use stem_extractor_dialog::{
     open_stem_extractor_window, StemExtractJobState, StemExtractJobSummary,
-    StemExtractorDialogDefaults, StemExtractorWindow, STEM_EXTRACTOR_WINDOW_WIDTH,
+    StemExtractorDialogDefaults, StemExtractorWindow, StemSourceClip, STEM_EXTRACTOR_WINDOW_WIDTH,
 };
 pub use text_input::{text_field, TextInputAction, TextInputState};
 pub use virtual_keyboard::{

--- a/crates/SphereUIComponents/src/components/stem_extractor_dialog.rs
+++ b/crates/SphereUIComponents/src/components/stem_extractor_dialog.rs
@@ -34,9 +34,26 @@ const BUTTON_H: f32 = 28.0;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SelectField {
+    Clip,
     Model,
     Device,
     Quality,
+}
+
+/// One resolvable audio clip on a track, offered as a Stem Extractor source.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StemSourceClip {
+    pub clip_id: String,
+    pub track_id: String,
+    pub track_name: String,
+    pub clip_name: String,
+    pub source_path: PathBuf,
+}
+
+impl StemSourceClip {
+    pub fn label(&self) -> String {
+        format!("{} · {}", self.track_name, self.clip_name)
+    }
 }
 
 pub enum StemExtractJobState {
@@ -70,14 +87,17 @@ struct ActiveJob {
 #[derive(Clone, Debug, Default)]
 pub struct StemExtractorDialogDefaults {
     pub project_name: String,
-    pub suggested_source: Option<PathBuf>,
+    /// Audio clips currently on arrangement tracks with a resolvable media path.
+    pub audio_clips: Vec<StemSourceClip>,
+    /// Preselected clip id (usually the timeline selection).
+    pub selected_clip_id: Option<String>,
     pub suggested_output_dir: Option<PathBuf>,
-    pub selected_clip_label: Option<String>,
 }
 
 pub struct StemExtractorWindow {
     defaults: StemExtractorDialogDefaults,
     params: SphereAudioProcessor::StemExtractParams,
+    selected_clip_id: Option<String>,
     source_path: Option<PathBuf>,
     output_dir: Option<PathBuf>,
     state: StemExtractJobState,
@@ -89,15 +109,22 @@ pub struct StemExtractorWindow {
 
 impl StemExtractorWindow {
     pub fn new(defaults: StemExtractorDialogDefaults, cx: &mut Context<Self>) -> Self {
-        let source_path = defaults.suggested_source.clone();
-        let output_dir = defaults.suggested_output_dir.clone().or_else(|| {
-            source_path
-                .as_ref()
-                .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        let selected_clip_id = defaults
+            .selected_clip_id
+            .clone()
+            .or_else(|| defaults.audio_clips.first().map(|c| c.clip_id.clone()));
+        let source_path = selected_clip_id.as_ref().and_then(|id| {
+            defaults
+                .audio_clips
+                .iter()
+                .find(|c| &c.clip_id == id)
+                .map(|c| c.source_path.clone())
         });
+        let output_dir = defaults.suggested_output_dir.clone();
         Self {
             defaults,
             params: SphereAudioProcessor::default_stem_extract_params(),
+            selected_clip_id,
             source_path,
             output_dir,
             state: StemExtractJobState::Editing,
@@ -105,6 +132,29 @@ impl StemExtractorWindow {
             job: None,
             focus_handle: cx.focus_handle(),
             gpu_available: SphereAudioProcessor::gpu_available(),
+        }
+    }
+
+    fn selected_clip(&self) -> Option<&StemSourceClip> {
+        let id = self.selected_clip_id.as_ref()?;
+        self.defaults
+            .audio_clips
+            .iter()
+            .find(|clip| &clip.clip_id == id)
+    }
+
+    fn select_clip(&mut self, clip_id: &str) {
+        if clip_id.is_empty() || clip_id == "__none__" {
+            return;
+        }
+        if let Some(clip) = self
+            .defaults
+            .audio_clips
+            .iter()
+            .find(|clip| clip.clip_id == clip_id)
+        {
+            self.selected_clip_id = Some(clip.clip_id.clone());
+            self.source_path = Some(clip.source_path.clone());
         }
     }
 
@@ -150,55 +200,11 @@ impl StemExtractorWindow {
     }
 
     fn can_extract(&self) -> bool {
-        self.source_path.is_some()
+        self.selected_clip().is_some()
+            && self.source_path.is_some()
             && self.output_dir.is_some()
             && self.params.validate().is_ok()
             && !self.params.stems.is_empty()
-    }
-
-    fn browse_source(&mut self, cx: &mut Context<Self>) {
-        #[cfg(feature = "native-dialogs")]
-        {
-            let entity = cx.entity().clone();
-            let start = self
-                .source_path
-                .as_ref()
-                .and_then(|p| p.parent().map(|d| d.to_path_buf()))
-                .or_else(|| self.output_dir.clone())
-                .unwrap_or_else(std::env::temp_dir);
-            cx.spawn(async move |_this, cx| {
-                let result = rfd::AsyncFileDialog::new()
-                    .set_title("Choose Source Audio")
-                    .set_directory(&start)
-                    .add_filter(
-                        "Audio",
-                        &["wav", "flac", "mp3", "aiff", "aif", "ogg", "m4a", "rauf"],
-                    )
-                    .pick_file()
-                    .await;
-                if let Some(handle) = result {
-                    let path = handle.path().to_path_buf();
-                    let _ = entity.update(cx, |this, cx| {
-                        this.source_path = Some(path.clone());
-                        if this.output_dir.is_none() {
-                            this.output_dir = path.parent().map(|d| d.to_path_buf());
-                        }
-                        if matches!(this.state, StemExtractJobState::Failed(_)) {
-                            this.state = StemExtractJobState::Editing;
-                        }
-                        cx.notify();
-                    });
-                }
-            })
-            .detach();
-        }
-        #[cfg(not(feature = "native-dialogs"))]
-        {
-            self.state = StemExtractJobState::Failed(
-                "Native file dialogs are unavailable in this build.".into(),
-            );
-            cx.notify();
-        }
     }
 
     fn browse_output(&mut self, cx: &mut Context<Self>) {
@@ -243,11 +249,22 @@ impl StemExtractorWindow {
             cx.notify();
             return;
         }
-        let Some(source_path) = self.source_path.clone() else {
-            self.state = StemExtractJobState::Failed("Choose a source audio file.".into());
+        let Some(clip) = self.selected_clip().cloned() else {
+            self.state = StemExtractJobState::Failed(
+                "Select an audio clip on a track as the source.".into(),
+            );
             cx.notify();
             return;
         };
+        let source_path = clip.source_path.clone();
+        if !source_path.exists() {
+            self.state = StemExtractJobState::Failed(format!(
+                "Audio clip media is missing: {}",
+                source_path.display()
+            ));
+            cx.notify();
+            return;
+        }
         let Some(output_dir) = self.output_dir.clone() else {
             self.state = StemExtractJobState::Failed("Choose an output folder.".into());
             cx.notify();
@@ -267,10 +284,7 @@ impl StemExtractorWindow {
         ));
 
         let params = self.params.clone();
-        let source_stem = source_path
-            .file_stem()
-            .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "stem".to_string());
+        let source_stem = sanitize_file_stem(&clip.clip_name);
         let worker_shared = shared.clone();
         std::thread::Builder::new()
             .name("fb-stem-extract".to_string())
@@ -404,6 +418,7 @@ impl StemExtractorWindow {
 
     fn apply_select(&mut self, field: SelectField, value: &str) {
         match field {
+            SelectField::Clip => self.select_clip(value),
             SelectField::Model => {
                 if let Some(model) = SphereAudioProcessor::StemModel::parse(value) {
                     self.params.set_model(model);
@@ -496,15 +511,10 @@ impl Render for StemExtractorWindow {
 
 impl StemExtractorWindow {
     fn subtitle(&self) -> String {
-        if let Some(label) = &self.defaults.selected_clip_label {
-            format!("Source clip · {label}")
-        } else if let Some(path) = &self.source_path {
-            format!(
-                "MDX-NET stem separation · {}",
-                path.file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| path.display().to_string())
-            )
+        if let Some(clip) = self.selected_clip() {
+            format!("Source clip · {}", clip.label())
+        } else if self.defaults.audio_clips.is_empty() {
+            "MDX-NET · select an audio clip on a track".to_string()
         } else {
             "MDX-NET stem separation · CPU / GPU".to_string()
         }
@@ -519,20 +529,7 @@ impl StemExtractorWindow {
             .py(px(BODY_PAD))
             .gap(px(ROW_GAP))
             .child(section_label("SOURCE"))
-            .child(self.path_row(
-                "Source",
-                self.source_path
-                    .as_ref()
-                    .map(|p| p.display().to_string())
-                    .unwrap_or_else(|| "No file selected".to_string()),
-                "stem-source-browse",
-                {
-                    let target = target.clone();
-                    move |_window, cx| {
-                        let _ = target.update(cx, |this, cx| this.browse_source(cx));
-                    }
-                },
-            ))
+            .child(self.clip_row(target.clone()))
             .child(self.path_row(
                 "Output",
                 self.output_dir
@@ -563,14 +560,50 @@ impl StemExtractorWindow {
 
         if let StemExtractJobState::Failed(message) = &self.state {
             col = col.child(error_banner(message.clone()));
+        } else if self.defaults.audio_clips.is_empty() {
+            col = col.child(hint_banner(
+                "No audio clips on tracks. Import or record audio first.".into(),
+            ));
         } else if !self.can_extract() {
             col = col.child(hint_banner(
-                "Choose a source file, output folder, and at least one stem.".into(),
+                "Select an audio clip, output folder, and at least one stem.".into(),
             ));
         }
 
         col = col.child(self.footer(self.can_extract(), target));
         col.into_any_element()
+    }
+
+    fn clip_row(&self, target: gpui::Entity<Self>) -> impl IntoElement {
+        let empty = self.defaults.audio_clips.is_empty();
+        let options = if empty {
+            vec![SelectOption::new("__none__", "No audio clips on tracks").disabled(true)]
+        } else {
+            self.defaults
+                .audio_clips
+                .iter()
+                .map(|clip| {
+                    let file_name = clip
+                        .source_path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| clip.source_path.display().to_string());
+                    SelectOption::new(clip.clip_id.clone(), clip.label()).description(file_name)
+                })
+                .collect()
+        };
+        let selected = self
+            .selected_clip_id
+            .clone()
+            .unwrap_or_else(|| {
+                if empty {
+                    "__none__".to_string()
+                } else {
+                    String::new()
+                }
+            });
+        let control = self.dropdown(SelectField::Clip, "stem-clip", selected, options, target);
+        self.labeled("Clip", control)
     }
 
     fn model_row(&self, target: gpui::Entity<Self>) -> impl IntoElement {

--- a/crates/SphereUIComponents/src/components/stem_extractor_dialog.rs
+++ b/crates/SphereUIComponents/src/components/stem_extractor_dialog.rs
@@ -425,7 +425,10 @@ impl StemExtractorWindow {
 
 impl Render for StemExtractorWindow {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let _ = window;
+        // Keep dialog key focus so Escape/Enter route here (not the studio).
+        if !self.focus_handle.is_focused(window) {
+            self.focus_handle.focus(window, cx);
+        }
         let target = cx.entity().clone();
         let body = match &self.state {
             StemExtractJobState::Editing | StemExtractJobState::Failed(_) => {

--- a/crates/SphereUIComponents/src/layout/stem_extract_ops.rs
+++ b/crates/SphereUIComponents/src/layout/stem_extract_ops.rs
@@ -1,14 +1,16 @@
 //! StudioLayout integration for the Stem Extractor dialog.
 //!
-//! Captures a plain source path / output folder suggestion from the current
-//! selection, then opens the external Stem Extractor window. The window owns
-//! the background MDX-NET job — StudioLayout holds only the window handle.
+//! Captures audio clips currently on arrangement tracks (plain owned data),
+//! then opens the external Stem Extractor window. The window owns the
+//! background MDX-NET job — StudioLayout holds only the window handle.
 
 use gpui::{Bounds, Context};
 
 use super::StudioLayout;
 use crate::components::timeline::timeline_state::ClipType;
-use crate::components::{open_stem_extractor_window, StemExtractorDialogDefaults};
+use crate::components::{
+    open_stem_extractor_window, StemExtractorDialogDefaults, StemSourceClip,
+};
 
 impl StudioLayout {
     pub(super) fn open_stem_extractor_external_window(
@@ -39,23 +41,14 @@ impl StudioLayout {
             .as_ref()
             .map(|p| p.to_path_buf());
 
-        let mut suggested_source = None;
-        let mut selected_clip_label = None;
-        if let Some(clip_id) = tl_state.selection.selected_clip_ids.first() {
-            if let Some((_track, clip)) = tl_state.find_clip(clip_id) {
-                selected_clip_label = Some(clip.name.clone());
-                if let ClipType::Audio {
-                    source_path: Some(path),
-                    ..
-                } = &clip.clip_type
-                {
-                    let path = std::path::PathBuf::from(path);
-                    if path.exists() {
-                        suggested_source = Some(path);
-                    }
-                }
-            }
-        }
+        let audio_clips = collect_audio_source_clips(&tl_state);
+        let selected_clip_id = tl_state
+            .selection
+            .selected_clip_ids
+            .iter()
+            .find(|id| audio_clips.iter().any(|clip| clip.clip_id == **id))
+            .cloned()
+            .or_else(|| audio_clips.first().map(|clip| clip.clip_id.clone()));
 
         let suggested_output_dir = project_root.as_ref().map(|root| {
             let dir = root.join("Rendered").join("Stems");
@@ -65,9 +58,9 @@ impl StudioLayout {
 
         let defaults = StemExtractorDialogDefaults {
             project_name,
-            suggested_source,
+            audio_clips,
+            selected_clip_id,
             suggested_output_dir,
-            selected_clip_label,
         };
 
         let owner_bounds = crate::window_position::resolve_owner_bounds_with_preferred(
@@ -80,5 +73,94 @@ impl StudioLayout {
             Ok(handle) => self.external_windows.stem_extractor = Some(handle),
             Err(err) => eprintln!("[stem-extractor] failed to open window: {err}"),
         }
+    }
+}
+
+fn collect_audio_source_clips(
+    tl_state: &crate::components::timeline::timeline_state::TimelineState,
+) -> Vec<StemSourceClip> {
+    let mut clips = Vec::new();
+    for track in &tl_state.tracks {
+        for clip in &track.clips {
+            let ClipType::Audio {
+                source_path: Some(path),
+                ..
+            } = &clip.clip_type
+            else {
+                continue;
+            };
+            let path = std::path::PathBuf::from(path);
+            if !path.exists() {
+                continue;
+            }
+            clips.push(StemSourceClip {
+                clip_id: clip.id.clone(),
+                track_id: track.id.clone(),
+                track_name: track.name.clone(),
+                clip_name: clip.name.clone(),
+                source_path: path,
+            });
+        }
+    }
+    clips
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::timeline::timeline_state::{ClipState, ClipType, TimelineState};
+
+    #[test]
+    fn collect_only_resolvable_audio_clips() {
+        let mut state = TimelineState::default();
+        let track_id = state.create_audio_track();
+        {
+            let track = state
+                .tracks
+                .iter_mut()
+                .find(|track| track.id == track_id)
+                .expect("audio track");
+            track.name = "Drums".into();
+            track.clips.push(ClipState {
+                id: "clip-a".into(),
+                name: "Loop A".into(),
+                start_beat: 0.0,
+                duration_beats: 4.0,
+                source_duration_seconds: Some(2.0),
+                offset_beats: 0.0,
+                gain: 1.0,
+                clip_type: ClipType::Audio {
+                    file_id: "a".into(),
+                    source_path: Some("/tmp/does-not-exist-stem.wav".into()),
+                },
+                muted: false,
+                audio_import: Default::default(),
+                stretch: Default::default(),
+            });
+            let existing = std::env::temp_dir().join("fb-stem-source-test.wav");
+            std::fs::write(&existing, b"RIFF").unwrap();
+            track.clips.push(ClipState {
+                id: "clip-b".into(),
+                name: "Loop B".into(),
+                start_beat: 4.0,
+                duration_beats: 4.0,
+                source_duration_seconds: Some(2.0),
+                offset_beats: 0.0,
+                gain: 1.0,
+                clip_type: ClipType::Audio {
+                    file_id: "b".into(),
+                    source_path: Some(existing.display().to_string()),
+                },
+                muted: false,
+                audio_import: Default::default(),
+                stretch: Default::default(),
+            });
+        }
+
+        let clips = collect_audio_source_clips(&state);
+        assert_eq!(clips.len(), 1);
+        assert_eq!(clips[0].clip_id, "clip-b");
+        assert_eq!(clips[0].label(), "Drums · Loop B");
+        let _ = std::fs::remove_file(std::env::temp_dir().join("fb-stem-source-test.wav"));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to #38: Stem Extractor source selection now picks an **audio clip on a track** instead of browsing for an arbitrary file.

- Replaces the Source file Browse control with a **Clip** dropdown labeled `Track · Clip`
- Catalog comes from arrangement audio clips that have a resolvable `source_path` on disk
- Preselects the timeline selection when that clip is in the catalog (else the first clip)
- Empty state: “No audio clips on tracks. Import or record audio first.”
- Also includes the Escape-focus fix so the dialog closes with Escape

## Computer-use UI test
Seeded project `StemClipTest` with one arrangement audio clip, launched FutureboardNative under nested Weston (software GL + Pulse null sink). Verified:

- Dialog opens from **Audio → Stem Extractor…**
- Source is a **Clip** dropdown (no input Browse)
- Selected value: `Audio 1 · fb-stem-clip-source`
- Dropdown lists that track clip
- Output still has Browse

[Stem Extractor Clip source](https://cursor.com/agents/bc-b21f16de-b6b4-4ee1-beda-024d6a61279e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstem-extractor-clip-source.webp)
[Stem Extractor Clip dropdown](https://cursor.com/agents/bc-b21f16de-b6b4-4ee1-beda-024d6a61279e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstem-extractor-clip-dropdown.webp)

## Validation
- `cargo test -p sphere_ui_components collect_only_resolvable_audio_clips` — pass
- `cargo check -p sphere_ui_components -p futureboard_native` — pass
- Computer-use GUI retest of Clip dropdown with a real track clip — pass

## Notes
- Output folder Browse is unchanged (defaults to project `Rendered/Stems` when a project folder exists)
- Inference still uses the spectral stub backend from #38


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b21f16de-b6b4-4ee1-beda-024d6a61279e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b21f16de-b6b4-4ee1-beda-024d6a61279e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

