### PR TITLE
feat(stem): download MDX-NET models and expand catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,11 @@ dependencies = [
 name = "SphereFBStemExtractor"
 version = "0.1.0"
 dependencies = [
+ "dirs 5.0.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "ureq",
 ]
 
 [[package]]

--- a/crates/SphereAudioProcessor/src/lib.rs
+++ b/crates/SphereAudioProcessor/src/lib.rs
@@ -12,11 +12,13 @@ pub mod stem;
 pub mod stretching;
 
 pub use stem::{
-    create_mdx_net_backend, default_stem_extract_params, extract_stems, gpu_available,
-    mdx_net_gpu_params, resolve_device, InferBackendKind, InferDevice, StemExtractCancelToken,
-    StemExtractError, StemExtractInput, StemExtractOutput, StemExtractParams, StemExtractProgress,
-    StemExtractQuality, StemExtractResult, StemExtractStage, StemInferBackend, StemKind, StemModel,
-    StemModelInfo, StemSet, STEM_MODELS,
+    create_mdx_net_backend, default_models_dir, default_stem_extract_params, download_model,
+    ensure_models_dir, extract_stems, gpu_available, mdx_net_gpu_params, model_installed,
+    resolve_device, resolve_installed_model_files, InferBackendKind, InferDevice,
+    StemExtractCancelToken, StemExtractError, StemExtractInput, StemExtractOutput,
+    StemExtractParams, StemExtractProgress, StemExtractQuality, StemExtractResult,
+    StemExtractStage, StemInferBackend, StemKind, StemModel, StemModelDownloadProgress,
+    StemModelFile, StemModelInfo, StemModelPackage, StemSet, STEM_MODELS, UVR_MODEL_RELEASE_BASE,
 };
 pub use stretching::{
     StretchAlgorithm, StretchBackend, StretchError, StretchMode, StretchParams, StretchProcessor,

--- a/crates/SphereAudioProcessor/src/stem/mod.rs
+++ b/crates/SphereAudioProcessor/src/stem/mod.rs
@@ -7,10 +7,13 @@
 //! audio callback.
 
 pub use sphere_stem_extractor::{
-    create_mdx_net_backend, extract_stems, gpu_available, resolve_device, InferBackendKind,
-    InferDevice, StemExtractCancelToken, StemExtractError, StemExtractInput, StemExtractOutput,
-    StemExtractParams, StemExtractProgress, StemExtractQuality, StemExtractResult, StemExtractStage,
-    StemInferBackend, StemKind, StemModel, StemModelInfo, StemSet, STEM_MODELS,
+    create_mdx_net_backend, default_models_dir, download_model, ensure_models_dir, extract_stems,
+    gpu_available, model_installed, resolve_device, resolve_installed_model_files,
+    InferBackendKind, InferDevice, StemExtractCancelToken, StemExtractError, StemExtractInput,
+    StemExtractOutput, StemExtractParams, StemExtractProgress, StemExtractQuality,
+    StemExtractResult, StemExtractStage, StemInferBackend, StemKind, StemModel,
+    StemModelDownloadProgress, StemModelFile, StemModelInfo, StemModelPackage, StemSet,
+    STEM_MODELS, UVR_MODEL_RELEASE_BASE,
 };
 
 /// Convenience constructor matching the Stem Extractor dialog defaults:

--- a/crates/SphereStemExtractor/Cargo.toml
+++ b/crates/SphereStemExtractor/Cargo.toml
@@ -11,8 +11,10 @@ name = "SphereStemExtractor"
 path = "src/lib.rs"
 
 [dependencies]
+dirs.workspace = true
 serde.workspace = true
 thiserror.workspace = true
+ureq.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/SphereStemExtractor/src/download.rs
+++ b/crates/SphereStemExtractor/src/download.rs
@@ -1,0 +1,320 @@
+//! Offline MDX-NET / UVR model package download.
+//!
+//! Classification: scanner/offline path (worker thread only). Downloads ONNX
+//! weights into `Documents/Futureboard Studio/Utilities/Models/`.
+
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::error::StemExtractError;
+use crate::model::{StemModel, StemModelPackage};
+use crate::progress::StemExtractCancelToken;
+
+/// Public UVR model release hosting MDX-NET ONNX weights.
+pub const UVR_MODEL_RELEASE_BASE: &str =
+    "https://github.com/TRvlvr/model_repo/releases/download/all_public_uvr_models";
+
+/// Progress event while downloading one or more ONNX files for a model.
+#[derive(Clone, Debug)]
+pub struct StemModelDownloadProgress {
+    pub model: StemModel,
+    pub file_name: String,
+    pub file_index: usize,
+    pub file_count: usize,
+    pub bytes_downloaded: u64,
+    pub bytes_total: Option<u64>,
+    pub percent: f32,
+    pub detail: String,
+}
+
+impl StemModelDownloadProgress {
+    pub fn new(
+        model: StemModel,
+        file_name: impl Into<String>,
+        file_index: usize,
+        file_count: usize,
+        bytes_downloaded: u64,
+        bytes_total: Option<u64>,
+        percent: f32,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            model,
+            file_name: file_name.into(),
+            file_index,
+            file_count,
+            bytes_downloaded,
+            bytes_total,
+            percent: percent.clamp(0.0, 100.0),
+            detail: detail.into(),
+        }
+    }
+}
+
+/// Default install directory: `~/Documents/Futureboard Studio/Utilities/Models/`.
+pub fn default_models_dir() -> PathBuf {
+    let doc = dirs::document_dir().unwrap_or_else(|| PathBuf::from("."));
+    doc.join("Futureboard Studio")
+        .join("Utilities")
+        .join("Models")
+}
+
+/// Ensure the models directory exists.
+pub fn ensure_models_dir(models_dir: &Path) -> Result<(), StemExtractError> {
+    fs::create_dir_all(models_dir).map_err(|e| {
+        StemExtractError::Backend(format!(
+            "could not create model folder {}: {e}",
+            models_dir.display()
+        ))
+    })
+}
+
+/// True when every ONNX file for `model` is present under `models_dir`.
+pub fn model_installed(model: StemModel, models_dir: &Path) -> bool {
+    let package = model.package();
+    package.files.iter().all(|file| {
+        let path = models_dir.join(file.file_name);
+        path.is_file()
+            && fs::metadata(&path)
+                .map(|meta| meta.len() > 1_024)
+                .unwrap_or(false)
+    })
+}
+
+/// Absolute paths for installed model files, or `None` if incomplete.
+pub fn resolve_installed_model_files(
+    model: StemModel,
+    models_dir: &Path,
+) -> Option<Vec<PathBuf>> {
+    if !model_installed(model, models_dir) {
+        return None;
+    }
+    Some(
+        model
+            .package()
+            .files
+            .iter()
+            .map(|file| models_dir.join(file.file_name))
+            .collect(),
+    )
+}
+
+fn download_url(file_name: &str) -> String {
+    format!("{UVR_MODEL_RELEASE_BASE}/{file_name}")
+}
+
+/// Download every ONNX file for `model` into `models_dir`.
+///
+/// Existing complete installs are a no-op. Partial files are written to
+/// `*.partial` then atomically renamed on success.
+pub fn download_model(
+    model: StemModel,
+    models_dir: &Path,
+    cancel: &StemExtractCancelToken,
+    on_progress: &mut dyn FnMut(StemModelDownloadProgress),
+) -> Result<(), StemExtractError> {
+    ensure_models_dir(models_dir)?;
+    let package = model.package();
+    if model_installed(model, models_dir) {
+        on_progress(StemModelDownloadProgress::new(
+            model,
+            package.files.first().map(|f| f.file_name).unwrap_or("model"),
+            package.file_count().saturating_sub(1),
+            package.file_count().max(1),
+            package.approx_bytes,
+            Some(package.approx_bytes),
+            100.0,
+            format!("{} already installed", model.label()),
+        ));
+        return Ok(());
+    }
+
+    let file_count = package.file_count().max(1);
+    for (file_index, file) in package.files.iter().enumerate() {
+        if cancel.is_cancelled() {
+            return Err(StemExtractError::Cancelled);
+        }
+        let dest = models_dir.join(file.file_name);
+        if dest.is_file()
+            && fs::metadata(&dest)
+                .map(|meta| meta.len() > 1_024)
+                .unwrap_or(false)
+        {
+            let base = (file_index as f32 / file_count as f32) * 100.0;
+            on_progress(StemModelDownloadProgress::new(
+                model,
+                file.file_name,
+                file_index,
+                file_count,
+                0,
+                None,
+                base,
+                format!("Skipping existing {}", file.file_name),
+            ));
+            continue;
+        }
+        download_one_file(
+            model,
+            package,
+            file.file_name,
+            file_index,
+            file_count,
+            &dest,
+            cancel,
+            on_progress,
+        )?;
+    }
+
+    if !model_installed(model, models_dir) {
+        return Err(StemExtractError::Backend(format!(
+            "download finished but {} is still incomplete",
+            model.label()
+        )));
+    }
+    on_progress(StemModelDownloadProgress::new(
+        model,
+        package
+            .files
+            .last()
+            .map(|f| f.file_name)
+            .unwrap_or("model"),
+        file_count.saturating_sub(1),
+        file_count,
+        package.approx_bytes,
+        Some(package.approx_bytes),
+        100.0,
+        format!("{} installed", model.label()),
+    ));
+    Ok(())
+}
+
+fn download_one_file(
+    model: StemModel,
+    package: StemModelPackage,
+    file_name: &str,
+    file_index: usize,
+    file_count: usize,
+    dest: &Path,
+    cancel: &StemExtractCancelToken,
+    on_progress: &mut dyn FnMut(StemModelDownloadProgress),
+) -> Result<(), StemExtractError> {
+    let url = download_url(file_name);
+    let partial = dest.with_extension("onnx.partial");
+    let _ = fs::remove_file(&partial);
+
+    on_progress(StemModelDownloadProgress::new(
+        model,
+        file_name,
+        file_index,
+        file_count,
+        0,
+        None,
+        (file_index as f32 / file_count as f32) * 100.0,
+        format!("Connecting to {}", package.source_label),
+    ));
+
+    let response = ureq::get(&url).call().map_err(|e| {
+        StemExtractError::Backend(format!("download failed for {file_name}: {e}"))
+    })?;
+
+    let content_length = response
+        .headers()
+        .get("Content-Length")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|n| *n > 0);
+
+    let mut reader = response.into_body().into_reader();
+    let mut file = File::create(&partial).map_err(|e| {
+        StemExtractError::Backend(format!("could not create {}: {e}", partial.display()))
+    })?;
+
+    let mut buf = [0u8; 64 * 1024];
+    let mut downloaded = 0u64;
+    let file_span = 100.0 / file_count as f32;
+    let file_base = file_index as f32 * file_span;
+
+    loop {
+        if cancel.is_cancelled() {
+            let _ = fs::remove_file(&partial);
+            return Err(StemExtractError::Cancelled);
+        }
+        let n = reader.read(&mut buf).map_err(|e| {
+            StemExtractError::Backend(format!("download read failed for {file_name}: {e}"))
+        })?;
+        if n == 0 {
+            break;
+        }
+        file.write_all(&buf[..n]).map_err(|e| {
+            StemExtractError::Backend(format!("download write failed for {file_name}: {e}"))
+        })?;
+        downloaded += n as u64;
+
+        let within = match content_length {
+            Some(total) if total > 0 => (downloaded as f32 / total as f32).clamp(0.0, 1.0),
+            _ => ((downloaded as f32) / (package.approx_bytes.max(1) as f32 / file_count as f32))
+                .clamp(0.0, 0.95),
+        };
+        let percent = file_base + within * file_span;
+        on_progress(StemModelDownloadProgress::new(
+            model,
+            file_name,
+            file_index,
+            file_count,
+            downloaded,
+            content_length,
+            percent,
+            format!("Downloading {file_name}"),
+        ));
+    }
+
+    file.flush().map_err(|e| {
+        StemExtractError::Backend(format!("download flush failed for {file_name}: {e}"))
+    })?;
+    drop(file);
+
+    if downloaded < 1_024 {
+        let _ = fs::remove_file(&partial);
+        return Err(StemExtractError::Backend(format!(
+            "download for {file_name} was too small ({downloaded} bytes)"
+        )));
+    }
+
+    fs::rename(&partial, dest).map_err(|e| {
+        StemExtractError::Backend(format!(
+            "could not finalize {}: {e}",
+            dest.display()
+        ))
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn installed_requires_every_package_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "fb-stem-models-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        assert!(!model_installed(StemModel::MdxNetKaraoke, &dir));
+        let path = dir.join("UVR_MDXNET_KARA.onnx");
+        fs::write(&path, vec![0u8; 2048]).unwrap();
+        assert!(model_installed(StemModel::MdxNetKaraoke, &dir));
+        assert!(!model_installed(StemModel::MdxNet, &dir));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn default_models_dir_ends_with_utilities_models() {
+        let dir = default_models_dir();
+        assert!(dir.ends_with(Path::new("Utilities").join("Models")));
+    }
+}

--- a/crates/SphereStemExtractor/src/download.rs
+++ b/crates/SphereStemExtractor/src/download.rs
@@ -54,10 +54,20 @@ impl StemModelDownloadProgress {
 
 /// Default install directory: `~/Documents/Futureboard Studio/Utilities/Models/`.
 pub fn default_models_dir() -> PathBuf {
-    let doc = dirs::document_dir().unwrap_or_else(|| PathBuf::from("."));
-    doc.join("Futureboard Studio")
+    documents_dir()
+        .join("Futureboard Studio")
         .join("Utilities")
         .join("Models")
+}
+
+fn documents_dir() -> PathBuf {
+    if let Some(dir) = dirs::document_dir() {
+        return dir;
+    }
+    if let Some(home) = dirs::home_dir() {
+        return home.join("Documents");
+    }
+    PathBuf::from("Documents")
 }
 
 /// Ensure the models directory exists.
@@ -316,5 +326,37 @@ mod tests {
     fn default_models_dir_ends_with_utilities_models() {
         let dir = default_models_dir();
         assert!(dir.ends_with(Path::new("Utilities").join("Models")));
+        assert!(
+            !dir.starts_with("."),
+            "models dir must not resolve to a relative CWD path: {}",
+            dir.display()
+        );
+    }
+
+    #[test]
+    fn live_download_karaoke_when_enabled() {
+        if std::env::var_os("STEM_LIVE_DL").is_none() {
+            return;
+        }
+        let dir = default_models_dir();
+        ensure_models_dir(&dir).unwrap();
+        let cancel = crate::progress::StemExtractCancelToken::new();
+        download_model(
+            StemModel::MdxNetKaraoke,
+            &dir,
+            &cancel,
+            &mut |progress| {
+                eprintln!(
+                    "[dl] {:.0}% {} ({})",
+                    progress.percent, progress.detail, progress.file_name
+                );
+            },
+        )
+        .unwrap();
+        assert!(model_installed(StemModel::MdxNetKaraoke, &dir));
+        let path = dir.join("UVR_MDXNET_KARA.onnx");
+        let len = fs::metadata(&path).unwrap().len();
+        eprintln!("downloaded bytes={len} path={}", path.display());
+        assert!(len > 1_000_000);
     }
 }

--- a/crates/SphereStemExtractor/src/lib.rs
+++ b/crates/SphereStemExtractor/src/lib.rs
@@ -1,8 +1,9 @@
 //! Offline stem extraction for Futureboard Studio.
 //!
 //! This crate owns the MDX-NET model catalog, CPU/GPU device selection, stem
-//! slot selection, and a buffer-in / stems-out extraction API. It does **not**
-//! perform filesystem I/O or touch the realtime audio callback.
+//! slot selection, ONNX package download into
+//! `Documents/Futureboard Studio/Utilities/Models/`, and a buffer-in /
+//! stems-out extraction API. It does **not** touch the realtime audio callback.
 //!
 //! Classification: scanner/offline path (worker thread only).
 //!
@@ -13,6 +14,7 @@
 
 pub mod backend;
 pub mod device;
+pub mod download;
 pub mod error;
 pub mod extractor;
 pub mod model;
@@ -22,9 +24,13 @@ pub mod stems;
 
 pub use backend::{create_mdx_net_backend, InferBackendKind, StemInferBackend};
 pub use device::{gpu_available, resolve_device, InferDevice};
+pub use download::{
+    default_models_dir, download_model, ensure_models_dir, model_installed,
+    resolve_installed_model_files, StemModelDownloadProgress, UVR_MODEL_RELEASE_BASE,
+};
 pub use error::StemExtractError;
 pub use extractor::{extract_stems, StemExtractInput, StemExtractOutput, StemExtractResult};
-pub use model::{StemModel, StemModelInfo, STEM_MODELS};
+pub use model::{StemModel, StemModelFile, StemModelInfo, StemModelPackage, STEM_MODELS};
 pub use params::{StemExtractParams, StemExtractQuality};
 pub use progress::{StemExtractCancelToken, StemExtractProgress, StemExtractStage};
 pub use stems::{StemKind, StemSet};

--- a/crates/SphereStemExtractor/src/model.rs
+++ b/crates/SphereStemExtractor/src/model.rs
@@ -6,11 +6,21 @@ use crate::stems::StemKind;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum StemModel {
-    /// Classic MDX-NET 4-stem separator (vocals / drums / bass / other).
+    /// Classic 4-stem MDX-NET pack (Kuielab A: vocals / drums / bass / other).
     #[default]
     MdxNet,
     /// MDX-NET karaoke variant (vocals + instrumental).
     MdxNetKaraoke,
+    /// UVR MDX-NET Main (vocals + instrumental).
+    MdxNetMain,
+    /// Fine-tuned vocal MDX-NET (vocals + instrumental residual).
+    MdxNetVocFt,
+    /// High-quality instrumental MDX-NET (instrumental + vocals residual).
+    MdxNetInstHq,
+    /// Kim Vocal 2 (vocals + instrumental residual).
+    KimVocal,
+    /// Kim Instrumental (instrumental + vocals residual).
+    KimInst,
 }
 
 impl StemModel {
@@ -18,6 +28,11 @@ impl StemModel {
         match self {
             Self::MdxNet => "mdx-net",
             Self::MdxNetKaraoke => "mdx-net-karaoke",
+            Self::MdxNetMain => "mdx-net-main",
+            Self::MdxNetVocFt => "mdx-net-voc-ft",
+            Self::MdxNetInstHq => "mdx-net-inst-hq",
+            Self::KimVocal => "kim-vocal",
+            Self::KimInst => "kim-inst",
         }
     }
 
@@ -25,13 +40,23 @@ impl StemModel {
         match self {
             Self::MdxNet => "MDX-NET",
             Self::MdxNetKaraoke => "MDX-NET Karaoke",
+            Self::MdxNetMain => "MDX-NET Main",
+            Self::MdxNetVocFt => "MDX-NET Voc FT",
+            Self::MdxNetInstHq => "MDX-NET Inst HQ",
+            Self::KimVocal => "Kim Vocal 2",
+            Self::KimInst => "Kim Instrumental",
         }
     }
 
     pub fn description(self) -> &'static str {
         match self {
-            Self::MdxNet => "4-stem separation: vocals, drums, bass, other",
-            Self::MdxNetKaraoke => "2-stem separation: vocals and instrumental",
+            Self::MdxNet => "4-stem Kuielab A: vocals, drums, bass, other",
+            Self::MdxNetKaraoke => "2-stem karaoke: vocals and instrumental",
+            Self::MdxNetMain => "2-stem UVR Main: vocals and instrumental",
+            Self::MdxNetVocFt => "2-stem vocal fine-tune: vocals and instrumental",
+            Self::MdxNetInstHq => "2-stem instrumental HQ: instrumental and vocals",
+            Self::KimVocal => "2-stem Kim Vocal 2: vocals and instrumental",
+            Self::KimInst => "2-stem Kim Instrumental: instrumental and vocals",
         }
     }
 
@@ -39,6 +64,11 @@ impl StemModel {
         match value {
             "mdx-net" | "mdxnet" | "MDX-NET" => Some(Self::MdxNet),
             "mdx-net-karaoke" | "mdxnet-karaoke" | "MDX-NET Karaoke" => Some(Self::MdxNetKaraoke),
+            "mdx-net-main" | "mdxnet-main" | "MDX-NET Main" => Some(Self::MdxNetMain),
+            "mdx-net-voc-ft" | "mdxnet-voc-ft" | "MDX-NET Voc FT" => Some(Self::MdxNetVocFt),
+            "mdx-net-inst-hq" | "mdxnet-inst-hq" | "MDX-NET Inst HQ" => Some(Self::MdxNetInstHq),
+            "kim-vocal" | "kim-vocal-2" | "Kim Vocal 2" => Some(Self::KimVocal),
+            "kim-inst" | "kim-instrumental" | "Kim Instrumental" => Some(Self::KimInst),
             _ => None,
         }
     }
@@ -51,12 +81,121 @@ impl StemModel {
                 StemKind::Bass,
                 StemKind::Other,
             ],
-            Self::MdxNetKaraoke => &[StemKind::Vocals, StemKind::Instrumental],
+            Self::MdxNetKaraoke
+            | Self::MdxNetMain
+            | Self::MdxNetVocFt
+            | Self::MdxNetInstHq
+            | Self::KimVocal
+            | Self::KimInst => &[StemKind::Vocals, StemKind::Instrumental],
         }
     }
 
     pub fn supports_stem(self, stem: StemKind) -> bool {
         self.default_stems().contains(&stem)
+    }
+
+    /// Downloadable ONNX weight package for this model (UVR public models).
+    pub fn package(self) -> StemModelPackage {
+        match self {
+            Self::MdxNet => StemModelPackage {
+                model: self,
+                files: &[
+                    StemModelFile {
+                        file_name: "kuielab_a_vocals.onnx",
+                    },
+                    StemModelFile {
+                        file_name: "kuielab_a_drums.onnx",
+                    },
+                    StemModelFile {
+                        file_name: "kuielab_a_bass.onnx",
+                    },
+                    StemModelFile {
+                        file_name: "kuielab_a_other.onnx",
+                    },
+                ],
+                approx_bytes: 116_000_000,
+                source_label: "UVR / Kuielab A",
+            },
+            Self::MdxNetKaraoke => StemModelPackage {
+                model: self,
+                files: &[StemModelFile {
+                    file_name: "UVR_MDXNET_KARA.onnx",
+                }],
+                approx_bytes: 29_700_000,
+                source_label: "UVR MDX-NET Karaoke",
+            },
+            Self::MdxNetMain => StemModelPackage {
+                model: self,
+                files: &[StemModelFile {
+                    file_name: "UVR_MDXNET_Main.onnx",
+                }],
+                approx_bytes: 66_800_000,
+                source_label: "UVR MDX-NET Main",
+            },
+            Self::MdxNetVocFt => StemModelPackage {
+                model: self,
+                files: &[StemModelFile {
+                    file_name: "UVR-MDX-NET-Voc_FT.onnx",
+                }],
+                approx_bytes: 66_800_000,
+                source_label: "UVR MDX-NET Voc FT",
+            },
+            Self::MdxNetInstHq => StemModelPackage {
+                model: self,
+                files: &[StemModelFile {
+                    file_name: "UVR-MDX-NET-Inst_HQ_3.onnx",
+                }],
+                approx_bytes: 66_800_000,
+                source_label: "UVR MDX-NET Inst HQ 3",
+            },
+            Self::KimVocal => StemModelPackage {
+                model: self,
+                files: &[StemModelFile {
+                    file_name: "Kim_Vocal_2.onnx",
+                }],
+                approx_bytes: 66_800_000,
+                source_label: "Kim Vocal 2",
+            },
+            Self::KimInst => StemModelPackage {
+                model: self,
+                files: &[StemModelFile {
+                    file_name: "Kim_Inst.onnx",
+                }],
+                approx_bytes: 66_800_000,
+                source_label: "Kim Instrumental",
+            },
+        }
+    }
+}
+
+/// One ONNX weight file belonging to a [`StemModelPackage`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StemModelFile {
+    pub file_name: &'static str,
+}
+
+/// Downloadable model package metadata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StemModelPackage {
+    pub model: StemModel,
+    pub files: &'static [StemModelFile],
+    /// Approximate total download size in bytes (UI hint only).
+    pub approx_bytes: u64,
+    pub source_label: &'static str,
+}
+
+impl StemModelPackage {
+    pub fn file_count(self) -> usize {
+        self.files.len()
+    }
+
+    pub fn approx_size_label(self) -> String {
+        let mb = (self.approx_bytes as f64) / (1024.0 * 1024.0);
+        if mb >= 100.0 {
+            format!("~{:.0} MB", mb)
+        } else {
+            format!("~{:.0} MB", mb)
+        }
     }
 }
 
