### PR TITLE
Enhanced Soundfont Player engine, Test button, and playable keyboard

### DIFF
--- a/crates/SphereDirectAudioEngine/Cargo.toml
+++ b/crates/SphereDirectAudioEngine/Cargo.toml
@@ -123,3 +123,9 @@ audio-test-bin = []
 # This only compiles the code path — ASIO stays unusable until the edition
 # provider registers a host factory after license verification.
 asio = ["cpal/asio"]
+
+# ── Test dependencies ────────────────────────────────────────────────────────
+[dev-dependencies]
+# `test-support` exposes the synthetic SoundFont the built-in Soundfont Player
+# tests load, so they exercise the real parse/select/render path.
+sphere-soundfont-player = { workspace = true, features = ["test-support"] }

--- a/crates/SphereDirectAudioEngine/src/engine/render.rs
+++ b/crates/SphereDirectAudioEngine/src/engine/render.rs
@@ -1428,13 +1428,12 @@ fn render_soundfont_instrument_block(track: &mut RuntimeTrack, frames: usize) {
                     let _ = player.note_off(event.channel.min(15), event.pitch.min(127));
                 }
                 2 => {
+                    // `pitch` carries the controller number here, including the
+                    // engine's out-of-band numbers for pitch bend and channel
+                    // pressure — clamping it to 127 would turn a bend lane into
+                    // a random CC, so the player does the translation.
                     let value = (event.velocity.clamp(0.0, 1.0) * 127.0).round() as u8;
-                    let _ = player.process_midi_message(
-                        event.channel.min(15),
-                        0xB0,
-                        event.pitch.min(127),
-                        value,
-                    );
+                    let _ = player.controller(event.channel.min(15), event.pitch, value);
                 }
                 _ => {}
             }
@@ -2453,6 +2452,248 @@ mod live_input_monitor_tests {
         let (left, right) = render_monitored_block(&mut runtime, 0);
         assert!(left.abs() < 1.0e-6);
         assert!(right.abs() < 1.0e-6);
+    }
+}
+
+/// End-to-end coverage for the built-in Soundfont Player as a track
+/// instrument: a real `.sf2` is loaded through the runtime graph, MIDI reaches
+/// it the same way the piano roll and the Soundfont Player window send it, and
+/// the rendered block is checked for actual audio.
+#[cfg(test)]
+mod soundfont_instrument_tests {
+    use super::render_project_block_interleaved;
+    use crate::runtime::RuntimeProject;
+    use crate::types::{EngineProjectSnapshot, EngineRoutingSnapshot, EngineTrackSnapshot};
+    use sphere_soundfont_player::test_font;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    const SAMPLE_RATE: u32 = 48_000;
+    const FRAMES: usize = 512;
+
+    /// A per-test `.sf2` on disk, removed when the guard drops.
+    struct FontFile {
+        dir: PathBuf,
+        path: PathBuf,
+    }
+
+    impl FontFile {
+        fn new(name: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "futureboard-soundfont-engine-{}-{name}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&dir).expect("temp dir");
+            let path = dir.join("test.sf2");
+            test_font::write_sf2(&path).expect("write test soundfont");
+            Self { dir, path }
+        }
+    }
+
+    impl Drop for FontFile {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.dir).ok();
+        }
+    }
+
+    fn soundfont_track(id: &str, font: &FontFile, preset: (i32, i32)) -> EngineTrackSnapshot {
+        EngineTrackSnapshot {
+            id: id.to_string(),
+            track_type: "instrument".to_string(),
+            volume: 1.0,
+            pan: 0.0,
+            muted: false,
+            solo: false,
+            armed: false,
+            input_monitor: false,
+            input_source: Default::default(),
+            preview_mode: "stereo".to_string(),
+            output_track_id: None,
+            inserts: Vec::new(),
+            sends: Vec::new(),
+            automation_lanes: Vec::new(),
+            builtin_soundfont_player: true,
+            soundfont_path: Some(font.path.to_string_lossy().into_owned()),
+            soundfont_preset_bank: Some(preset.0),
+            soundfont_preset_patch: Some(preset.1),
+            soundfont_volume: 1.0,
+            soundfont_reverb_chorus: true,
+            soundfont_polyphony: 64,
+        }
+    }
+
+    fn master_track() -> EngineTrackSnapshot {
+        EngineTrackSnapshot {
+            id: "master".to_string(),
+            track_type: "master".to_string(),
+            volume: 1.0,
+            pan: 0.0,
+            muted: false,
+            solo: false,
+            armed: false,
+            input_monitor: false,
+            input_source: Default::default(),
+            preview_mode: "stereo".to_string(),
+            output_track_id: None,
+            inserts: Vec::new(),
+            sends: Vec::new(),
+            automation_lanes: Vec::new(),
+            builtin_soundfont_player: false,
+            soundfont_path: None,
+            soundfont_preset_bank: None,
+            soundfont_preset_patch: None,
+            soundfont_volume: 1.0,
+            soundfont_reverb_chorus: true,
+            soundfont_polyphony: 64,
+        }
+    }
+
+    fn runtime(font: &FontFile, preset: (i32, i32)) -> RuntimeProject {
+        let snapshot = EngineProjectSnapshot {
+            project_id: "soundfont-test".to_string(),
+            project_root: None,
+            preferred_input_device: None,
+            bpm: 120.0,
+            tempo_points: Vec::new(),
+            time_signature: [4, 4],
+            sample_rate: SAMPLE_RATE,
+            tracks: vec![soundfont_track("sf-1", font, preset), master_track()],
+            clips: Vec::new(),
+            midi_clips: Vec::new(),
+            pdc_enabled: true,
+            latency_graph_version: 1,
+            routing: EngineRoutingSnapshot {
+                master_output_device: None,
+                sample_rate: SAMPLE_RATE,
+                buffer_size: FRAMES as u32,
+            },
+        };
+        RuntimeProject::build(&snapshot, SAMPLE_RATE, &mut HashMap::new(), None, true)
+            .expect("soundfont runtime builds")
+    }
+
+    /// Renders one stopped-transport block — the state the Soundfont Player
+    /// window's Test button and the piano roll audition run in — and returns
+    /// its peak level.
+    fn render_peak(runtime: &mut RuntimeProject) -> f32 {
+        let mut output = vec![0.0f32; FRAMES * 2];
+        render_project_block_interleaved(runtime, 0, 1.0, &mut output, 2, false, 4, 4, None);
+        output.iter().fold(0.0f32, |peak, s| peak.max(s.abs()))
+    }
+
+    #[test]
+    fn snapshot_load_attaches_a_player_with_the_requested_preset() {
+        let font = FontFile::new("load");
+        let runtime = runtime(&font, test_font::MELODIC_PRESET);
+        let soundfont = runtime.tracks[0]
+            .soundfont_player
+            .as_ref()
+            .expect("track carries a soundfont player");
+        let player = soundfont.player.as_ref().expect("font loaded");
+        assert_eq!(player.bank_name(), test_font::BANK_NAME);
+        assert_eq!(soundfont.preset, Some(test_font::MELODIC_PRESET));
+    }
+
+    #[test]
+    fn preview_note_renders_without_an_instrument_insert() {
+        let font = FontFile::new("preview");
+        let mut runtime = runtime(&font, test_font::MELODIC_PRESET);
+        assert!(
+            runtime.tracks[0].midi_instrument_insert_ix.is_none(),
+            "the built-in player is a track instrument, not an insert"
+        );
+        assert_eq!(render_peak(&mut runtime), 0.0, "silent before any note");
+
+        runtime.midi_preview_note_on("sf-1", 0, 60, 100);
+        assert!(
+            runtime.has_active_midi_preview(),
+            "a soundfont preview note must register so the callback keeps rendering"
+        );
+        assert!(
+            render_peak(&mut runtime) > 0.001,
+            "preview note should be audible"
+        );
+
+        runtime.midi_preview_note_off("sf-1", 0, 60);
+        assert!(!runtime.has_active_midi_preview());
+    }
+
+    #[test]
+    fn preview_note_plays_on_a_channel_other_than_the_first() {
+        // Tracks can put each note on its own MIDI channel, so the selected
+        // preset has to be live on every melodic channel, not only channel 1.
+        let font = FontFile::new("channels");
+        let mut runtime = runtime(&font, test_font::MELODIC_PRESET);
+        runtime.midi_preview_note_on("sf-1", 7, 64, 110);
+        assert!(render_peak(&mut runtime) > 0.001);
+    }
+
+    #[test]
+    fn muted_track_renders_no_soundfont_audio() {
+        let font = FontFile::new("muted");
+        let mut runtime = runtime(&font, test_font::MELODIC_PRESET);
+        runtime.tracks[0].muted = true;
+        runtime.fader_smoothing = false;
+        runtime.midi_preview_note_on("sf-1", 0, 60, 100);
+        assert!(render_peak(&mut runtime) < 1.0e-6);
+    }
+
+    #[test]
+    fn graph_clone_reuses_the_parsed_font_and_still_plays() {
+        let font = FontFile::new("clone");
+        let runtime = runtime(&font, test_font::MELODIC_PRESET);
+        let original = runtime.tracks[0]
+            .soundfont_player
+            .as_ref()
+            .and_then(|sf| sf.player.as_ref())
+            .expect("font loaded")
+            .sound_font();
+
+        let mut cloned = runtime.clone();
+        let clone_font = cloned.tracks[0]
+            .soundfont_player
+            .as_ref()
+            .and_then(|sf| sf.player.as_ref())
+            .expect("clone keeps a loaded player")
+            .sound_font();
+        assert!(
+            std::sync::Arc::ptr_eq(&original, &clone_font),
+            "a graph swap must not re-parse the SoundFont"
+        );
+
+        cloned.midi_preview_note_on("sf-1", 0, 60, 100);
+        assert!(render_peak(&mut cloned) > 0.001);
+    }
+
+    #[test]
+    fn missing_font_leaves_the_track_silent_instead_of_failing_the_graph() {
+        let font = FontFile::new("missing");
+        let mut track = soundfont_track("sf-1", &font, test_font::MELODIC_PRESET);
+        track.soundfont_path = Some("/definitely/not/a/soundfont.sf2".to_string());
+        let snapshot = EngineProjectSnapshot {
+            project_id: "soundfont-missing".to_string(),
+            project_root: None,
+            preferred_input_device: None,
+            bpm: 120.0,
+            tempo_points: Vec::new(),
+            time_signature: [4, 4],
+            sample_rate: SAMPLE_RATE,
+            tracks: vec![track, master_track()],
+            clips: Vec::new(),
+            midi_clips: Vec::new(),
+            pdc_enabled: true,
+            latency_graph_version: 1,
+            routing: EngineRoutingSnapshot {
+                master_output_device: None,
+                sample_rate: SAMPLE_RATE,
+                buffer_size: FRAMES as u32,
+            },
+        };
+        let mut runtime =
+            RuntimeProject::build(&snapshot, SAMPLE_RATE, &mut HashMap::new(), None, true)
+                .expect("graph still builds without the font");
+        runtime.midi_preview_note_on("sf-1", 0, 60, 100);
+        assert_eq!(render_peak(&mut runtime), 0.0);
     }
 }
 

--- a/crates/SphereDirectAudioEngine/src/runtime.rs
+++ b/crates/SphereDirectAudioEngine/src/runtime.rs
@@ -14,7 +14,7 @@ use crate::audio_source::{open_clip_audio_source, ClipAudioSource};
 use crate::latency_graph::{plan_runtime_latency_graph, RuntimeLatencyGraph};
 use serde_json::Value;
 use sphere_audio_plugins::{canonical_plugin_id, should_rebuild_state, AudioPluginDspState};
-use sphere_soundfont_player::{SoundfontPlayer, SoundfontPlayerSettings};
+use sphere_soundfont_player::{SoundFont, SoundfontPlayer, SoundfontPlayerSettings};
 use SphereAudioProcessor::{
     create_stretch_processor, effective_pitch_ratio, effective_time_ratio, resolve_backend,
     source_read_rate_for_repitch, stretched_duration_samples, StretchAlgorithm, StretchBackend,
@@ -74,22 +74,40 @@ impl RuntimeSoundfontPlayer {
             polyphony: track.soundfont_polyphony.clamp(1, 256),
             player: None,
         };
-        state.reload(sample_rate);
+        state.rebuild(sample_rate, None);
         Some(state)
     }
 
