### PR TITLE
fix(stem): show download percent on Weights status row

### DIFF
--- a/crates/SphereUIComponents/src/components/stem_extractor_dialog.rs
+++ b/crates/SphereUIComponents/src/components/stem_extractor_dialog.rs
@@ -825,7 +825,13 @@ impl StemExtractorWindow {
 
     fn model_status_row(&self, target: gpui::Entity<Self>) -> impl IntoElement {
         let package = self.params.model.package();
-        let status = if self.model_installed {
+        let downloading = self.is_downloading();
+        let status = if let ModelDownloadUi::Running(progress) = &self.download_ui {
+            format!(
+                "Downloading… {:.0}% · {}",
+                progress.percent, progress.file_name
+            )
+        } else if self.model_installed {
             format!(
                 "Installed · {} file(s) · {}",
                 package.file_count(),
@@ -838,7 +844,6 @@ impl StemExtractorWindow {
                 package.approx_size_label()
             )
         };
-        let downloading = self.is_downloading();
         let can_download = !self.model_installed
             && !downloading
             && !matches!(self.state, StemExtractJobState::Running(_));
@@ -852,7 +857,9 @@ impl StemExtractorWindow {
                     .flex_1()
                     .min_w(px(0.0))
                     .text_size(px(11.0))
-                    .text_color(if self.model_installed {
+                    .text_color(if downloading {
+                        Colors::accent_primary()
+                    } else if self.model_installed {
                         Colors::text_secondary()
                     } else {
                         Colors::text_muted()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up polish for #41: the Stem Extractor **Weights** row now shows live download percent + filename while a model pack is downloading, so progress stays visible even if the progress panel is clipped.

## Validation
- `cargo test -p SphereFBStemExtractor --lib` — pass
- Prior #41 computer-use download of Karaoke + Kim Vocal 2 into `Documents/Futureboard Studio/Utilities/Models/` — pass

## Notes
- Main model download / expanded catalog landed in #41

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b21f16de-b6b4-4ee1-beda-024d6a61279e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b21f16de-b6b4-4ee1-beda-024d6a61279e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