@@ -75,13 +214,43 @@ pub const STEM_MODELS: &[StemModelInfo] = &[
         model: StemModel::MdxNet,
         id: "mdx-net",
         label: "MDX-NET",
-        description: "4-stem separation: vocals, drums, bass, other",
+        description: "4-stem Kuielab A: vocals, drums, bass, other",
     },
     StemModelInfo {
         model: StemModel::MdxNetKaraoke,
         id: "mdx-net-karaoke",
         label: "MDX-NET Karaoke",
-        description: "2-stem separation: vocals and instrumental",
+        description: "2-stem karaoke: vocals and instrumental",
+    },
+    StemModelInfo {
+        model: StemModel::MdxNetMain,
+        id: "mdx-net-main",
+        label: "MDX-NET Main",
+        description: "2-stem UVR Main: vocals and instrumental",
+    },
+    StemModelInfo {
+        model: StemModel::MdxNetVocFt,
+        id: "mdx-net-voc-ft",
+        label: "MDX-NET Voc FT",
+        description: "2-stem vocal fine-tune: vocals and instrumental",
+    },
+    StemModelInfo {
+        model: StemModel::MdxNetInstHq,
+        id: "mdx-net-inst-hq",
+        label: "MDX-NET Inst HQ",
+        description: "2-stem instrumental HQ: instrumental and vocals",
+    },
+    StemModelInfo {
+        model: StemModel::KimVocal,
+        id: "kim-vocal",
+        label: "Kim Vocal 2",
+        description: "2-stem Kim Vocal 2: vocals and instrumental",
+    },
+    StemModelInfo {
+        model: StemModel::KimInst,
+        id: "kim-inst",
+        label: "Kim Instrumental",
+        description: "2-stem Kim Instrumental: instrumental and vocals",
     },
 ];
 