-    fn reload(&mut self, sample_rate: u32) {
+    /// Rebuilds the synthesizer for the current settings. `sound_font` lets the
+    /// caller hand back an already-parsed font (a graph clone, or the player
+    /// being replaced), so changing polyphony or reverb never re-reads a bank
+    /// that can be tens of megabytes. Control thread only — this can do
+    /// filesystem I/O.
+    fn rebuild(&mut self, sample_rate: u32, sound_font: Option<Arc<SoundFont>>) {
         let settings = SoundfontPlayerSettings {
             sample_rate: sample_rate.max(1) as i32,
             block_size: 0,
             maximum_polyphony: self.polyphony,
             enable_reverb_and_chorus: self.reverb_chorus,
         };
-        match SoundfontPlayer::from_path(&self.path, settings) {
+        let built = match sound_font {
+            Some(font) => SoundfontPlayer::from_sound_font(font, settings),
+            None => SoundfontPlayer::from_path(&self.path, settings),
+        };
+        match built {
             Ok(mut player) => {
                 player.set_master_volume(self.volume);
                 if let Some((bank, patch)) = self.preset {
-                    let _ = player.select_preset(0, bank, patch);
+                    // Every melodic channel gets the track's preset: a
+                    // Futureboard MIDI track can put each note on its own
+                    // channel, and only channel 1 answering the selected sound
+                    // would leave the rest on the SoundFont's default preset.
+                    if let Err(error) = player.select_preset_all_channels(bank, patch) {
+                        eprintln!(
+                            "[soundfont-player] preset {bank}:{patch} not applied for '{}': {error}",
+                            self.path.display()
+                        );
+                    }
                 }
                 self.player = Some(player);
             }
@@ -124,6 +142,10 @@ impl Clone for RuntimeSoundfontPlayer {
             .as_ref()
             .map(|player| player.sample_rate().max(1) as u32)
             .unwrap_or(48_000);
+        // A synthesizer owns per-voice state that must not be shared, but the
+        // parsed font is immutable — hand it to the clone instead of reading
+        // the file again on every graph swap.
+        let sound_font = self.player.as_ref().map(SoundfontPlayer::sound_font);
         let mut cloned = Self {
             path: self.path.clone(),
             preset: self.preset,
@@ -132,7 +154,7 @@ impl Clone for RuntimeSoundfontPlayer {
             polyphony: self.polyphony,
             player: None,
         };
-        cloned.reload(sample_rate);
+        cloned.rebuild(sample_rate, sound_font);
         cloned
     }
 }
@@ -1137,7 +1159,8 @@ impl RuntimeProject {
 
         for track in &mut self.tracks {
             if let Some(soundfont) = track.soundfont_player.as_mut() {
-                soundfont.reload(sample_rate);
+                let font = soundfont.player.as_ref().map(SoundfontPlayer::sound_font);
+                soundfont.rebuild(sample_rate, font);
             }
             track.plugin_latency_samples = 0;
             for insert in &mut track.inserts {
@@ -2453,6 +2476,23 @@ impl RuntimeProject {
             );
         }
         let Some(insert_ix) = track.midi_instrument_insert_ix else {
+            // The built-in Soundfont Player is a track instrument, not an
+            // insert, so it has no instrument insert index. Its events are
+            // consumed by `render_soundfont_instrument_block` straight from
+            // `midi_block_events` — the same queue an instrument insert reads.
+            if track.soundfont_player.is_some() {
+                if verbose {
+                    eprintln!(
+                        "[InstrumentRoute] track={} selected_instrument_plugin=builtin_soundfont_player",
+                        track_id
+                    );
+                    eprintln!(
+                        "[PluginMidiIn] plugin=builtin_soundfont_player {event_type} ch={channel} pitch={pitch} offset=0"
+                    );
+                }
+                self.tracks[ti].midi_block_events.push(event);
+                return true;
+            }
             if verbose {
                 eprintln!(
                     "[InstrumentRoute] track={} selected_instrument_plugin=none no instrument plugin found",

--- a/crates/SphereSoundfontPlayer/Cargo.toml
+++ b/crates/SphereSoundfontPlayer/Cargo.toml
@@ -10,6 +10,11 @@ name = "SphereSoundfontPlayer"
 path = "src/lib.rs"
 crate-type = ["rlib", "cdylib"]
 
+[features]
+# Exposes `test_font`, a synthetic SoundFont used by this crate's tests and by
+# the audio engine's tests. Never enabled by the shipping binaries.
+test-support = []
+
 [dependencies]
 rustysynth = "1.3.6"
 

--- a/crates/SphereSoundfontPlayer/src/font_cache.rs
+++ b/crates/SphereSoundfontPlayer/src/font_cache.rs
@@ -1,0 +1,105 @@
+//! Process-wide reuse of parsed SoundFonts.
+//!
+//! A parsed [`SoundFont`] is immutable, shareable, and expensive: a General
+//! MIDI bank costs tens of megabytes of file read plus a full RIFF walk. A
+//! [`Synthesizer`](rustysynth::Synthesizer), by contrast, must be rebuilt every
+//! time polyphony, reverb/chorus, or the sample rate changes, and the runtime
+//! audio graph clones its players whenever the engine swaps graphs. Without a
+//! cache each of those rebuilds re-reads the file on the control thread.
+//!
+//! Entries are held weakly, so the cache costs nothing once the last player
+//! using a font is dropped, and a file that changed on disk is re-read rather
+//! than served stale.
+//!
+//! Control/offline only: [`load`] performs filesystem I/O and must never be
+//! called from an audio callback.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::time::SystemTime;
+
+use rustysynth::SoundFont;
+
+use crate::SoundfontPlayerError;
+
+/// Identity of a cached font. Length and modification time are checked so an
+/// edited or replaced file is re-read instead of served from the cache.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FontKey {
+    path: PathBuf,
+    len: u64,
+    modified: Option<SystemTime>,
+}
+
+static CACHE: OnceLock<Mutex<HashMap<FontKey, Weak<SoundFont>>>> = OnceLock::new();
+static HITS: AtomicU64 = AtomicU64::new(0);
+static MISSES: AtomicU64 = AtomicU64::new(0);
+
+fn cache() -> &'static Mutex<HashMap<FontKey, Weak<SoundFont>>> {
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn font_key(path: &Path) -> Result<FontKey, SoundfontPlayerError> {
+    let metadata = std::fs::metadata(path)?;
+    Ok(FontKey {
+        path: std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()),
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
+/// Returns the parsed font for `path`, reading and parsing it only if no live
+/// copy of that exact file is already loaded.
+pub fn load(path: &Path) -> Result<Arc<SoundFont>, SoundfontPlayerError> {
+    let key = font_key(path)?;
+    if let Some(font) = cache()
+        .lock()
+        .ok()
+        .and_then(|entries| entries.get(&key).and_then(Weak::upgrade))
+    {
+        HITS.fetch_add(1, Ordering::Relaxed);
+        return Ok(font);
+    }
+
+    let mut file = File::open(path)?;
+    let font = Arc::new(SoundFont::new(&mut file)?);
+    MISSES.fetch_add(1, Ordering::Relaxed);
+
+    if let Ok(mut entries) = cache().lock() {
+        entries.retain(|_, weak| weak.strong_count() > 0);
+        entries.insert(key, Arc::downgrade(&font));
+    }
+    Ok(font)
+}
+
+/// Cache counters for diagnostics: `(live_entries, hits, misses)`.
+pub fn stats() -> (usize, u64, u64) {
+    let live = cache()
+        .lock()
+        .map(|entries| {
+            entries
+                .values()
+                .filter(|weak| weak.strong_count() > 0)
+                .count()
+        })
+        .unwrap_or(0);
+    (
+        live,
+        HITS.load(Ordering::Relaxed),
+        MISSES.load(Ordering::Relaxed),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_reports_io_error() {
+        let error = load(Path::new("/definitely/not/a/soundfont.sf2")).unwrap_err();
+        assert!(matches!(error, SoundfontPlayerError::Io(_)));
+    }
+}

--- a/crates/SphereSoundfontPlayer/src/lib.rs
+++ b/crates/SphereSoundfontPlayer/src/lib.rs
@@ -2,8 +2,19 @@
 //!
 //! Loading a SoundFont is a control/offline operation. Rendering assumes the
 //! caller owns the output buffers and keeps filesystem I/O out of the audio path.
+//!
+//! A parsed [`SoundFont`] is immutable and large (a General MIDI bank is tens of
+//! megabytes), while a [`Synthesizer`] is cheap by comparison and must be rebuilt
+//! whenever polyphony, reverb/chorus, or the sample rate changes. [`font_cache`]
+//! keeps the parse result shareable so those rebuilds — and runtime graph clones —
+//! never re-read the file.
 
-use rustysynth::{SoundFont, Synthesizer, SynthesizerSettings};
+pub mod font_cache;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_font;
+
+pub use rustysynth::SoundFont;
+use rustysynth::{Synthesizer, SynthesizerSettings};
 use std::ffi::CStr;
 use std::fs::File;
 use std::io::{Cursor, Read};
@@ -15,6 +26,21 @@ use std::slice;
 use std::sync::Arc;
 
 const DEFAULT_SAMPLE_RATE: i32 = 44_100;
+
+/// The MIDI channel rustysynth reserves for percussion (channel 10 in
+/// one-based MIDI numbering). Bank select on this channel is offset into the
+/// SoundFont's drum banks, so it never carries a melodic preset.
+pub const PERCUSSION_CHANNEL: u8 = Synthesizer::PERCUSSION_CHANNEL as u8;
+
+/// SoundFont bank number of the General MIDI drum kits.
+pub const DRUM_BANK: i32 = 128;
+
+/// Controller number the engine uses for pitch bend on a controller lane
+/// (VST3 `kPitchBend`). Not a real MIDI CC — see [`SoundfontPlayer::controller`].
+pub const CONTROLLER_PITCH_BEND: u8 = 129;
+
+/// Controller number the engine uses for channel pressure (VST3 `kAfterTouch`).
+pub const CONTROLLER_CHANNEL_PRESSURE: u8 = 128;
 
 #[derive(Debug)]
 pub enum SoundfontPlayerError {
@@ -28,6 +54,14 @@ pub enum SoundfontPlayerError {
     /// preset list — distinct from `InvalidBank`/`InvalidPatch`, which reject
     /// out-of-range values before ever consulting the font.
     PresetNotFound {
+        bank: i32,
+        patch: i32,
+    },
+    /// `(bank, patch)` exists in the font but MIDI bank select cannot address
+    /// it from `channel` — a drum-bank preset asked for on a melodic channel,
+    /// or a melodic preset asked for on the percussion channel.
+    PresetUnreachableOnChannel {
+        channel: u8,
         bank: i32,
         patch: i32,
     },
@@ -55,6 +89,17 @@ impl std::fmt::Display for SoundfontPlayerError {
                 write!(
                     f,
                     "no preset at bank {bank} patch {patch} in this SoundFont"
+                )
+            }
+            Self::PresetUnreachableOnChannel {
+                channel,
+                bank,
+                patch,
+            } => {
+                write!(
+                    f,
+                    "bank {bank} patch {patch} cannot be selected on MIDI channel {}",
+                    channel + 1
                 )
             }
             Self::Io(error) => write!(f, "SoundFont I/O failed: {error}"),
@@ -126,10 +171,25 @@ impl SoundfontPlayerSettings {
 
 pub struct SoundfontPlayer {
     synthesizer: Synthesizer,
+    /// The same parsed font the synthesizer holds. Kept here because rustysynth
+    /// only hands back a `&SoundFont`, and rebuilding a synthesizer (or cloning
+    /// a runtime graph) must reuse the parse instead of re-reading the file.
+    sound_font: Arc<SoundFont>,
 }
 
 impl SoundfontPlayer {
+    /// Loads `path` through [`font_cache`], so a font already parsed for another
+    /// player (or for the previous settings of this one) is reused.
     pub fn from_path(
+        path: impl AsRef<Path>,
+        settings: SoundfontPlayerSettings,
+    ) -> Result<Self, SoundfontPlayerError> {
+        let sound_font = font_cache::load(path.as_ref())?;
+        Self::from_sound_font(sound_font, settings)
+    }
+
+    /// Reads and parses `path` unconditionally, bypassing [`font_cache`].
+    pub fn from_path_uncached(
         path: impl AsRef<Path>,
         settings: SoundfontPlayerSettings,
     ) -> Result<Self, SoundfontPlayerError> {
@@ -149,10 +209,26 @@ impl SoundfontPlayer {
         reader: &mut R,
         settings: SoundfontPlayerSettings,
     ) -> Result<Self, SoundfontPlayerError> {
-        let sound_font = Arc::new(SoundFont::new(reader)?);
+        Self::from_sound_font(Arc::new(SoundFont::new(reader)?), settings)
+    }
+
+    /// Builds a player over an already-parsed font. Rebuilding for new settings
+    /// costs a voice pool and preset table, not another multi-megabyte parse.
+    pub fn from_sound_font(
+        sound_font: Arc<SoundFont>,
+        settings: SoundfontPlayerSettings,
+    ) -> Result<Self, SoundfontPlayerError> {
         let synth_settings = settings.to_rustysynth()?;
         let synthesizer = Synthesizer::new(&sound_font, &synth_settings)?;
-        Ok(Self { synthesizer })
+        Ok(Self {
+            synthesizer,
+            sound_font,
+        })
+    }
+
+    /// The parsed font backing this player, for reuse by a rebuilt player.
+    pub fn sound_font(&self) -> Arc<SoundFont> {
+        Arc::clone(&self.sound_font)
     }
 
     pub fn note_on(
@@ -246,7 +322,12 @@ impl SoundfontPlayer {
     /// The loaded SoundFont's own bank name (from its INFO chunk), e.g.
     /// "General MIDI" — control-side metadata for a UI title, not audio state.
     pub fn bank_name(&self) -> &str {
-        self.synthesizer.get_sound_font().get_info().get_bank_name()
+        self.sound_font.get_info().get_bank_name()
+    }
+
+    /// How many presets the loaded SoundFont exposes.
+    pub fn preset_count(&self) -> usize {
+        self.sound_font.get_presets().len()
     }
 
     /// Every preset (MIDI bank + patch + display name) in the loaded
@@ -254,8 +335,7 @@ impl SoundfontPlayer {
     /// walks the font's preset table, never touches the render path.
     pub fn list_presets(&self) -> Vec<SoundfontPresetInfo> {
         let mut presets: Vec<SoundfontPresetInfo> = self
-            .synthesizer
-            .get_sound_font()
+            .sound_font
             .get_presets()
             .iter()
             .map(|preset| SoundfontPresetInfo {
@@ -268,13 +348,36 @@ impl SoundfontPlayer {
         presets
     }
 
+    /// Whether `(bank, patch)` exists in the loaded font. Allocation-free, so
+    /// preset selection stays usable from a control command drained on the
+    /// audio thread — unlike [`Self::list_presets`], which builds owned names.
+    pub fn has_preset(&self, bank: i32, patch: i32) -> bool {
+        self.sound_font
+            .get_presets()
+            .iter()
+            .any(|preset| preset.get_bank_number() == bank && preset.get_patch_number() == patch)
+    }
+
+    /// Name of `(bank, patch)` in the loaded font, borrowed from the font's own
+    /// preset table.
+    pub fn preset_name(&self, bank: i32, patch: i32) -> Option<&str> {
+        self.sound_font
+            .get_presets()
+            .iter()
+            .find(|preset| preset.get_bank_number() == bank && preset.get_patch_number() == patch)
+            .map(|preset| preset.get_name())
+    }
+
     /// Selects a preset on `channel` via MIDI Bank Select (CC0 MSB / CC32
     /// LSB) followed by Program Change — the standard way to switch patches
     /// on a General MIDI-style synth, so this also works against any other
-    /// host that only understands MIDI. Rejects `(bank, patch)` pairs that
-    /// only match on `is_empty` (empty rejects "not present"): the caller
-    /// should first check [`Self::list_presets`], but this is control-side
-    /// validation, not silent fallback to whatever program change lands on.
+    /// host that only understands MIDI. Rejects `(bank, patch)` pairs that are
+    /// not in the font instead of silently falling back to whatever the
+    /// program change lands on.
+    ///
+    /// The percussion channel offsets bank select into the drum banks, so a
+    /// drum-bank preset is requested there with the bank the drum kits occupy
+    /// and a melodic preset cannot be selected on it at all.
     pub fn select_preset(
         &mut self,
         channel: u8,
@@ -288,16 +391,19 @@ impl SoundfontPlayer {
         if !(0..=127).contains(&patch) {
             return Err(SoundfontPlayerError::InvalidPatch(patch));
         }
-        if !self
-            .list_presets()
-            .iter()
-            .any(|preset| preset.bank == bank && preset.patch == patch)
-        {
+        if !self.has_preset(bank, patch) {
             return Err(SoundfontPlayerError::PresetNotFound { bank, patch });
         }
+        let Some(selected) = bank_select_value(channel, bank) else {
+            return Err(SoundfontPlayerError::PresetUnreachableOnChannel {
+                channel,
+                bank,
+                patch,
+            });
+        };
 
-        let bank_msb = (bank >> 7) & 0x7F;
-        let bank_lsb = bank & 0x7F;
+        let bank_msb = (selected >> 7) & 0x7F;
+        let bank_lsb = selected & 0x7F;
         self.synthesizer
             .process_midi_message(channel.into(), 0xB0, 0x00, bank_msb);
         self.synthesizer
@@ -305,6 +411,100 @@ impl SoundfontPlayer {
         self.synthesizer
             .process_midi_message(channel.into(), 0xC0, patch, 0);
         Ok(())
+    }
+
+    /// Selects one preset on every melodic channel so a track plays the chosen
+    /// sound no matter which MIDI channel its notes carry (Futureboard tracks
+    /// can put each note on its own channel). The percussion channel keeps the
+    /// font's drum banks.
+    ///
+    /// A drum-bank preset is instead selected on the percussion channel alone,
+    /// which is the only channel that can address it.
+    pub fn select_preset_all_channels(
+        &mut self,
+        bank: i32,
+        patch: i32,
+    ) -> Result<(), SoundfontPlayerError> {
+        if bank >= DRUM_BANK {
+            return self.select_preset(PERCUSSION_CHANNEL, bank, patch);
+        }
+        for channel in 0..Synthesizer::CHANNEL_COUNT as u8 {
+            if channel == PERCUSSION_CHANNEL {
+                continue;
+            }
+            self.select_preset(channel, bank, patch)?;
+        }
+        Ok(())
+    }
+
+    /// Applies one controller-lane value. Plain CC numbers go through as MIDI
+    /// control change; the engine's out-of-band controller numbers for pitch
+    /// bend and channel pressure are translated to their own MIDI status bytes
+    /// instead of being clamped into the CC range.
+    pub fn controller(
+        &mut self,
+        channel: u8,
+        controller: u8,
+        value: u8,
+    ) -> Result<(), SoundfontPlayerError> {
+        validate_channel(channel)?;
+        match controller {
+            CONTROLLER_PITCH_BEND => {
+                // Lane values are 7-bit; expand to the 14-bit bend range so
+                // centre (64) lands on the unbent 8192 rather than slightly flat.
+                let bend = u16::from(value.min(127)) << 7;
+                self.pitch_bend(channel, bend)
+            }
+            // rustysynth has no channel-pressure handling; dropping it is
+            // honest, and clamping it into CC 127 would be a wrong sound.
+            CONTROLLER_CHANNEL_PRESSURE => Ok(()),
+            _ => {
+                self.synthesizer.process_midi_message(
+                    channel.into(),
+                    0xB0,
+                    controller.min(127).into(),
+                    value.min(127).into(),
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// Sets the 14-bit pitch bend for `channel` (`0x2000` is centre).
+    pub fn pitch_bend(&mut self, channel: u8, value: u16) -> Result<(), SoundfontPlayerError> {
+        validate_channel(channel)?;
+        let value = value.min(0x3FFF);
+        self.synthesizer.process_midi_message(
+            channel.into(),
+            0xE0,
+            i32::from(value & 0x7F),
+            i32::from(value >> 7),
+        );
+        Ok(())
+    }
+
+    /// Releases every held note on `channel` without touching other channels.
+    pub fn all_notes_off_channel(
+        &mut self,
+        channel: u8,
+        immediate: bool,
+    ) -> Result<(), SoundfontPlayerError> {
+        validate_channel(channel)?;
+        self.synthesizer
+            .note_off_all_channel(channel.into(), immediate);
+        Ok(())
+    }
+}
+
+/// The bank-select value that makes rustysynth resolve `bank` on `channel`, or
+/// `None` when the channel cannot reach that bank at all. The percussion
+/// channel adds [`DRUM_BANK`] to whatever bank select it receives, so it only
+/// addresses drum banks and every other channel only addresses melodic ones.
+fn bank_select_value(channel: u8, bank: i32) -> Option<i32> {
+    if channel == PERCUSSION_CHANNEL {
+        (bank >= DRUM_BANK).then_some(bank - DRUM_BANK)
+    } else {
+        (bank < DRUM_BANK).then_some(bank)
     }
 }
 
@@ -395,7 +595,8 @@ fn status_from_error(error: &SoundfontPlayerError) -> SphereSoundfontPlayerStatu
         | SoundfontPlayerError::InvalidVelocity(_)
         | SoundfontPlayerError::InvalidBank(_)
         | SoundfontPlayerError::InvalidPatch(_)
-        | SoundfontPlayerError::PresetNotFound { .. } => {
+        | SoundfontPlayerError::PresetNotFound { .. }
+        | SoundfontPlayerError::PresetUnreachableOnChannel { .. } => {
             SphereSoundfontPlayerStatus::InvalidArgument
         }
     }
@@ -685,6 +886,231 @@ pub extern "C" fn sphere_soundfont_player_null() -> *mut SoundfontPlayer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn player() -> SoundfontPlayer {
+        SoundfontPlayer::from_sound_font(
+            test_font::sound_font(),
+            SoundfontPlayerSettings::default(),
+        )
+        .expect("synthetic font loads")
+    }
+
+    fn peak(player: &mut SoundfontPlayer, frames: usize) -> f32 {
+        let mut left = vec![0.0; frames];
+        let mut right = vec![0.0; frames];
+        player.render(&mut left, &mut right).expect("render");
+        left.iter()
+            .chain(right.iter())
+            .fold(0.0f32, |peak, sample| peak.max(sample.abs()))
+    }
+
+    #[test]
+    fn loads_synthetic_font_metadata() {
+        let player = player();
+        assert_eq!(player.bank_name(), test_font::BANK_NAME);
+        assert_eq!(player.preset_count(), 2);
+        assert!(player.has_preset(test_font::MELODIC_PRESET.0, test_font::MELODIC_PRESET.1));
+        assert!(player.has_preset(test_font::DRUM_PRESET.0, test_font::DRUM_PRESET.1));
+        assert!(!player.has_preset(0, 42));
+        assert_eq!(
+            player.preset_name(test_font::MELODIC_PRESET.0, test_font::MELODIC_PRESET.1),
+            Some("Test Tone")
+        );
+    }
+
+    #[test]
+    fn note_on_renders_audio_and_note_off_releases_it() {
+        let mut player = player();
+        assert_eq!(peak(&mut player, 512), 0.0, "silent before any note");
+
+        player.note_on(0, 60, 100).expect("note on");
+        let held = peak(&mut player, 4_096);
+        assert!(held > 0.01, "held note should render audio");
+
+        // Reverb and chorus are on by default, so the voices stop but their
+        // tail keeps decaying — assert the drop, not instant digital silence.
+        player.all_notes_off(true);
+        let released = peak(&mut player, 4_096);
+        assert!(
+            released < held * 0.5,
+            "immediate all-notes-off should drop the level: held={held} released={released}"
+        );
+    }
+
+    #[test]
+    fn select_preset_all_channels_makes_every_melodic_channel_play() {
+        let mut player = player();
+        player
+            .select_preset_all_channels(test_font::MELODIC_PRESET.0, test_font::MELODIC_PRESET.1)
+            .expect("melodic preset selects");
+
+        for channel in [0u8, 3, 15] {
+            player.note_on(channel, 60, 100).expect("note on");
+            assert!(
+                peak(&mut player, 2_048) > 0.01,
+                "channel {channel} should play the selected preset"
+            );
+            player.all_notes_off(true);
+        }
+    }
+
+    #[test]
+    fn drum_bank_preset_only_selects_on_the_percussion_channel() {
+        let mut player = player();
+        let (bank, patch) = test_font::DRUM_PRESET;
+
+        player
+            .select_preset(PERCUSSION_CHANNEL, bank, patch)
+            .expect("drum preset selects on the percussion channel");
+
+        let error = player.select_preset(0, bank, patch).unwrap_err();
+        assert!(matches!(
+            error,
+            SoundfontPlayerError::PresetUnreachableOnChannel { channel: 0, .. }
+        ));
+
+        // A melodic preset is equally unreachable from the percussion channel.
+        let (bank, patch) = test_font::MELODIC_PRESET;
+        let error = player
+            .select_preset(PERCUSSION_CHANNEL, bank, patch)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            SoundfontPlayerError::PresetUnreachableOnChannel { .. }
+        ));
+    }
+
+    #[test]
+    fn select_preset_all_channels_routes_a_drum_bank_to_percussion() {
+        let mut player = player();
+        player
+            .select_preset_all_channels(test_font::DRUM_PRESET.0, test_font::DRUM_PRESET.1)
+            .expect("drum preset routes to the percussion channel");
+
+        player
+            .note_on(PERCUSSION_CHANNEL, 60, 100)
+            .expect("note on");
+        assert!(peak(&mut player, 2_048) > 0.01);
+    }
+
+    #[test]
+    fn missing_preset_is_reported_before_any_program_change() {
+        let mut player = player();
+        let error = player.select_preset(0, 0, 42).unwrap_err();
+        assert!(matches!(
+            error,
+            SoundfontPlayerError::PresetNotFound { bank: 0, patch: 42 }
+        ));
+    }
+
+    #[test]
+    fn pitch_bend_controller_uses_the_bend_status_not_a_cc() {
+        let mut player = player();
+        player.note_on(0, 60, 100).expect("note on");
+        let mut unbent = vec![0.0; 4_096];
+        let mut scratch = vec![0.0; 4_096];
+        player.render(&mut unbent, &mut scratch).expect("render");
+
+        // CC 7 (channel volume) at 0 must silence the note; the pitch-bend
+        // controller number must not be clamped into the CC range and do that.
+        player
+            .controller(0, CONTROLLER_PITCH_BEND, 127)
+            .expect("pitch bend");
+        let bent_peak = peak(&mut player, 4_096);
+        assert!(bent_peak > 0.01, "pitch bend must not silence the note");
+
+        player.controller(0, 7, 0).expect("channel volume");
+        assert!(
+            peak(&mut player, 8_192) < bent_peak,
+            "channel volume 0 should reduce the rendered level"
+        );
+    }
+
+    #[test]
+    fn master_volume_scales_the_rendered_level() {
+        let mut player = player();
+        player.set_master_volume(1.0);
+        player.note_on(0, 60, 100).expect("note on");
+        let loud = peak(&mut player, 4_096);
+
+        player.all_notes_off(true);
+        player.set_master_volume(0.1);
+        player.note_on(0, 60, 100).expect("note on");
+        let quiet = peak(&mut player, 4_096);
+
+        assert!(loud > quiet * 2.0, "loud={loud} quiet={quiet}");
+    }
+
+    #[test]
+    fn mismatched_render_buffers_are_rejected_before_rustysynth_panics() {
+        let mut player = player();
+        let mut left = vec![0.0; 64];
+        let mut right = vec![0.0; 32];
+        let error = player.render(&mut left, &mut right).unwrap_err();
+        assert!(matches!(
+            error,
+            SoundfontPlayerError::BufferLengthMismatch {
+                left: 64,
+                right: 32
+            }
+        ));
+    }
+
+    #[test]
+    fn font_cache_reuses_one_parse_across_players() {
+        let dir = std::env::temp_dir().join(format!(
+            "futureboard-sf2-cache-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("test.sf2");
+        test_font::write_sf2(&path).expect("write font");
+
+        let (_, _, misses_before) = font_cache::stats();
+        let first = SoundfontPlayer::from_path(&path, SoundfontPlayerSettings::default())
+            .expect("first load");
+        let (_, hits_before, misses_after_first) = font_cache::stats();
+        assert_eq!(
+            misses_after_first,
+            misses_before + 1,
+            "first load parses the file"
+        );
+
+        let second = SoundfontPlayer::from_path(&path, SoundfontPlayerSettings::default())
+            .expect("second load");
+        let (_, hits_after, misses_after_second) = font_cache::stats();
+        assert_eq!(
+            misses_after_second, misses_after_first,
+            "second load must not re-parse"
+        );
+        assert_eq!(hits_after, hits_before + 1);
+        assert!(Arc::ptr_eq(&first.sound_font(), &second.sound_font()));
+
+        drop((first, second));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rebuilding_for_new_settings_reuses_the_parsed_font() {
+        let font = test_font::sound_font();
+        let player =
+            SoundfontPlayer::from_sound_font(Arc::clone(&font), SoundfontPlayerSettings::default())
+                .expect("build");
+        let rebuilt = SoundfontPlayer::from_sound_font(
+            player.sound_font(),
+            SoundfontPlayerSettings {
+                maximum_polyphony: 32,
+                enable_reverb_and_chorus: false,
+                ..SoundfontPlayerSettings::default()
+            },
+        )
+        .expect("rebuild");
+
+        assert!(Arc::ptr_eq(&font, &rebuilt.sound_font()));
+        assert_eq!(rebuilt.maximum_polyphony(), 32);
+        assert!(!rebuilt.enable_reverb_and_chorus());
+    }
 
     #[test]
     fn default_ffi_config_uses_default_settings() {

--- a/crates/SphereSoundfontPlayer/src/test_font.rs
+++ b/crates/SphereSoundfontPlayer/src/test_font.rs
@@ -1,0 +1,234 @@
+//! A synthetic SoundFont for tests.
+//!
+//! Behind the `test-support` feature so tests in this crate and in the audio
+//! engine can exercise the real load → preset select → render path without
+//! shipping (or depending on the presence of) a multi-megabyte `.sf2` file.
+//!
+//! The bank is deliberately minimal but valid SF2: one looping sine sample,
+//! one instrument, and presets at the banks a General MIDI player must handle —
+//! a melodic bank 0 preset and a drum bank 128 preset.
+
+use std::sync::Arc;
+
+use rustysynth::SoundFont;
+
+/// Bank/patch of the melodic preset in [`sound_font`].
+pub const MELODIC_PRESET: (i32, i32) = (0, 0);
+/// Bank/patch of the drum preset in [`sound_font`], reachable only on the
+/// percussion channel.
+pub const DRUM_PRESET: (i32, i32) = (128, 0);
+/// Bank name reported by [`sound_font`].
+pub const BANK_NAME: &str = "Futureboard Test Bank";
+
+const SAMPLE_RATE: i32 = 44_100;
+const SAMPLE_FRAMES: usize = 2_048;
+/// SF2 requires at least 46 zero frames of separation after each sample.
+const SAMPLE_PADDING: usize = 46;
+
+const GEN_INSTRUMENT: u16 = 41;
+const GEN_KEY_RANGE: u16 = 43;
+const GEN_SAMPLE_ID: u16 = 53;
+const GEN_SAMPLE_MODES: u16 = 54;
+const GEN_OVERRIDING_ROOT_KEY: u16 = 58;
+
+/// Serialized bytes of the synthetic bank.
+pub fn sf2_bytes() -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(b"sfbk");
+    body.extend_from_slice(&info_list());
+    body.extend_from_slice(&sdta_list());
+    body.extend_from_slice(&pdta_list());
+
+    let mut out = Vec::with_capacity(body.len() + 8);
+    out.extend_from_slice(b"RIFF");
+    out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    out.extend_from_slice(&body);
+    out
+}
+
+/// The synthetic bank, parsed.
+pub fn sound_font() -> Arc<SoundFont> {
+    let bytes = sf2_bytes();
+    Arc::new(SoundFont::new(&mut std::io::Cursor::new(bytes)).expect("synthetic SoundFont parses"))
+}
+
+/// Writes the synthetic bank to `path` so tests can exercise file loading.
+pub fn write_sf2(path: &std::path::Path) -> std::io::Result<()> {
+    std::fs::write(path, sf2_bytes())
+}
+
+fn chunk(id: &[u8; 4], data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len() + 9);
+    out.extend_from_slice(id);
+    out.extend_from_slice(&(data.len() as u32).to_le_bytes());
+    out.extend_from_slice(data);
+    if data.len() % 2 == 1 {
+        out.push(0);
+    }
+    out
+}
+
+fn list_chunk(list_type: &[u8; 4], data: &[u8]) -> Vec<u8> {
+    let mut body = Vec::with_capacity(data.len() + 4);
+    body.extend_from_slice(list_type);
+    body.extend_from_slice(data);
+    chunk(b"LIST", &body)
+}
+
+/// A NUL-terminated, even-length string field.
+fn zstr(value: &str) -> Vec<u8> {
+    let mut bytes = value.as_bytes().to_vec();
+    bytes.push(0);
+    if bytes.len() % 2 == 1 {
+        bytes.push(0);
+    }
+    bytes
+}
+
+/// A fixed 20-byte name field, as used by phdr / inst / shdr records.
+fn name20(value: &str) -> [u8; 20] {
+    let mut out = [0u8; 20];
+    let bytes = value.as_bytes();
+    let len = bytes.len().min(19);
+    out[..len].copy_from_slice(&bytes[..len]);
+    out
+}
+
+fn info_list() -> Vec<u8> {
+    let mut data = Vec::new();
+    let mut ifil = Vec::new();
+    ifil.extend_from_slice(&2i16.to_le_bytes());
+    ifil.extend_from_slice(&1i16.to_le_bytes());
+    data.extend_from_slice(&chunk(b"ifil", &ifil));
+    data.extend_from_slice(&chunk(b"isng", &zstr("EMU8000")));
+    data.extend_from_slice(&chunk(b"INAM", &zstr(BANK_NAME)));
+    list_chunk(b"INFO", &data)
+}
+
+fn sdta_list() -> Vec<u8> {
+    let mut samples = Vec::with_capacity((SAMPLE_FRAMES + SAMPLE_PADDING) * 2);
+    for frame in 0..SAMPLE_FRAMES {
+        // One full sine period across the sample, so looping it is continuous.
+        let phase = frame as f64 / SAMPLE_FRAMES as f64 * std::f64::consts::TAU;
+        let value = (phase.sin() * 24_000.0) as i16;
+        samples.extend_from_slice(&value.to_le_bytes());
+    }
+    samples.extend(std::iter::repeat_n(0u8, SAMPLE_PADDING * 2));
+    list_chunk(b"sdta", &chunk(b"smpl", &samples))
+}
+
+fn generator(kind: u16, value: u16) -> [u8; 4] {
+    let mut out = [0u8; 4];
+    out[..2].copy_from_slice(&kind.to_le_bytes());
+    out[2..].copy_from_slice(&value.to_le_bytes());
+    out
+}
+
+fn zone(generator_index: u16) -> [u8; 4] {
+    let mut out = [0u8; 4];
+    out[..2].copy_from_slice(&generator_index.to_le_bytes());
+    out[2..].copy_from_slice(&0u16.to_le_bytes());
+    out
+}
+
+/// One `phdr` record: name, patch, bank, first preset zone, then the unused
+/// library / genre / morphology fields.
+fn preset_header(name: &str, patch: u16, bank: u16, zone_start: u16) -> Vec<u8> {
+    let mut out = Vec::with_capacity(38);
+    out.extend_from_slice(&name20(name));
+    out.extend_from_slice(&patch.to_le_bytes());
+    out.extend_from_slice(&bank.to_le_bytes());
+    out.extend_from_slice(&zone_start.to_le_bytes());
+    out.extend_from_slice(&0i32.to_le_bytes());
+    out.extend_from_slice(&0i32.to_le_bytes());
+    out.extend_from_slice(&0i32.to_le_bytes());
+    out
+}
+
+fn instrument_header(name: &str, zone_start: u16) -> Vec<u8> {
+    let mut out = Vec::with_capacity(22);
+    out.extend_from_slice(&name20(name));
+    out.extend_from_slice(&zone_start.to_le_bytes());
+    out
+}
+
+fn pdta_list() -> Vec<u8> {
+    // Two presets (melodic + drum) sharing one instrument, plus the terminator
+    // record each SF2 list ends with.
+    let mut phdr = Vec::new();
+    phdr.extend_from_slice(&preset_header(
+        "Test Tone",
+        MELODIC_PRESET.1 as u16,
+        MELODIC_PRESET.0 as u16,
+        0,
+    ));
+    phdr.extend_from_slice(&preset_header(
+        "Test Kit",
+        DRUM_PRESET.1 as u16,
+        DRUM_PRESET.0 as u16,
+        1,
+    ));
+    phdr.extend_from_slice(&preset_header("EOP", 0, 0, 2));
+
+    let mut pbag = Vec::new();
+    pbag.extend_from_slice(&zone(0));
+    pbag.extend_from_slice(&zone(1));
+    pbag.extend_from_slice(&zone(2));
+
+    let mut pgen = Vec::new();
+    pgen.extend_from_slice(&generator(GEN_INSTRUMENT, 0));
+    pgen.extend_from_slice(&generator(GEN_INSTRUMENT, 0));
+    pgen.extend_from_slice(&generator(0, 0)); // terminator
+
+    let mut inst = Vec::new();
+    inst.extend_from_slice(&instrument_header("Test Instrument", 0));
+    inst.extend_from_slice(&instrument_header("EOI", 1));
+
+    let mut ibag = Vec::new();
+    ibag.extend_from_slice(&zone(0));
+    ibag.extend_from_slice(&zone(4));
+
+    let mut igen = Vec::new();
+    igen.extend_from_slice(&generator(GEN_KEY_RANGE, 0x7F00));
+    igen.extend_from_slice(&generator(GEN_OVERRIDING_ROOT_KEY, 60));
+    igen.extend_from_slice(&generator(GEN_SAMPLE_MODES, 1)); // loop continuously
+    igen.extend_from_slice(&generator(GEN_SAMPLE_ID, 0)); // must be last in the zone
+    igen.extend_from_slice(&generator(0, 0)); // terminator
+
+    let mut shdr = Vec::new();
+    shdr.extend_from_slice(&sample_header(
+        "Sine",
+        0,
+        SAMPLE_FRAMES as i32,
+        0,
+        SAMPLE_FRAMES as i32 - 1,
+    ));
+    shdr.extend_from_slice(&sample_header("EOS", 0, 0, 0, 0));
+
+    let mut data = Vec::new();
+    data.extend_from_slice(&chunk(b"phdr", &phdr));
+    data.extend_from_slice(&chunk(b"pbag", &pbag));
+    data.extend_from_slice(&chunk(b"pmod", &[0u8; 10]));
+    data.extend_from_slice(&chunk(b"pgen", &pgen));
+    data.extend_from_slice(&chunk(b"inst", &inst));
+    data.extend_from_slice(&chunk(b"ibag", &ibag));
+    data.extend_from_slice(&chunk(b"imod", &[0u8; 10]));
+    data.extend_from_slice(&chunk(b"igen", &igen));
+    data.extend_from_slice(&chunk(b"shdr", &shdr));
+    list_chunk(b"pdta", &data)
+}
+
+fn sample_header(name: &str, start: i32, end: i32, start_loop: i32, end_loop: i32) -> Vec<u8> {
+    let mut out = Vec::with_capacity(46);
+    out.extend_from_slice(&name20(name));
+    out.extend_from_slice(&start.to_le_bytes());
+    out.extend_from_slice(&end.to_le_bytes());
+    out.extend_from_slice(&start_loop.to_le_bytes());
+    out.extend_from_slice(&end_loop.to_le_bytes());
+    out.extend_from_slice(&SAMPLE_RATE.to_le_bytes());
+    out.push(60); // original pitch
+    out.push(0); // pitch correction
+    out.extend_from_slice(&0u16.to_le_bytes()); // sample link
+    out.extend_from_slice(&1u16.to_le_bytes()); // monoSample
+    out
+}

--- a/crates/SphereUIComponents/src/components/soundfont_player_mdi.rs
+++ b/crates/SphereUIComponents/src/components/soundfont_player_mdi.rs
@@ -42,7 +42,22 @@ pub struct SoundfontPlayerPanelState {
     pub preset_list_open: bool,
     pub loading: bool,
     pub status: Option<String>,
+    /// MIDI note of the leftmost key on the panel keyboard.
+    pub keyboard_root: u8,
+    /// Notes the panel is currently holding on the engine, so keys and the
+    /// Test button show what is actually sounding.
+    pub active_notes: Vec<u8>,
+    /// `true` while the Test button's audition is holding notes.
+    pub testing: bool,
 }
+
+/// Two octaves starting at C3 — enough to reach a recognisable range without
+/// crowding the window, and centred where a General MIDI preset sounds best.
+pub const KEYBOARD_DEFAULT_ROOT: u8 = 48;
+/// How many white keys the panel keyboard shows.
+const KEYBOARD_WHITE_KEYS: usize = 14;
+const KEYBOARD_LOWEST_ROOT: u8 = 0;
+const KEYBOARD_HIGHEST_ROOT: u8 = 108;
 
 impl Default for SoundfontPlayerPanelState {
     fn default() -> Self {
@@ -57,7 +72,24 @@ impl Default for SoundfontPlayerPanelState {
             preset_list_open: false,
             loading: false,
             status: None,
+            keyboard_root: KEYBOARD_DEFAULT_ROOT,
+            active_notes: Vec::new(),
+            testing: false,
         }
+    }
+}
+
+impl SoundfontPlayerPanelState {
+    /// Whether the panel has a loaded font to play. Gestures are disabled
+    /// rather than sending MIDI that could not make a sound.
+    pub fn is_playable(&self) -> bool {
+        self.file_name.is_some() && !self.loading
+    }
+
+    pub fn shift_keyboard_octave(&mut self, delta: i32) {
+        let root = self.keyboard_root as i32 + delta * 12;
+        self.keyboard_root =
+            root.clamp(KEYBOARD_LOWEST_ROOT as i32, KEYBOARD_HIGHEST_ROOT as i32) as u8;
     }
 }
 
@@ -65,6 +97,8 @@ type SoundfontVoidCb = Arc<dyn Fn(&mut Window, &mut App) + 'static>;
 type SoundfontPresetCb = Arc<dyn Fn(&(i32, i32), &mut Window, &mut App) + 'static>;
 type SoundfontF32Cb = Arc<dyn Fn(&f32, &mut Window, &mut App) + 'static>;
 type SoundfontUsizeCb = Arc<dyn Fn(&usize, &mut Window, &mut App) + 'static>;
+type SoundfontNoteCb = Arc<dyn Fn(&u8, &mut Window, &mut App) + 'static>;
+type SoundfontI32Cb = Arc<dyn Fn(&i32, &mut Window, &mut App) + 'static>;
 
 #[derive(Clone)]
 pub struct SoundfontPlayerCallbacks {
@@ -74,6 +108,15 @@ pub struct SoundfontPlayerCallbacks {
     pub on_set_volume: SoundfontF32Cb,
     pub on_toggle_reverb_chorus: SoundfontVoidCb,
     pub on_set_polyphony: SoundfontUsizeCb,
+    /// Press and release of one panel key — routed to the engine so the note
+    /// sounds through the track it belongs to.
+    pub on_note_on: SoundfontNoteCb,
+    pub on_note_off: SoundfontNoteCb,
+    /// Auditions the selected preset without needing the transport or a clip.
+    pub on_test: SoundfontVoidCb,
+    /// Releases everything the panel is holding.
+    pub on_all_notes_off: SoundfontVoidCb,
+    pub on_shift_octave: SoundfontI32Cb,
 }
 
 const PRESET_LIST_MAX_H: f32 = 150.0;
@@ -159,14 +202,8 @@ pub fn soundfont_player_panel(
                 .flex()
                 .flex_col()
                 .gap(px(5.0))
-                .child(
-                    div()
-                        .text_size(px(10.0))
-                        .font_weight(gpui::FontWeight::SEMIBOLD)
-                        .text_color(Colors::text_faint())
-                        .child("Keyboard Range"),
-                )
-                .child(keyboard_preview()),
+                .child(keyboard_header(panel, &cb))
+                .child(keyboard(panel, &cb)),
         )
         .into_any_element()
 }
@@ -293,18 +330,45 @@ fn preset_row(panel: &SoundfontPlayerPanelState, cb: &SoundfontPlayerCallbacks) 
     } else {
         "Choose…"
     };
+    let test = cb.on_test.clone();
+    let panic = cb.on_all_notes_off.clone();
+    let playing = panel.testing || !panel.active_notes.is_empty();
     field_row(
         "Preset",
         value,
         Some(
-            fb_button(
-                "soundfont-preset-toggle",
-                toggle_label,
-                FbButtonKind::Default,
-                has_presets,
-                move |_, w, cx| toggle(w, cx),
-            )
-            .into_any_element(),
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap(px(6.0))
+                .child(fb_button(
+                    "soundfont-preset-toggle",
+                    toggle_label,
+                    FbButtonKind::Default,
+                    has_presets,
+                    move |_, w, cx| toggle(w, cx),
+                ))
+                .child(if playing {
+                    fb_button(
+                        "soundfont-test-stop",
+                        "Stop",
+                        FbButtonKind::Default,
+                        true,
+                        move |_, w, cx| panic(w, cx),
+                    )
+                    .into_any_element()
+                } else {
+                    fb_button(
+                        "soundfont-test",
+                        "Test",
+                        FbButtonKind::Primary,
+                        panel.is_playable(),
+                        move |_, w, cx| test(w, cx),
+                    )
+                    .into_any_element()
+                })
+                .into_any_element(),
         ),
     )
 }
@@ -471,34 +535,207 @@ fn status_banner(message: String) -> AnyElement {
         .into_any_element()
 }
 
-fn keyboard_preview() -> AnyElement {
-    let mut row = div()
+/// Semitone offsets of the white keys within one octave, and of the black keys
+/// with the white key each sits between.
+const WHITE_SEMITONES: [u8; 7] = [0, 2, 4, 5, 7, 9, 11];
+const BLACK_SEMITONES: [(usize, u8); 5] = [(0, 1), (1, 3), (3, 6), (4, 8), (5, 10)];
+const WHITE_KEY_W: f32 = 30.0;
+const BLACK_KEY_W: f32 = 18.0;
+const KEY_H: f32 = 62.0;
+const BLACK_KEY_H: f32 = 38.0;
+
+const NOTE_NAMES: [&str; 12] = [
+    "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
+];
+
+/// `60` → `"C4"`, matching the pitch labels used elsewhere in Studio.
+pub fn note_label(pitch: u8) -> String {
+    let octave = pitch as i32 / 12 - 1;
+    format!("{}{octave}", NOTE_NAMES[pitch as usize % 12])
+}
+
+fn keyboard_header(panel: &SoundfontPlayerPanelState, cb: &SoundfontPlayerCallbacks) -> AnyElement {
+    let down = cb.on_shift_octave.clone();
+    let up = cb.on_shift_octave.clone();
+    let highest = panel
+        .keyboard_root
+        .saturating_add((KEYBOARD_WHITE_KEYS.div_ceil(7) * 12) as u8)
+        .min(127);
+    let range = format!(
+        "{} – {}",
+        note_label(panel.keyboard_root),
+        note_label(highest)
+    );
+    let holding = if panel.active_notes.is_empty() {
+        range
+    } else {
+        let names: Vec<String> = panel.active_notes.iter().copied().map(note_label).collect();
+        format!("Playing {}", names.join(" "))
+    };
+
+    div()
         .flex()
         .flex_row()
-        .h(px(48.0))
+        .items_center()
+        .gap(px(8.0))
+        .child(
+            div()
+                .text_size(px(10.0))
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_color(Colors::text_faint())
+                .child("Keyboard"),
+        )
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.0))
+                .truncate()
+                .text_size(px(10.0))
+                .text_color(if panel.active_notes.is_empty() {
+                    Colors::text_muted()
+                } else {
+                    Colors::accent_primary()
+                })
+                .child(holding),
+        )
+        .child(fb_stepper_button(
+            "soundfont-octave-down",
+            "–",
+            move |_, w, cx| down(&-1, w, cx),
+        ))
+        .child(fb_stepper_button(
+            "soundfont-octave-up",
+            "+",
+            move |_, w, cx| up(&1, w, cx),
+        ))
+        .into_any_element()
+}
+
+/// The panel keyboard. Press-and-hold plays through the engine on the owning
+/// track: this is the same MIDI preview path the piano roll uses, not a
+/// separate preview synth.
+fn keyboard(panel: &SoundfontPlayerPanelState, cb: &SoundfontPlayerCallbacks) -> AnyElement {
+    let playable = panel.is_playable();
+    let mut white_row = div().flex().flex_row().h(px(KEY_H));
+    for index in 0..KEYBOARD_WHITE_KEYS {
+        let Some(pitch) = white_pitch(panel.keyboard_root, index) else {
+            continue;
+        };
+        white_row = white_row.child(key(
+            ("soundfont-white-key", index),
+            pitch,
+            false,
+            panel.active_notes.contains(&pitch),
+            playable,
+            cb,
+        ));
+    }
+
+    let mut board = div()
+        .relative()
+        .w(px(WHITE_KEY_W * KEYBOARD_WHITE_KEYS as f32))
+        .h(px(KEY_H))
+        .rounded_md()
+        .overflow_hidden()
         .border(px(1.0))
         .border_color(Colors::border_subtle())
         .bg(Colors::surface_muted())
-        .overflow_hidden()
-        .rounded_md();
+        .child(white_row);
 
-    for i in 0..18 {
-        let is_dark = matches!(i % 7, 1 | 3 | 6);
-        row = row.child(
-            div()
-                .flex_1()
-                .h_full()
-                .border_l(px(if i == 0 { 0.0 } else { 1.0 }))
-                .border_color(Colors::border_subtle())
-                .bg(if is_dark {
-                    Colors::surface_base()
-                } else {
-                    Colors::surface_input()
-                }),
+    for index in 0..KEYBOARD_WHITE_KEYS {
+        let octave = index / 7;
+        let degree = index % 7;
+        let Some((_, semitone)) = BLACK_SEMITONES.iter().find(|(white, _)| *white == degree) else {
+            continue;
+        };
+        let pitch = panel.keyboard_root as u16 + (octave * 12) as u16 + *semitone as u16;
+        if pitch > 127 {
+            continue;
+        }
+        let pitch = pitch as u8;
+        let left = WHITE_KEY_W * (index as f32 + 1.0) - BLACK_KEY_W / 2.0;
+        board = board.child(
+            key(
+                ("soundfont-black-key", index),
+                pitch,
+                true,
+                panel.active_notes.contains(&pitch),
+                playable,
+                cb,
+            )
+            .absolute()
+            .left(px(left))
+            .top(px(0.0)),
         );
     }
 
-    row.into_any_element()
+    board.into_any_element()
+}
+
+fn white_pitch(root: u8, index: usize) -> Option<u8> {
+    let pitch = root as u16 + ((index / 7) * 12) as u16 + WHITE_SEMITONES[index % 7] as u16;
+    (pitch <= 127).then_some(pitch as u8)
+}
+
+fn key(
+    id: impl Into<gpui::ElementId>,
+    pitch: u8,
+    black: bool,
+    active: bool,
+    playable: bool,
+    cb: &SoundfontPlayerCallbacks,
+) -> gpui::Stateful<gpui::Div> {
+    let note_on = cb.on_note_on.clone();
+    let note_off = cb.on_note_off.clone();
+    let mut key = div()
+        .id(id)
+        .w(px(if black { BLACK_KEY_W } else { WHITE_KEY_W }))
+        .h(px(if black { BLACK_KEY_H } else { KEY_H }))
+        .flex()
+        .items_end()
+        .justify_center()
+        .pb(px(4.0))
+        .border_r(px(1.0))
+        .border_color(if active {
+            Colors::border_accent()
+        } else {
+            Colors::border_subtle()
+        })
+        .bg(if active {
+            Colors::accent_muted()
+        } else if black {
+            Colors::surface_base()
+        } else {
+            Colors::surface_input()
+        })
+        .text_size(px(8.0))
+        .text_color(if active {
+            Colors::accent_primary()
+        } else {
+            Colors::text_faint()
+        })
+        .child(if black || pitch % 12 != 0 {
+            String::new()
+        } else {
+            note_label(pitch)
+        });
+
+    if black {
+        key = key.rounded_b_md().border(px(1.0));
+    }
+
+    if playable {
+        key = key
+            .cursor(gpui::CursorStyle::PointingHand)
+            .hover(|s| s.bg(Colors::surface_hover()))
+            .on_mouse_down(gpui::MouseButton::Left, move |_, w, cx| {
+                note_on(&pitch, w, cx)
+            })
+            .on_mouse_up(gpui::MouseButton::Left, move |_, w, cx| {
+                note_off(&pitch, w, cx)
+            });
+    }
+    key
 }
 
 fn empty_document() -> AnyElement {
@@ -524,5 +761,55 @@ mod tests {
         let second = ensure_soundfont_player_document(&mut state);
         assert_eq!(first, second);
         assert_eq!(state.document_count(), 1);
+    }
+
+    #[test]
+    fn note_labels_match_middle_c_convention() {
+        assert_eq!(note_label(60), "C4");
+        assert_eq!(note_label(61), "C#4");
+        assert_eq!(note_label(48), "C3");
+        assert_eq!(note_label(0), "C-1");
+    }
+
+    #[test]
+    fn white_keys_walk_the_major_scale_from_the_root() {
+        let root = KEYBOARD_DEFAULT_ROOT;
+        let pitches: Vec<u8> = (0..8).filter_map(|i| white_pitch(root, i)).collect();
+        assert_eq!(pitches, vec![48, 50, 52, 53, 55, 57, 59, 60]);
+    }
+
+    #[test]
+    fn white_keys_stop_at_the_top_of_the_midi_range() {
+        assert_eq!(white_pitch(120, 0), Some(120));
+        assert_eq!(white_pitch(120, 6), None);
+    }
+
+    #[test]
+    fn octave_shift_clamps_to_the_playable_range() {
+        let mut panel = SoundfontPlayerPanelState::default();
+        panel.shift_keyboard_octave(-1);
+        assert_eq!(panel.keyboard_root, KEYBOARD_DEFAULT_ROOT - 12);
+
+        for _ in 0..12 {
+            panel.shift_keyboard_octave(-1);
+        }
+        assert_eq!(panel.keyboard_root, 0);
+
+        for _ in 0..12 {
+            panel.shift_keyboard_octave(1);
+        }
+        assert_eq!(panel.keyboard_root, 108);
+    }
+
+    #[test]
+    fn panel_is_only_playable_once_a_font_is_loaded() {
+        let mut panel = SoundfontPlayerPanelState::default();
+        assert!(!panel.is_playable(), "no font loaded yet");
+
+        panel.file_name = Some("GeneralUser-GS.sf2".to_string());
+        assert!(panel.is_playable());
+
+        panel.loading = true;
+        assert!(!panel.is_playable(), "a load in flight blocks gestures");
     }
 }

--- a/crates/SphereUIComponents/src/components/soundfont_player_window.rs
+++ b/crates/SphereUIComponents/src/components/soundfont_player_window.rs
@@ -4,15 +4,21 @@
 //! `TrackState::builtin_soundfont_player`) in a simple floating utility window.
 //! The player panel fills the window directly — no nested MDI/document chrome.
 //!
-//! This window owns a real [`SoundfontPlayer`] instance (control/offline
-//! side only — see that crate's doc comment). Loading a `.sf2`, browsing its
-//! real presets, and switching preset/volume/reverb/polyphony all mutate the
-//! live instance. There is no audio device attached to this preview window,
-//! so none of this produces sound yet; wiring the built-in player into the
-//! audio engine as a real track instrument is a separate, larger task.
+//! Two separate players are in play here, and the split is deliberate:
+//!
+//! - this window owns a control-side [`SoundfontPlayer`] used to read the
+//!   `.sf2`'s real bank name and preset list and to validate a preset choice;
+//! - the audible instrument is the engine's own player on the owning track,
+//!   rebuilt from the track state this window publishes.
+//!
+//! So the keyboard and the Test button do not play the window's instance. They
+//! send MIDI preview through [`SoundfontPlayerPreview`] to the engine, which is
+//! the same path the piano roll uses — what you hear here is what the track
+//! will play back.
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use gpui::{
     div, px, size, App, AppContext, Bounds, Context, FocusHandle, InteractiveElement, IntoElement,
@@ -32,11 +38,34 @@ use crate::soundfont_player::{
 use crate::theme::Colors;
 
 pub const SOUNDFONT_PLAYER_WINDOW_WIDTH: f32 = 640.0;
-pub const SOUNDFONT_PLAYER_WINDOW_HEIGHT: f32 = 460.0;
+pub const SOUNDFONT_PLAYER_WINDOW_HEIGHT: f32 = 520.0;
 pub const SOUNDFONT_PLAYER_WINDOW_MIN_WIDTH: f32 = 480.0;
-pub const SOUNDFONT_PLAYER_WINDOW_MIN_HEIGHT: f32 = 360.0;
+pub const SOUNDFONT_PLAYER_WINDOW_MIN_HEIGHT: f32 = 420.0;
 
 const PREVIEW_MIDI_CHANNEL: u8 = 0;
+const PREVIEW_VELOCITY: u8 = 100;
+/// Notes the Test button auditions: a C major triad, low enough to be clear on
+/// a bass or pad preset and high enough not to disappear on a lead.
+const TEST_CHORD: [u8; 3] = [60, 64, 67];
+/// How long the Test button holds its chord. Long enough to hear a slow
+/// attack, short enough that the button is not a mode the user has to exit.
+const TEST_CHORD_HOLD: Duration = Duration::from_millis(1_400);
+
+/// One MIDI preview gesture from this window, addressed to the track that owns
+/// the built-in player.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SoundfontPlayerPreview {
+    NoteOn {
+        channel: u8,
+        pitch: u8,
+        velocity: u8,
+    },
+    NoteOff {
+        channel: u8,
+        pitch: u8,
+    },
+    AllNotesOff,
+}
 
 #[derive(Debug, Clone)]
 pub struct SoundfontPlayerTrackUpdate {
@@ -48,14 +77,20 @@ pub struct SoundfontPlayerTrackUpdate {
     pub polyphony: usize,
 }
 
+type PreviewCb = Arc<dyn Fn(&str, SoundfontPlayerPreview, &mut App) + Send + Sync>;
+
 pub struct SoundfontPlayerWindow {
     track_id: String,
     on_close: Arc<dyn Fn(&mut Window, &mut App) + Send + Sync>,
     on_update_track: Arc<dyn Fn(SoundfontPlayerTrackUpdate, &mut App) + Send + Sync>,
+    on_preview: PreviewCb,
     focus_handle: FocusHandle,
     player: Option<SoundfontPlayer>,
     loaded_path: Option<PathBuf>,
     panel: SoundfontPlayerPanelState,
+    /// Bumped whenever an audition starts or is cancelled, so a hold timer that
+    /// belongs to an earlier press cannot release the notes of a later one.
+    test_generation: u64,
 }
 
 impl SoundfontPlayerWindow {
@@ -63,17 +98,123 @@ impl SoundfontPlayerWindow {
         track_id: String,
         on_close: Arc<dyn Fn(&mut Window, &mut App) + Send + Sync>,
         on_update_track: Arc<dyn Fn(SoundfontPlayerTrackUpdate, &mut App) + Send + Sync>,
+        on_preview: PreviewCb,
         cx: &mut Context<Self>,
     ) -> Self {
         Self {
             track_id,
             on_close,
             on_update_track,
+            on_preview,
             focus_handle: cx.focus_handle(),
             player: None,
             loaded_path: None,
             panel: SoundfontPlayerPanelState::default(),
+            test_generation: 0,
         }
+    }
+
+    fn preview(&self, event: SoundfontPlayerPreview, app: &mut App) {
+        (self.on_preview)(&self.track_id, event, app);
+    }
+
+    /// The channel this window must preview on. A drum-bank preset only exists
+    /// on the percussion channel — auditioning it on channel 1 would play
+    /// whatever melodic preset that channel happens to hold.
+    fn preview_channel(&self) -> u8 {
+        match self.panel.selected_preset {
+            Some((bank, _)) if bank >= sphere_soundfont_player::DRUM_BANK => {
+                sphere_soundfont_player::PERCUSSION_CHANNEL
+            }
+            _ => PREVIEW_MIDI_CHANNEL,
+        }
+    }
+
+    /// Presses one panel key. Held until [`Self::note_off`] so a sustained
+    /// preset actually sustains, matching the piano roll's key behavior.
+    fn note_on(&mut self, pitch: u8, app: &mut App) {
+        if !self.panel.is_playable() || self.panel.active_notes.contains(&pitch) {
+            return;
+        }
+        let channel = self.preview_channel();
+        self.panel.active_notes.push(pitch);
+        self.panel.status = None;
+        self.preview(
+            SoundfontPlayerPreview::NoteOn {
+                channel,
+                pitch,
+                velocity: PREVIEW_VELOCITY,
+            },
+            app,
+        );
+    }
+
+    fn note_off(&mut self, pitch: u8, app: &mut App) {
+        if !self.panel.active_notes.contains(&pitch) {
+            return;
+        }
+        let channel = self.preview_channel();
+        self.panel.active_notes.retain(|held| *held != pitch);
+        if self.panel.active_notes.is_empty() {
+            self.panel.testing = false;
+        }
+        self.preview(SoundfontPlayerPreview::NoteOff { channel, pitch }, app);
+    }
+
+    /// Auditions the loaded preset through the engine and releases the chord
+    /// after [`TEST_CHORD_HOLD`].
+    fn start_test(&mut self, cx: &mut Context<Self>) {
+        if !self.panel.is_playable() {
+            self.panel.status = Some("Load a SoundFont before testing.".into());
+            return;
+        }
+        self.release_all(cx);
+        self.test_generation = self.test_generation.wrapping_add(1);
+        let generation = self.test_generation;
+        let channel = self.preview_channel();
+        self.panel.testing = true;
+        self.panel.status = None;
+        for pitch in TEST_CHORD {
+            self.panel.active_notes.push(pitch);
+            self.preview(
+                SoundfontPlayerPreview::NoteOn {
+                    channel,
+                    pitch,
+                    velocity: PREVIEW_VELOCITY,
+                },
+                cx,
+            );
+        }
+
+        let entity = cx.entity().clone();
+        cx.spawn(async move |_this, cx| {
+            cx.background_executor().timer(TEST_CHORD_HOLD).await;
+            let _ = entity.update(cx, |this, cx| {
+                if this.test_generation != generation {
+                    return;
+                }
+                this.release_all(cx);
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    /// Releases every note this panel is holding. Also invalidates any pending
+    /// audition timer.
+    fn release_all(&mut self, app: &mut App) {
+        self.test_generation = self.test_generation.wrapping_add(1);
+        self.panel.testing = false;
+        if self.panel.active_notes.is_empty() {
+            return;
+        }
+        self.panel.active_notes.clear();
+        self.preview(SoundfontPlayerPreview::AllNotesOff, app);
+    }
+
+    fn shift_octave(&mut self, delta: i32, app: &mut App) {
+        self.release_all(app);
+        self.panel.shift_keyboard_octave(delta);
     }
 
     /// Kept for the existing Inspector open path. The window now contains one
@@ -155,7 +296,7 @@ impl SoundfontPlayerWindow {
                 self.panel.selected_preset = None;
                 self.panel.status = None;
                 if let Some(first) = self.panel.presets.first() {
-                    match player.select_preset(PREVIEW_MIDI_CHANNEL, first.bank, first.patch) {
+                    match player.select_preset_all_channels(first.bank, first.patch) {
                         Ok(()) => self.panel.selected_preset = Some((first.bank, first.patch)),
                         Err(error) => {
                             self.panel.status =
@@ -184,7 +325,7 @@ impl SoundfontPlayerWindow {
         let Some(player) = self.player.as_mut() else {
             return;
         };
-        match player.select_preset(PREVIEW_MIDI_CHANNEL, bank, patch) {
+        match player.select_preset_all_channels(bank, patch) {
             Ok(()) => {
                 self.panel.selected_preset = Some((bank, patch));
                 self.panel.preset_list_open = false;
@@ -227,7 +368,7 @@ impl SoundfontPlayerWindow {
             Ok(mut player) => {
                 player.set_master_volume(self.panel.master_volume);
                 if let Some((bank, patch)) = self.panel.selected_preset {
-                    if let Err(error) = player.select_preset(PREVIEW_MIDI_CHANNEL, bank, patch) {
+                    if let Err(error) = player.select_preset_all_channels(bank, patch) {
                         self.panel.status = Some(format!("Preset reselect failed: {error}"));
                     }
                 }
@@ -257,6 +398,7 @@ impl Render for SoundfontPlayerWindow {
         }
         let on_close = self.on_close.clone();
         let entity = cx.entity().clone();
+        let self_entity = entity.clone();
 
         let panel_callbacks = SoundfontPlayerCallbacks {
             on_browse: Arc::new({
@@ -308,11 +450,59 @@ impl Render for SoundfontPlayerWindow {
                     });
                 }
             }),
-            on_set_polyphony: Arc::new(move |value: &usize, _window, app: &mut App| {
-                let value = *value;
+            on_set_polyphony: Arc::new({
+                let entity = entity.clone();
+                move |value: &usize, _window, app: &mut App| {
+                    let value = *value;
+                    let _ = entity.update(app, |this, cx| {
+                        this.set_polyphony(value);
+                        this.notify_track_update(cx);
+                        cx.notify();
+                    });
+                }
+            }),
+            on_note_on: Arc::new({
+                let entity = entity.clone();
+                move |pitch: &u8, _window, app: &mut App| {
+                    let pitch = *pitch;
+                    let _ = entity.update(app, |this, cx| {
+                        this.note_on(pitch, cx);
+                        cx.notify();
+                    });
+                }
+            }),
+            on_note_off: Arc::new({
+                let entity = entity.clone();
+                move |pitch: &u8, _window, app: &mut App| {
+                    let pitch = *pitch;
+                    let _ = entity.update(app, |this, cx| {
+                        this.note_off(pitch, cx);
+                        cx.notify();
+                    });
+                }
+            }),
+            on_test: Arc::new({
+                let entity = entity.clone();
+                move |_window, app: &mut App| {
+                    let _ = entity.update(app, |this, cx| {
+                        this.start_test(cx);
+                        cx.notify();
+                    });
+                }
+            }),
+            on_all_notes_off: Arc::new({
+                let entity = entity.clone();
+                move |_window, app: &mut App| {
+                    let _ = entity.update(app, |this, cx| {
+                        this.release_all(cx);
+                        cx.notify();
+                    });
+                }
+            }),
+            on_shift_octave: Arc::new(move |delta: &i32, _window, app: &mut App| {
+                let delta = *delta;
                 let _ = entity.update(app, |this, cx| {
-                    this.set_polyphony(value);
-                    this.notify_track_update(cx);
+                    this.shift_octave(delta, cx);
                     cx.notify();
                 });
             }),
@@ -330,9 +520,15 @@ impl Render for SoundfontPlayerWindow {
             .child(external_window_titlebar(
                 SOUNDFONT_PLAYER_MDI_TITLE,
                 "soundfont-player-window-close",
-                move |window, cx| {
-                    on_close(window, cx);
-                    window.remove_window();
+                {
+                    let entity = self_entity.clone();
+                    move |window, cx| {
+                        // Closing must not leave an auditioned note held on the
+                        // engine — nothing would ever send its note-off.
+                        let _ = entity.update(cx, |this, cx| this.release_all(cx));
+                        on_close(window, cx);
+                        window.remove_window();
+                    }
                 },
             ))
             .child(
@@ -350,6 +546,7 @@ pub fn open_soundfont_player_window(
     track_id: String,
     on_close: Arc<dyn Fn(&mut Window, &mut App) + Send + Sync>,
     on_update_track: Arc<dyn Fn(SoundfontPlayerTrackUpdate, &mut App) + Send + Sync>,
+    on_preview: PreviewCb,
     cx: &mut App,
 ) -> Result<WindowHandle<SoundfontPlayerWindow>, String> {
     let window_bounds = crate::window_position::centered_window_bounds(
@@ -373,7 +570,7 @@ pub fn open_soundfont_player_window(
     crate::window_position::apply_owner_display(&mut options, owner_bounds, cx);
 
     cx.open_window(options, move |_window, cx| {
-        cx.new(|cx| SoundfontPlayerWindow::new(track_id, on_close, on_update_track, cx))
+        cx.new(|cx| SoundfontPlayerWindow::new(track_id, on_close, on_update_track, on_preview, cx))
     })
     .map_err(|error| error.to_string())
 }

--- a/crates/SphereUIComponents/src/components/soundfont_player_window.rs
+++ b/crates/SphereUIComponents/src/components/soundfont_player_window.rs
@@ -47,9 +47,10 @@ const PREVIEW_VELOCITY: u8 = 100;
 /// Notes the Test button auditions: a C major triad, low enough to be clear on
 /// a bass or pad preset and high enough not to disappear on a lead.
 const TEST_CHORD: [u8; 3] = [60, 64, 67];
-/// How long the Test button holds its chord. Long enough to hear a slow
-/// attack, short enough that the button is not a mode the user has to exit.
-const TEST_CHORD_HOLD: Duration = Duration::from_millis(1_400);
+/// How long the Test button holds its chord. Long enough to judge a slow
+/// attack or a pad, short enough that the button is not a mode the user has to
+/// exit — and Stop is there for the impatient.
+const TEST_CHORD_HOLD: Duration = Duration::from_millis(2_200);
 
 /// One MIDI preview gesture from this window, addressed to the track that owns
 /// the built-in player.

--- a/crates/SphereUIComponents/src/layout/midi_input_router.rs
+++ b/crates/SphereUIComponents/src/layout/midi_input_router.rs
@@ -95,6 +95,55 @@ impl StudioLayout {
         )
     }
 
+    /// Routes a gesture from the Soundfont Player window's keyboard or Test
+    /// button. The built-in player is a track instrument with no plugin
+    /// instance, so this always lands on the engine's track MIDI preview.
+    pub(crate) fn dispatch_soundfont_preview(
+        &mut self,
+        track_id: &str,
+        event: components::soundfont_player_window::SoundfontPlayerPreview,
+        cx: &mut Context<Self>,
+    ) {
+        use components::soundfont_player_window::SoundfontPlayerPreview;
+
+        // The engine builds its player from the project snapshot, so a font or
+        // preset chosen moments ago has to reach the graph before the note
+        // does. Only forced when something is actually pending.
+        if self.audio_bridge.project_dirty {
+            self.schedule_audio_project_sync(cx, true, "soundfont_preview");
+        }
+
+        let event = match event {
+            SoundfontPlayerPreview::NoteOn {
+                channel,
+                pitch,
+                velocity,
+            } => MidiInputEvent::NoteOn {
+                note: pitch,
+                velocity,
+                channel,
+            },
+            SoundfontPlayerPreview::NoteOff { channel, pitch } => MidiInputEvent::NoteOff {
+                note: pitch,
+                channel,
+            },
+            SoundfontPlayerPreview::AllNotesOff => MidiInputEvent::AllNotesOff,
+        };
+        let status = self.route_midi_input_event(
+            MidiInputSource::VirtualKeyboard,
+            MidiInputTarget {
+                track_id: track_id.to_string(),
+                plugin_instance_id: None,
+            },
+            event,
+            cx,
+        );
+        match status {
+            MidiInputRouteStatus::Routed => {}
+            other => eprintln!("[soundfont-player] preview not routed: {other:?}"),
+        }
+    }
+
     pub(super) fn route_midi_input_event(
         &mut self,
         source: MidiInputSource,
@@ -264,6 +313,23 @@ impl StudioLayout {
             .or_else(|| first_instrument_insert_id(track));
 
         let Some(plugin_instance_id) = plugin_instance_id else {
+            // The built-in Soundfont Player is a track instrument rather than a
+            // hosted plugin, so it has no instance id — the engine's track MIDI
+            // preview reaches it directly.
+            if track.builtin_soundfont_player {
+                let loaded = track
+                    .soundfont_path
+                    .as_deref()
+                    .is_some_and(|path| !path.is_empty());
+                return VirtualKeyboardTargetStatus {
+                    target: loaded.then(|| MidiInputTarget {
+                        track_id: track.id.clone(),
+                        plugin_instance_id: None,
+                    }),
+                    label: Some(track.name.clone()),
+                    hint: (!loaded).then(|| "Load a SoundFont on the selected track.".to_string()),
+                };
+            }
             return VirtualKeyboardTargetStatus {
                 target: None,
                 label: Some(track.name.clone()),

--- a/crates/SphereUIComponents/src/layout/window_ops.rs
+++ b/crates/SphereUIComponents/src/layout/window_ops.rs
@@ -942,11 +942,29 @@ impl StudioLayout {
             });
         });
 
+        // The window's own player is control-side only. Auditioning routes
+        // through the engine's MIDI preview so the sound comes from the track's
+        // instrument — the same signal path playback uses.
+        let studio = cx.entity().clone();
+        let on_preview: Arc<
+            dyn Fn(
+                    &str,
+                    crate::components::soundfont_player_window::SoundfontPlayerPreview,
+                    &mut App,
+                ) + Send
+                + Sync,
+        > = Arc::new(move |track_id, event, app| {
+            let _ = studio.update(app, |layout, cx| {
+                layout.dispatch_soundfont_preview(track_id, event, cx);
+            });
+        });
+
         match crate::components::soundfont_player_window::open_soundfont_player_window(
             owner_bounds,
             track_id,
             on_close,
             on_update_track,
+            on_preview,
             cx,
         ) {
             Ok(handle) => self.external_windows.soundfont_player = Some(handle),

--- a/crates/SphereUIComponents/src/project/format.rs
+++ b/crates/SphereUIComponents/src/project/format.rs
@@ -4,9 +4,9 @@ use super::{
     MidiControllerPoint, MidiNote, MidiSysExEvent, MidiSysExKind, PluginFormat, PluginStateBlob,
     ProjectAsset, ProjectClip, ProjectInsert, ProjectLyricSyllable, ProjectLyricSyllableMode,
     ProjectMixer, ProjectPluginInstance, ProjectSend, ProjectSongSectionType, ProjectSongTextEvent,
-    ProjectSongTextEventKind, ProjectTempoPoint, ProjectTimelineMarker, ProjectTimelineRegion,
-    ProjectTrack, ProjectTrackAudioFormat, ProjectTrackInputRouting, ProjectTrackMidiInputRouting,
-    ProjectTrackOutputRouting, ProjectTrackType, TrackRouting,
+    ProjectSongTextEventKind, ProjectSoundfontPlayer, ProjectTempoPoint, ProjectTimelineMarker,
+    ProjectTimelineRegion, ProjectTrack, ProjectTrackAudioFormat, ProjectTrackInputRouting,
+    ProjectTrackMidiInputRouting, ProjectTrackOutputRouting, ProjectTrackType, TrackRouting,
 };
 use crate::components::timeline::timeline_state::{
     AudioClipStretchState, StretchAlgorithm, StretchMode, WarpMarker,
@@ -50,7 +50,10 @@ pub const PROJECT_MAGIC: &[u8; 8] = b"FBSTUD1\0";
 /// v27 replaces combined chord/lyric cues with typed Song Text events and adds
 /// lyric timing/syllable data plus section metadata. v24-v26 cues migrate on load;
 /// pre-v24 projects have no Song Text events.
-pub const PROJECT_VERSION: u32 = 27;
+/// v28 persists the built-in Soundfont Player instrument per track (`.sf2`
+/// path, preset bank/patch, volume, reverb/chorus, polyphony). Pre-v28 tracks
+/// load with no soundfont, which is what they had before the field existed.
+pub const PROJECT_VERSION: u32 = 28;
 
 /// Minimum on-disk header size: magic (8) + version (4) + reserved (4) + body_len (4).
 pub const PROJECT_HEADER_SIZE: usize = 20;
@@ -783,6 +786,49 @@ fn encode_track(w: &mut FbWriter, t: &ProjectTrack) {
         encode_clip(w, c);
     }
     w.write_opt_f32(&t.row_height_px);
+    encode_soundfont_player(w, t.soundfont.as_ref()); // v28
+}
+
+/// v28: built-in Soundfont Player instrument state. A leading flag keeps the
+/// common case (no soundfont on this track) to a single byte.
+fn encode_soundfont_player(w: &mut FbWriter, soundfont: Option<&ProjectSoundfontPlayer>) {
+    let Some(soundfont) = soundfont else {
+        w.write_bool(false);
+        return;
+    };
+    w.write_bool(true);
+    w.write_opt_path(&soundfont.path);
+    // Bank and patch are only meaningful together, and both are non-negative
+    // (MIDI bank select / program change), so one flag plus two u32s round-trips
+    // the pair without a signed encoding.
+    let preset = soundfont.preset_bank.zip(soundfont.preset_patch);
+    w.write_bool(preset.is_some());
+    let (bank, patch) = preset.unwrap_or((0, 0));
+    w.write_u32(bank.max(0) as u32);
+    w.write_u32(patch.max(0) as u32);
+    w.write_f32(soundfont.volume);
+    w.write_bool(soundfont.reverb_chorus);
+    w.write_u32(soundfont.polyphony);
+}
+
+fn decode_soundfont_player(
+    r: &mut FbReader,
+) -> Result<Option<ProjectSoundfontPlayer>, ProjectError> {
+    if !r.read_bool()? {
+        return Ok(None);
+    }
+    let path = r.read_opt_path()?;
+    let has_preset = r.read_bool()?;
+    let bank = r.read_u32()? as i32;
+    let patch = r.read_u32()? as i32;
+    Ok(Some(ProjectSoundfontPlayer {
+        path,
+        preset_bank: has_preset.then_some(bank),
+        preset_patch: has_preset.then_some(patch),
+        volume: r.read_f32()?.clamp(0.0, 1.0),
+        reverb_chorus: r.read_bool()?,
+        polyphony: r.read_u32()?.clamp(1, 256),
+    }))
 }
 
 fn encode_asset(w: &mut FbWriter, a: &ProjectAsset) {
@@ -1666,6 +1712,12 @@ fn decode_track(r: &mut FbReader, version: u32) -> Result<ProjectTrack, ProjectE
         None
     };
 
+    let soundfont = if version >= 28 {
+        decode_soundfont_player(r)?
+    } else {
+        None
+    };
+
     Ok(ProjectTrack {
         id,
         name,
@@ -1682,6 +1734,7 @@ fn decode_track(r: &mut FbReader, version: u32) -> Result<ProjectTrack, ProjectE
         automation_lanes,
         clips,
         row_height_px,
+        soundfont,
     })
 }
 
@@ -2719,6 +2772,108 @@ mod tests {
         assert!(!decoded.stretch.preserve_pitch);
     }
 
+    #[test]
+    fn soundfont_player_track_round_trips() {
+        let mut track = track_with_clip(ProjectClip {
+            id: "c1".to_string(),
+            name: "clip".to_string(),
+            start_beat: 0.0,
+            duration_beats: 4.0,
+            offset_beats: 0.0,
+            gain: 1.0,
+            muted: false,
+            source: ClipSource::Empty,
+            stretch: AudioClipStretchState::default(),
+        });
+        track.soundfont = Some(ProjectSoundfontPlayer {
+            path: Some(PathBuf::from("/home/user/SoundFonts/GeneralUser-GS.sf2")),
+            preset_bank: Some(128),
+            preset_patch: Some(8),
+            volume: 0.65,
+            reverb_chorus: false,
+            polyphony: 96,
+        });
+
+        let mut project = FutureboardProject::new("Soundfont");
+        project.tracks.push(track);
+        let decoded = decode_project(&encode_project(&project)).expect("round trip");
+        let soundfont = decoded.tracks[0]
+            .soundfont
+            .as_ref()
+            .expect("soundfont persisted");
+        assert_eq!(
+            soundfont.path.as_deref(),
+            Some(std::path::Path::new(
+                "/home/user/SoundFonts/GeneralUser-GS.sf2"
+            ))
+        );
+        assert_eq!(soundfont.preset_bank, Some(128));
+        assert_eq!(soundfont.preset_patch, Some(8));
+        assert!((soundfont.volume - 0.65).abs() < 1.0e-6);
+        assert!(!soundfont.reverb_chorus);
+        assert_eq!(soundfont.polyphony, 96);
+    }
+
+    #[test]
+    fn track_without_a_soundfont_round_trips_as_none() {
+        let track = track_with_clip(ProjectClip {
+            id: "c1".to_string(),
+            name: "clip".to_string(),
+            start_beat: 0.0,
+            duration_beats: 4.0,
+            offset_beats: 0.0,
+            gain: 1.0,
+            muted: false,
+            source: ClipSource::Empty,
+            stretch: AudioClipStretchState::default(),
+        });
+        let mut project = FutureboardProject::new("Plain");
+        project.tracks.push(track);
+        let decoded = decode_project(&encode_project(&project)).expect("round trip");
+        assert!(decoded.tracks[0].soundfont.is_none());
+    }
+
+    #[test]
+    fn pre_v28_track_loads_without_a_soundfont() {
+        // A v27 track body ends at the row height; decoding it must not read
+        // into the next record looking for a soundfont block.
+        let mut w = FbWriter::new();
+        encode_track_body_v27(&mut w);
+        let bytes = w.into_bytes();
+        let mut r = FbReader::new(&bytes);
+        let decoded = decode_track(&mut r, 27).expect("v27 track decodes");
+        assert!(decoded.soundfont.is_none());
+        assert_eq!(decoded.id, "t1");
+    }
+
+    /// Writes exactly the track body a v27 writer produced — everything through
+    /// the v17 row height, and nothing after it.
+    fn encode_track_body_v27(w: &mut FbWriter) {
+        w.write_str("t1");
+        w.write_str("Audio 1");
+        encode_track_type(w, ProjectTrackType::Audio);
+        w.write_str("#56C7C9");
+        w.write_f32(1.0);
+        w.write_f32(0.0);
+        w.write_bool(false);
+        w.write_bool(false);
+        w.write_bool(false);
+        encode_input_monitor(w, InputMonitorMode::Off);
+        let routing = TrackRouting::default();
+        encode_track_input_routing(w, &routing.input);
+        encode_track_output_routing(w, &routing.output);
+        encode_track_audio_format(w, routing.audio_format);
+        encode_track_midi_input_routing(w, &routing.midi_input);
+        w.write_opt_u8(&None);
+        w.write_bool(false);
+        w.write_opt_str(&None);
+        w.write_u32(0); // sends
+        w.write_u32(0); // inserts
+        w.write_u32(0); // automation lanes
+        w.write_u32(0); // clips
+        w.write_opt_f32(&None); // row height
+    }
+
     fn track_with_clip(clip: ProjectClip) -> ProjectTrack {
         ProjectTrack {
             id: "t1".to_string(),
@@ -2736,6 +2891,7 @@ mod tests {
             automation_lanes: Vec::new(),
             clips: vec![clip],
             row_height_px: None,
+            soundfont: None,
         }
     }
 

--- a/crates/SphereUIComponents/src/project/io.rs
+++ b/crates/SphereUIComponents/src/project/io.rs
@@ -787,6 +787,7 @@ mod tests {
                 stretch: AudioClipStretchState::default(),
             }],
             row_height_px: None,
+            soundfont: None,
         });
 
         let project_file = root.join("Portable.fbproj");
@@ -842,6 +843,7 @@ mod tests {
             automation_lanes: Vec::new(),
             clips,
             row_height_px: None,
+            soundfont: None,
         }
     }
 

--- a/crates/SphereUIComponents/src/project/mod.rs
+++ b/crates/SphereUIComponents/src/project/mod.rs
@@ -430,6 +430,39 @@ pub struct ProjectTrack {
     pub clips: Vec<ProjectClip>,
     /// Arrangement row height in px (v17+). `None` uses the default height.
     pub row_height_px: Option<f32>,
+    /// Built-in Soundfont Player instrument state (v28+). The player is a track
+    /// instrument rather than an insert, so it has no `ProjectInsert` to carry
+    /// its settings.
+    pub soundfont: Option<ProjectSoundfontPlayer>,
+}
+
+/// Persisted state of a track's built-in Soundfont Player.
+///
+/// The `.sf2` itself is referenced by absolute path, not copied into the
+/// project: General MIDI banks are large, shared between projects, and often
+/// live outside the project folder. A missing file loads as a track with no
+/// audible instrument rather than failing the project open.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectSoundfontPlayer {
+    pub path: Option<PathBuf>,
+    pub preset_bank: Option<i32>,
+    pub preset_patch: Option<i32>,
+    pub volume: f32,
+    pub reverb_chorus: bool,
+    pub polyphony: u32,
+}
+
+impl Default for ProjectSoundfontPlayer {
+    fn default() -> Self {
+        Self {
+            path: None,
+            preset_bank: None,
+            preset_patch: None,
+            volume: 1.0,
+            reverb_chorus: true,
+            polyphony: 64,
+        }
+    }
 }
 
 // ── Mixer ─────────────────────────────────────────────────────────────────────
@@ -977,6 +1010,14 @@ impl From<&TimelineState> for FutureboardProject {
                             .abs()
                             >= 0.01
                     }),
+                    soundfont: t.builtin_soundfont_player.then(|| ProjectSoundfontPlayer {
+                        path: t.soundfont_path.as_ref().map(PathBuf::from),
+                        preset_bank: t.soundfont_preset.map(|(bank, _)| bank),
+                        preset_patch: t.soundfont_preset.map(|(_, patch)| patch),
+                        volume: t.soundfont_volume,
+                        reverb_chorus: t.soundfont_reverb_chorus,
+                        polyphony: t.soundfont_polyphony as u32,
+                    }),
                 }
             })
             .collect();
@@ -1500,13 +1541,31 @@ pub fn apply_to_timeline(project: &FutureboardProject, tl: &mut TimelineState) {
                 sends,
                 routing: project_routing_to_timeline(&pt.routing, track_type),
                 instrument_plugin_instance_id,
-                // Session-only marker, not part of the project file format yet.
-                builtin_soundfont_player: false,
-                soundfont_path: None,
-                soundfont_preset: None,
-                soundfont_volume: 1.0,
-                soundfont_reverb_chorus: true,
-                soundfont_polyphony: 64,
+                builtin_soundfont_player: pt.soundfont.is_some(),
+                soundfont_path: pt
+                    .soundfont
+                    .as_ref()
+                    .and_then(|sf| sf.path.as_ref())
+                    .map(|path| path.to_string_lossy().into_owned()),
+                soundfont_preset: pt
+                    .soundfont
+                    .as_ref()
+                    .and_then(|sf| sf.preset_bank.zip(sf.preset_patch)),
+                soundfont_volume: pt
+                    .soundfont
+                    .as_ref()
+                    .map(|sf| sf.volume.clamp(0.0, 1.0))
+                    .unwrap_or(1.0),
+                soundfont_reverb_chorus: pt
+                    .soundfont
+                    .as_ref()
+                    .map(|sf| sf.reverb_chorus)
+                    .unwrap_or(true),
+                soundfont_polyphony: pt
+                    .soundfont
+                    .as_ref()
+                    .map(|sf| sf.polyphony.clamp(1, 256) as usize)
+                    .unwrap_or(64),
             }
         })
         .collect();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

### Engine (`SphereSoundfontPlayer`, `SphereDirectAudioEngine`)

- **Parsed banks are shared.** Rebuilding the synthesizer (polyphony, reverb/chorus, sample rate) and cloning the runtime graph both used to re-read the `.sf2` from disk — tens of megabytes for a General MIDI bank, on the control thread, on every graph swap. `font_cache` holds parsed fonts weakly, and rebuilds hand the existing `Arc<SoundFont>` straight to the new synthesizer.
- **Preset selection covers every melodic channel.** Only channel 1 was selected, so a track that spreads notes across channels played the SoundFont's default preset on the rest.
- **Drum banks are reachable.** Bank select cannot address bank 128 from a melodic channel, so a drum kit could never be selected. Drum-bank presets now go to the percussion channel, and unreachable channel/bank combinations are reported instead of silently landing on another preset.
- **Pitch bend is pitch bend.** Controller lanes reached the player clamped into `0..127`, turning the engine's pitch-bend controller number into an arbitrary CC.
- **Preview notes reach the built-in player.** It is a track instrument with no instrument insert index, so every preview note was dropped — the piano roll could not audition a Soundfont Player track at all.

### UI (`SphereUIComponents`)

- The Soundfont Player window's keyboard strip was decoration. It is now playable, press-and-hold, with an octave stepper and a readout of what is sounding.
- A **Test** button auditions a C major triad and turns into **Stop** while anything is held.
- Both route through the engine's track MIDI preview, so the sound comes from the track's own instrument rather than the window's control-side player. Closing the window releases held notes.
- The global virtual keyboard now targets a Soundfont Player track instead of reporting that the track has no instrument.

## Tests

A synthetic SF2 behind a `test-support` feature lets both crates exercise the real load → preset → render path.

- `cargo test -p SphereSoundfontPlayer --features test-support` — 16 tests
- `cargo test -p sphere_directaudioengine --lib soundfont` — 6 tests
- `cargo test -p sphere_ui_components --lib soundfont` — 8 tests

## Manual testing

Verified in the running app against [GeneralUser GS](https://github.com/mrbumpy409/GeneralUser-GS), including writing MIDI in the piano roll and capturing the rendered audio.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0936b6b5-0bcd-4c79-9ce6-6e26ca6eee34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0936b6b5-0bcd-4c79-9ce6-6e26ca6eee34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