@@ -97,5 +266,8 @@ mod tests {
         assert!(StemModel::MdxNet.supports_stem(StemKind::Vocals));
         assert!(!StemModel::MdxNet.supports_stem(StemKind::Instrumental));
         assert!(StemModel::MdxNetKaraoke.supports_stem(StemKind::Instrumental));
+        assert_eq!(STEM_MODELS.len(), 7);
+        assert_eq!(StemModel::MdxNet.package().file_count(), 4);
+        assert_eq!(StemModel::KimVocal.package().file_count(), 1);
     }
 }

--- a/crates/SphereUIComponents/src/components/stem_extractor_dialog.rs
+++ b/crates/SphereUIComponents/src/components/stem_extractor_dialog.rs
@@ -25,7 +25,7 @@ use crate::theme::{self, Colors};
 use crate::window_position::{apply_owner_display, centered_window_bounds};
 
 pub const STEM_EXTRACTOR_WINDOW_WIDTH: f32 = 520.0;
-const STEM_EXTRACTOR_WINDOW_HEIGHT: f32 = 480.0;
+const STEM_EXTRACTOR_WINDOW_HEIGHT: f32 = 560.0;
 const BODY_PAD: f32 = 14.0;
 const ROW_GAP: f32 = 9.0;
 const LABEL_W: f32 = 96.0;
@@ -103,6 +103,23 @@ struct ActiveJob {
     cancel: SphereAudioProcessor::StemExtractCancelToken,
 }
 
+#[derive(Default)]
+struct SharedDownloadJob {
+    progress: Option<SphereAudioProcessor::StemModelDownloadProgress>,
+    done: Option<Result<(), String>>,
+}
+
+struct ActiveDownload {
+    shared: Arc<Mutex<SharedDownloadJob>>,
+    cancel: SphereAudioProcessor::StemExtractCancelToken,
+}
+
+enum ModelDownloadUi {
+    Idle,
+    Running(SphereAudioProcessor::StemModelDownloadProgress),
+    Failed(String),
+}
+
 /// Plain data captured when the dialog opens — never a live entity borrow.
 #[derive(Clone, Debug, Default)]
 pub struct StemExtractorDialogDefaults {
@@ -113,6 +130,8 @@ pub struct StemExtractorDialogDefaults {
     pub selected_clip_id: Option<String>,
     /// Project root used for rendered stem WAV files (`Rendered/Stems`).
     pub project_root: Option<PathBuf>,
+    /// ONNX install folder (`Documents/Futureboard Studio/Utilities/Models`).
+    pub models_dir: Option<PathBuf>,
 }
 
 pub struct StemExtractorWindow {
@@ -123,6 +142,10 @@ pub struct StemExtractorWindow {
     state: StemExtractJobState,
     open_select: Option<SelectField>,
     job: Option<ActiveJob>,
+    download: Option<ActiveDownload>,
+    download_ui: ModelDownloadUi,
+    models_dir: PathBuf,
+    model_installed: bool,
     focus_handle: FocusHandle,
     gpu_available: bool,
     on_apply: Arc<dyn Fn(StemExtractApplyRequest, &mut App) + 'static>,
@@ -146,19 +169,40 @@ impl StemExtractorWindow {
                 .find(|c| &c.clip_id == id)
                 .map(|c| c.source_path.clone())
         });
+        let models_dir = defaults
+            .models_dir
+            .clone()
+            .unwrap_or_else(SphereAudioProcessor::default_models_dir);
+        let _ = SphereAudioProcessor::ensure_models_dir(&models_dir);
+        let params = SphereAudioProcessor::default_stem_extract_params();
+        let model_installed =
+            SphereAudioProcessor::model_installed(params.model, &models_dir);
         Self {
             defaults,
-            params: SphereAudioProcessor::default_stem_extract_params(),
+            params,
             selected_clip_id,
             source_path,
             state: StemExtractJobState::Editing,
             open_select: None,
             job: None,
+            download: None,
+            download_ui: ModelDownloadUi::Idle,
+            models_dir,
+            model_installed,
             focus_handle: cx.focus_handle(),
             gpu_available: SphereAudioProcessor::gpu_available(),
             on_apply,
             applied: false,
         }
+    }
+
+    fn refresh_model_installed(&mut self) {
+        self.model_installed =
+            SphereAudioProcessor::model_installed(self.params.model, &self.models_dir);
+    }
+
+    fn is_downloading(&self) -> bool {
+        self.download.is_some() || matches!(self.download_ui, ModelDownloadUi::Running(_))
     }
 
     fn selected_clip(&self) -> Option<&StemSourceClip> {
@@ -188,6 +232,9 @@ impl StemExtractorWindow {
         if let Some(job) = &self.job {
             job.cancel.cancel();
         }
+        if let Some(download) = &self.download {
+            download.cancel.cancel();
+        }
         window.remove_window();
     }
 
@@ -203,6 +250,8 @@ impl StemExtractorWindow {
                 if self.open_select.is_some() {
                     self.open_select = None;
                     cx.notify();
+                } else if self.is_downloading() {
+                    self.request_cancel_download(cx);
                 } else if matches!(self.state, StemExtractJobState::Running(_)) {
                     self.request_cancel(cx);
                 } else {
@@ -210,7 +259,9 @@ impl StemExtractorWindow {
                 }
                 true
             }
-            "enter" if matches!(self.state, StemExtractJobState::Editing) => {
+            "enter"
+                if matches!(self.state, StemExtractJobState::Editing) && !self.is_downloading() =>
+            {
                 self.start_extract(cx);
                 true
             }
@@ -225,11 +276,127 @@ impl StemExtractorWindow {
         cx.notify();
     }
 
+    fn request_cancel_download(&mut self, cx: &mut Context<Self>) {
+        if let Some(download) = &self.download {
+            download.cancel.cancel();
+        }
+        cx.notify();
+    }
+
     fn can_extract(&self) -> bool {
-        self.selected_clip().is_some()
+        !self.is_downloading()
+            && self.selected_clip().is_some()
             && self.source_path.is_some()
             && self.params.validate().is_ok()
             && !self.params.stems.is_empty()
+    }
+
+    fn start_download(&mut self, cx: &mut Context<Self>) {
+        if self.is_downloading() || matches!(self.state, StemExtractJobState::Running(_)) {
+            return;
+        }
+        if self.model_installed {
+            return;
+        }
+        let models_dir = self.models_dir.clone();
+        let model = self.params.model;
+        let shared = Arc::new(Mutex::new(SharedDownloadJob::default()));
+        let cancel = SphereAudioProcessor::StemExtractCancelToken::new();
+        self.download = Some(ActiveDownload {
+            shared: shared.clone(),
+            cancel: cancel.clone(),
+        });
+        self.download_ui = ModelDownloadUi::Running(
+            SphereAudioProcessor::StemModelDownloadProgress::new(
+                model,
+                model.package().files.first().map(|f| f.file_name).unwrap_or("model"),
+                0,
+                model.package().file_count().max(1),
+                0,
+                None,
+                0.0,
+                format!("Starting {} download…", model.label()),
+            ),
+        );
+
+        let worker_shared = shared.clone();
+        std::thread::Builder::new()
+            .name("fb-stem-model-dl".to_string())
+            .spawn(move || {
+                let progress_shared = worker_shared.clone();
+                let mut on_progress =
+                    move |progress: SphereAudioProcessor::StemModelDownloadProgress| {
+                        if let Ok(mut guard) = progress_shared.lock() {
+                            guard.progress = Some(progress);
+                        }
+                    };
+                let result = SphereAudioProcessor::download_model(
+                    model,
+                    &models_dir,
+                    &cancel,
+                    &mut on_progress,
+                )
+                .map_err(|e| e.user_message());
+                if let Ok(mut guard) = worker_shared.lock() {
+                    guard.done = Some(result);
+                }
+            })
+            .ok();
+
+        cx.spawn(async move |this, cx| {
+            let executor = cx.background_executor().clone();
+            loop {
+                if crate::shutdown::ShutdownState::global().is_shutting_down() {
+                    break;
+                }
+                executor.timer(std::time::Duration::from_millis(50)).await;
+                let keep_going = this
+                    .update(cx, |this, cx| this.poll_download(cx))
+                    .unwrap_or(false);
+                if !keep_going {
+                    break;
+                }
+            }
+        })
+        .detach();
+        cx.notify();
+    }
+
+    fn poll_download(&mut self, cx: &mut Context<Self>) -> bool {
+        let Some(job) = &self.download else {
+            return false;
+        };
+        let (progress, done) = {
+            let Ok(mut guard) = job.shared.lock() else {
+                return true;
+            };
+            (guard.progress.take(), guard.done.take())
+        };
+        if let Some(done) = done {
+            match done {
+                Ok(()) => {
+                    self.refresh_model_installed();
+                    self.download_ui = ModelDownloadUi::Idle;
+                }
+                Err(message)
+                    if job.cancel.is_cancelled()
+                        || message.to_ascii_lowercase().contains("cancel") =>
+                {
+                    self.download_ui = ModelDownloadUi::Idle;
+                }
+                Err(message) => {
+                    self.download_ui = ModelDownloadUi::Failed(message);
+                }
+            }
+            self.download = None;
+            cx.notify();
+            return false;
+        }
+        if let Some(progress) = progress {
+            self.download_ui = ModelDownloadUi::Running(progress);
+            cx.notify();
+        }
+        true
     }
 
     fn start_extract(&mut self, cx: &mut Context<Self>) {
@@ -436,6 +603,10 @@ impl StemExtractorWindow {
             SelectField::Model => {
                 if let Some(model) = SphereAudioProcessor::StemModel::parse(value) {
                     self.params.set_model(model);
+                    self.refresh_model_installed();
+                    if !matches!(self.download_ui, ModelDownloadUi::Running(_)) {
+                        self.download_ui = ModelDownloadUi::Idle;
+                    }
                 }
             }
             SelectField::Device => {
@@ -555,6 +726,7 @@ impl StemExtractorWindow {
             )
             .child(section_label("MODEL"))
             .child(self.model_row(target.clone()))
+            .child(self.model_status_row(target.clone()))
             .child(self.device_row(target.clone()))
             .child(self.quality_row(target.clone()))
             .child(section_label("STEMS"))
@@ -563,9 +735,19 @@ impl StemExtractorWindow {
                 div()
                     .text_size(px(10.0))
                     .text_color(Colors::text_faint())
-                    .child(model_hint(&self.params)),
+                    .child(model_hint(
+                        &self.params,
+                        self.model_installed,
+                        &self.models_dir,
+                    )),
             )
             .child(div().flex_1());
+
+        if let ModelDownloadUi::Failed(message) = &self.download_ui {
+            col = col.child(error_banner(message.clone()));
+        } else if let ModelDownloadUi::Running(progress) = &self.download_ui {
+            col = col.child(self.render_download_progress(progress.clone(), target.clone()));
+        }
 
         if let StemExtractJobState::Failed(message) = &self.state {
             col = col.child(error_banner(message.clone()));
@@ -573,7 +755,7 @@ impl StemExtractorWindow {
             col = col.child(hint_banner(
                 "No audio clips on tracks. Import or record audio first.".into(),
             ));
-        } else if !self.can_extract() {
+        } else if !self.can_extract() && !self.is_downloading() {
             col = col.child(hint_banner(
                 "Select an audio clip and at least one stem.".into(),
             ));
@@ -616,9 +798,20 @@ impl StemExtractorWindow {
     }
 
     fn model_row(&self, target: gpui::Entity<Self>) -> impl IntoElement {
+        let models_dir = self.models_dir.clone();
         let options = SphereAudioProcessor::STEM_MODELS
             .iter()
-            .map(|info| SelectOption::new(info.id, info.label))
+            .map(|info| {
+                let package = info.model.package();
+                let installed =
+                    SphereAudioProcessor::model_installed(info.model, &models_dir);
+                let status = if installed { "Installed" } else { "Not installed" };
+                SelectOption::new(info.id, info.label).description(format!(
+                    "{} · {} · {status}",
+                    info.description,
+                    package.approx_size_label()
+                ))
+            })
             .collect::<Vec<_>>();
         let control = self.dropdown(
             SelectField::Model,
@@ -628,6 +821,128 @@ impl StemExtractorWindow {
             target,
         );
         self.labeled("Model", control)
+    }
+
+    fn model_status_row(&self, target: gpui::Entity<Self>) -> impl IntoElement {
+        let package = self.params.model.package();
+        let status = if self.model_installed {
+            format!(
+                "Installed · {} file(s) · {}",
+                package.file_count(),
+                package.approx_size_label()
+            )
+        } else {
+            format!(
+                "Not installed · {} · {}",
+                package.source_label,
+                package.approx_size_label()
+            )
+        };
+        let downloading = self.is_downloading();
+        let can_download = !self.model_installed
+            && !downloading
+            && !matches!(self.state, StemExtractJobState::Running(_));
+        let control = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(px(8.0))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .text_size(px(11.0))
+                    .text_color(if self.model_installed {
+                        Colors::text_secondary()
+                    } else {
+                        Colors::text_muted()
+                    })
+                    .truncate()
+                    .child(status),
+            )
+            .child(fb_button(
+                "stem-model-download",
+                if downloading { "Downloading…" } else { "Download" },
+                FbButtonKind::Default,
+                can_download,
+                {
+                    let target = target.clone();
+                    move |_, _window, cx| {
+                        let _ = target.update(cx, |this, cx| this.start_download(cx));
+                    }
+                },
+            ));
+        self.labeled("Weights", control)
+    }
+
+    fn render_download_progress(
+        &self,
+        progress: SphereAudioProcessor::StemModelDownloadProgress,
+        target: gpui::Entity<Self>,
+    ) -> impl IntoElement {
+        let percent = format!("{:.0}%", progress.percent);
+        let detail = if progress.file_count > 1 {
+            format!(
+                "{} ({}/{}) · {}",
+                progress.detail,
+                progress.file_index + 1,
+                progress.file_count,
+                progress.file_name
+            )
+        } else {
+            format!("{} · {}", progress.detail, progress.file_name)
+        };
+        div()
+            .flex()
+            .flex_col()
+            .gap(px(6.0))
+            .px(px(10.0))
+            .py(px(8.0))
+            .rounded(px(5.0))
+            .bg(Colors::surface_panel_alt())
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .justify_between()
+                    .child(
+                        div()
+                            .text_size(px(11.0))
+                            .font_weight(gpui::FontWeight::SEMIBOLD)
+                            .text_color(Colors::text_primary())
+                            .child(format!("Downloading {}", progress.model.label())),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(11.0))
+                            .text_color(Colors::accent_primary())
+                            .child(percent),
+                    ),
+            )
+            .child(progress_bar(ProgressBarValue::value(
+                progress.percent / 100.0,
+            )))
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(Colors::text_muted())
+                    .child(detail),
+            )
+            .child(
+                div().flex().flex_row().justify_end().child(fb_button(
+                    "stem-download-cancel",
+                    "Cancel Download",
+                    FbButtonKind::Default,
+                    true,
+                    {
+                        let target = target.clone();
+                        move |_, _window, cx| {
+                            let _ = target.update(cx, |this, cx| this.request_cancel_download(cx));
+                        }
+                    },
+                )),
+            )
     }
 
     fn device_row(&self, target: gpui::Entity<Self>) -> impl IntoElement {
@@ -974,7 +1289,11 @@ impl StemExtractorWindow {
     }
 }
 
-fn model_hint(params: &SphereAudioProcessor::StemExtractParams) -> String {
+fn model_hint(
+    params: &SphereAudioProcessor::StemExtractParams,
+    installed: bool,
+    models_dir: &std::path::Path,
+) -> String {
     let device = if params.device == SphereAudioProcessor::InferDevice::Gpu {
         if SphereAudioProcessor::gpu_available() {
             "GPU"
@@ -986,8 +1305,13 @@ fn model_hint(params: &SphereAudioProcessor::StemExtractParams) -> String {
     } else {
         "CPU"
     };
+    let weights = if installed {
+        format!("weights in {}", models_dir.display())
+    } else {
+        "weights not installed — Download saves to Utilities/Models".to_string()
+    };
     format!(
-        "{} · {device} · {}",
+        "{} · {device} · {} · {weights}",
         params.model.description(),
         params.quality.label()
     )

--- a/crates/SphereUIComponents/src/layout/stem_extract_ops.rs
+++ b/crates/SphereUIComponents/src/layout/stem_extract_ops.rs
@@ -47,6 +47,9 @@ impl StudioLayout {
             .folder_path
             .as_ref()
             .map(|p| p.to_path_buf());
+        let paths = crate::paths::FutureboardPaths::resolve();
+        let _ = paths.ensure_user_dirs();
+        let models_dir = Some(paths.models.clone());
 
         let audio_clips = collect_audio_source_clips(&tl_state);
         let selected_clip_id = tl_state
@@ -62,6 +65,7 @@ impl StudioLayout {
             audio_clips,
             selected_clip_id,
             project_root,
+            models_dir,
         };
 
         let owner_bounds = crate::window_position::resolve_owner_bounds_with_preferred(

--- a/crates/SphereUIComponents/src/paths.rs
+++ b/crates/SphereUIComponents/src/paths.rs
@@ -115,7 +115,14 @@ impl FutureboardPaths {
     /// Call [`ensure_user_dirs()`] afterwards to create directories.
     pub fn resolve() -> Self {
         // ── User document root ────────────────────────────────────────────
-        let doc_dir = dirs::document_dir().unwrap_or_else(|| PathBuf::from("."));
+        // Prefer `dirs::document_dir()`, but fall back to `$HOME/Documents`
+        // (never `.`) so Utilities/Models and Projects stay under the real
+        // user Documents tree even when XDG user-dirs are unset.
+        let doc_dir = dirs::document_dir().unwrap_or_else(|| {
+            dirs::home_dir()
+                .map(|home| home.join("Documents"))
+                .unwrap_or_else(|| PathBuf::from("Documents"))
+        });
         let user_root = doc_dir.join(APP_NAME);
 
         let projects = user_root.join("Projects");

--- a/crates/SphereUIComponents/src/paths.rs
+++ b/crates/SphereUIComponents/src/paths.rs
@@ -57,6 +57,10 @@ pub struct FutureboardPaths {
     pub loops: PathBuf,
     /// `~/Documents/Futureboard Studio/Exports/`
     pub exports: PathBuf,
+    /// `~/Documents/Futureboard Studio/Utilities/`
+    pub utilities: PathBuf,
+    /// `~/Documents/Futureboard Studio/Utilities/Models/` — MDX-NET / UVR ONNX packs.
+    pub models: PathBuf,
 
     // ── AppData ────────────────────────────────────────────────────────────
     /// Platform application data directory:
@@ -122,6 +126,8 @@ impl FutureboardPaths {
         let templates = user_root.join("Templates");
         let loops = user_root.join("Loops");
         let exports = user_root.join("Exports");
+        let utilities = user_root.join("Utilities");
+        let models = utilities.join("Models");
 
         // ── Factory (installer-managed) ───────────────────────────────────
         let factory_content = user_root.join("Factory Content");
@@ -163,6 +169,8 @@ impl FutureboardPaths {
             templates,
             loops,
             exports,
+            utilities,
+            models,
             app_data,
             settings_file,
             studio_window_file,
@@ -199,6 +207,8 @@ impl FutureboardPaths {
             &self.templates,
             &self.loops,
             &self.exports,
+            &self.utilities,
+            &self.models,
         ];
         for dir in &user_dirs {
             fs::create_dir_all(dir)?;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds MDX-NET / UVR model download support to Stem Extractor and expands the model catalog.

- Download ONNX packs into `Documents/Futureboard Studio/Utilities/Models/`
- New models: MDX-NET Karaoke, Main, Voc FT, Inst HQ, Kim Vocal 2, Kim Instrumental (plus existing 4-stem MDX-NET / Kuielab A)
- Dialog shows installed / not-installed status, approximate size, and a **Download** button with progress + cancel
- `FutureboardPaths` now creates `Utilities/Models`

## Validation
- `cargo test -p SphereFBStemExtractor --lib` — pass
- `cargo check -p sphere_ui_components -p futureboard_native` — pass
- Computer-use Download UI — in progress

## Notes
- Inference still uses the spectral stub until ONNX runtime is wired; downloaded weights are installed and detected for the next inference slice
- Packages come from the public UVR model release (`TRvlvr/model_repo`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b21f16de-b6b4-4ee1-beda-024d6a61279e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b21f16de-b6b4-4ee1-beda-024d6a61279e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

