### PR TITLE
Open the Soundfont Player window on the track's saved SoundFont

### DIFF
--- a/crates/SphereDirectAudioEngine/src/engine/render.rs
+++ b/crates/SphereDirectAudioEngine/src/engine/render.rs
@@ -2463,7 +2463,10 @@ mod live_input_monitor_tests {
 mod soundfont_instrument_tests {
     use super::render_project_block_interleaved;
     use crate::runtime::RuntimeProject;
-    use crate::types::{EngineProjectSnapshot, EngineRoutingSnapshot, EngineTrackSnapshot};
+    use crate::types::{
+        EngineMidiClipSnapshot, EngineMidiNoteSnapshot, EngineProjectSnapshot,
+        EngineRoutingSnapshot, EngineTrackSnapshot,
+    };
     use sphere_soundfont_player::test_font;
     use std::collections::HashMap;
     use std::path::PathBuf;
@@ -2663,6 +2666,120 @@ mod soundfont_instrument_tests {
 
         cloned.midi_preview_note_on("sf-1", 0, 60, 100);
         assert!(render_peak(&mut cloned) > 0.001);
+    }
+
+    /// Renders a whole bar of transport playback offline and reports the peak
+    /// level in each 0.25-beat slice, so a test can assert *when* the notes of
+    /// a MIDI clip sound rather than only that something did.
+    fn render_bar_envelope(runtime: &mut RuntimeProject, beats: f64, bpm: f64) -> Vec<f32> {
+        let samples_per_beat = SAMPLE_RATE as f64 * 60.0 / bpm;
+        let total = (samples_per_beat * beats) as u64;
+        let mut envelope = Vec::new();
+        let mut position = 0u64;
+        let slice = (samples_per_beat * 0.25) as u64;
+        while position < total {
+            let mut slice_peak = 0.0f32;
+            let slice_end = (position + slice).min(total);
+            while position < slice_end {
+                let frames = FRAMES.min((slice_end - position) as usize);
+                let mut output = vec![0.0f32; frames * 2];
+                crate::engine::schedule_midi_render_block(runtime, position, frames as u64, None);
+                render_project_block_interleaved(
+                    runtime,
+                    position,
+                    1.0,
+                    &mut output,
+                    2,
+                    true,
+                    4,
+                    4,
+                    None,
+                );
+                slice_peak = output.iter().fold(slice_peak, |peak, s| peak.max(s.abs()));
+                position += frames as u64;
+            }
+            envelope.push(slice_peak);
+        }
+        envelope
+    }
+
+    #[test]
+    fn midi_clip_notes_play_through_the_soundfont_during_transport() {
+        // The arrangement path: a MIDI clip on a Soundfont Player track, played
+        // by the transport rather than auditioned. Two notes a bar apart, so
+        // the rendered envelope has to be silent before the first, loud on each
+        // note, and quiet in the gap between them.
+        let font = FontFile::new("clip");
+        let bpm = 120.0;
+        let mut snapshot = EngineProjectSnapshot {
+            project_id: "soundfont-clip".to_string(),
+            project_root: None,
+            preferred_input_device: None,
+            bpm,
+            tempo_points: Vec::new(),
+            time_signature: [4, 4],
+            sample_rate: SAMPLE_RATE,
+            tracks: vec![
+                soundfont_track("sf-1", &font, test_font::MELODIC_PRESET),
+                master_track(),
+            ],
+            clips: Vec::new(),
+            midi_clips: vec![EngineMidiClipSnapshot {
+                id: "clip-1".to_string(),
+                track_id: "sf-1".to_string(),
+                start_beat: 1.0,
+                length_beats: 4.0,
+                notes: vec![
+                    EngineMidiNoteSnapshot {
+                        id: 1,
+                        pitch: 60,
+                        start_beat: 0.0,
+                        length_beats: 0.5,
+                        velocity: 100,
+                        channel: 0,
+                    },
+                    EngineMidiNoteSnapshot {
+                        id: 2,
+                        pitch: 67,
+                        start_beat: 3.0,
+                        length_beats: 0.5,
+                        velocity: 100,
+                        channel: 0,
+                    },
+                ],
+                controllers: Vec::new(),
+            }],
+            pdc_enabled: true,
+            latency_graph_version: 1,
+            routing: EngineRoutingSnapshot {
+                master_output_device: None,
+                sample_rate: SAMPLE_RATE,
+                buffer_size: FRAMES as u32,
+            },
+        };
+        snapshot.midi_clips[0].length_beats = 4.0;
+
+        let mut runtime =
+            RuntimeProject::build(&snapshot, SAMPLE_RATE, &mut HashMap::new(), None, true)
+                .expect("runtime builds");
+        let envelope = render_bar_envelope(&mut runtime, 6.0, bpm);
+
+        // Beat 0..1 is before the clip starts.
+        let before = envelope[..4].iter().fold(0.0f32, |a, b| a.max(*b));
+        assert!(before < 1.0e-6, "silent before the clip: {before}");
+
+        // The clip's first note lands on beat 1, the second on beat 4.
+        let first = envelope[4..6].iter().fold(0.0f32, |a, b| a.max(*b));
+        let second = envelope[16..18].iter().fold(0.0f32, |a, b| a.max(*b));
+        assert!(first > 0.001, "first note should sound: {first}");
+        assert!(second > 0.001, "second note should sound: {second}");
+
+        // The two-beat gap in the middle decays well below the note attacks.
+        let gap = envelope[10..15].iter().fold(0.0f32, |a, b| a.max(*b));
+        assert!(
+            gap < first * 0.5,
+            "gap between notes should decay: gap={gap} first={first}"
+        );
     }
 
     #[test]

--- a/crates/SphereUIComponents/src/components/soundfont_player_mdi.rs
+++ b/crates/SphereUIComponents/src/components/soundfont_player_mdi.rs
@@ -802,6 +802,14 @@ mod tests {
     }
 
     #[test]
+    fn a_freshly_loaded_panel_reports_full_volume() {
+        // The panel is the authority for volume (the engine reads it from the
+        // track), so it must not start at RustySynth's own internal default.
+        let panel = SoundfontPlayerPanelState::default();
+        assert_eq!(panel.master_volume, 1.0);
+    }
+
+    #[test]
     fn panel_is_only_playable_once_a_font_is_loaded() {
         let mut panel = SoundfontPlayerPanelState::default();
         assert!(!panel.is_playable(), "no font loaded yet");

--- a/crates/SphereUIComponents/src/components/soundfont_player_window.rs
+++ b/crates/SphereUIComponents/src/components/soundfont_player_window.rs
@@ -78,6 +78,30 @@ pub struct SoundfontPlayerTrackUpdate {
     pub polyphony: usize,
 }
 
+/// A track's saved Soundfont Player settings, used to restore the window when
+/// it is opened on a track that already has a `.sf2` (a reopened project, or a
+/// window closed and reopened in the same session).
+#[derive(Debug, Clone, PartialEq)]
+pub struct SoundfontPlayerTrackState {
+    pub path: Option<String>,
+    pub preset: Option<(i32, i32)>,
+    pub volume: f32,
+    pub reverb_chorus: bool,
+    pub polyphony: usize,
+}
+
+impl Default for SoundfontPlayerTrackState {
+    fn default() -> Self {
+        Self {
+            path: None,
+            preset: None,
+            volume: 1.0,
+            reverb_chorus: true,
+            polyphony: 64,
+        }
+    }
+}
+
 type PreviewCb = Arc<dyn Fn(&str, SoundfontPlayerPreview, &mut App) + Send + Sync>;
 
 pub struct SoundfontPlayerWindow {
@@ -97,12 +121,13 @@ pub struct SoundfontPlayerWindow {
 impl SoundfontPlayerWindow {
     pub fn new(
         track_id: String,
+        initial: SoundfontPlayerTrackState,
         on_close: Arc<dyn Fn(&mut Window, &mut App) + Send + Sync>,
         on_update_track: Arc<dyn Fn(SoundfontPlayerTrackUpdate, &mut App) + Send + Sync>,
         on_preview: PreviewCb,
         cx: &mut Context<Self>,
     ) -> Self {
-        Self {
+        let mut window = Self {
             track_id,
             on_close,
             on_update_track,
@@ -112,7 +137,67 @@ impl SoundfontPlayerWindow {
             loaded_path: None,
             panel: SoundfontPlayerPanelState::default(),
             test_generation: 0,
+        };
+        window.restore_track_state(initial, cx);
+        window
+    }
+
+    /// Reloads the panel from a track's saved settings. Without this the window
+    /// would open on "No .sf2 loaded" for a track whose SoundFont the engine has
+    /// had loaded since the project opened, and the first gesture would publish
+    /// that empty state back over the saved one.
+    fn restore_track_state(&mut self, state: SoundfontPlayerTrackState, cx: &mut Context<Self>) {
+        self.panel.master_volume = state.volume.clamp(0.0, 1.0);
+        self.panel.reverb_chorus = state.reverb_chorus;
+        self.panel.polyphony = state.polyphony.clamp(1, 256);
+
+        let Some(path) = state
+            .path
+            .filter(|path| !path.is_empty())
+            .map(PathBuf::from)
+        else {
+            self.player = None;
+            self.loaded_path = None;
+            self.panel.file_name = None;
+            self.panel.bank_name = None;
+            self.panel.presets.clear();
+            self.panel.selected_preset = None;
+            return;
+        };
+        if self.loaded_path.as_deref() == Some(path.as_path()) {
+            return;
         }
+
+        // Parsing a General MIDI bank takes long enough to stall the first
+        // frame, so load it the same way Browse does — off the UI thread, with
+        // the panel showing its loading state until it lands.
+        self.panel.loading = true;
+        self.panel.status = None;
+        let settings = SoundfontPlayerSettings {
+            sample_rate: 44_100,
+            block_size: 0,
+            maximum_polyphony: self.panel.polyphony,
+            enable_reverb_and_chorus: self.panel.reverb_chorus,
+        };
+        let entity = cx.entity().clone();
+        let preset = state.preset;
+        cx.spawn(async move |_this, cx| {
+            let result = cx
+                .background_spawn({
+                    let path = path.clone();
+                    async move { SoundfontPlayer::from_path(&path, settings) }
+                })
+                .await;
+            let _ = entity.update(cx, |this, cx| {
+                this.apply_loaded_player(path, result);
+                // Prefer the track's saved preset over the font's first one.
+                if let Some((bank, patch)) = preset {
+                    this.select_preset(bank, patch);
+                }
+                cx.notify();
+            });
+        })
+        .detach();
     }
 
     fn preview(&self, event: SoundfontPlayerPreview, app: &mut App) {
@@ -218,10 +303,20 @@ impl SoundfontPlayerWindow {
         self.panel.shift_keyboard_octave(delta);
     }
 
-    /// Kept for the existing Inspector open path. The window now contains one
-    /// direct panel, so focusing the OS window is handled by the caller.
-    pub fn focus_soundfont_player(&mut self, track_id: String) {
-        self.track_id = track_id;
+    /// Retargets an already-open window at `track_id` and reloads the panel from
+    /// that track's saved settings. Focusing the OS window is the caller's job.
+    pub fn focus_soundfont_player(
+        &mut self,
+        track_id: String,
+        state: SoundfontPlayerTrackState,
+        cx: &mut Context<Self>,
+    ) {
+        if self.track_id != track_id {
+            self.release_all(cx);
+            self.track_id = track_id;
+            self.loaded_path = None;
+        }
+        self.restore_track_state(state, cx);
     }
 
     fn notify_track_update(&self, app: &mut App) {
@@ -305,7 +400,11 @@ impl SoundfontPlayerWindow {
                         }
                     }
                 }
-                self.panel.master_volume = player.master_volume();
+                // The panel (and through it the track state the engine reads) is
+                // the authority for volume — a freshly built synthesizer starts
+                // at RustySynth's own default, which would otherwise show up as
+                // a volume the user never chose and disagree with playback.
+                player.set_master_volume(self.panel.master_volume);
                 self.panel.reverb_chorus = player.enable_reverb_and_chorus();
                 self.panel.polyphony = player.maximum_polyphony();
                 self.player = Some(player);
@@ -545,6 +644,7 @@ impl Render for SoundfontPlayerWindow {
 pub fn open_soundfont_player_window(
     owner_bounds: Option<Bounds<gpui::Pixels>>,
     track_id: String,
+    initial: SoundfontPlayerTrackState,
     on_close: Arc<dyn Fn(&mut Window, &mut App) + Send + Sync>,
     on_update_track: Arc<dyn Fn(SoundfontPlayerTrackUpdate, &mut App) + Send + Sync>,
     on_preview: PreviewCb,
@@ -571,7 +671,9 @@ pub fn open_soundfont_player_window(
     crate::window_position::apply_owner_display(&mut options, owner_bounds, cx);
 
     cx.open_window(options, move |_window, cx| {
-        cx.new(|cx| SoundfontPlayerWindow::new(track_id, on_close, on_update_track, on_preview, cx))
+        cx.new(|cx| {
+            SoundfontPlayerWindow::new(track_id, initial, on_close, on_update_track, on_preview, cx)
+        })
     })
     .map_err(|error| error.to_string())
 }

--- a/crates/SphereUIComponents/src/layout/window_ops.rs
+++ b/crates/SphereUIComponents/src/layout/window_ops.rs
@@ -880,6 +880,28 @@ impl StudioLayout {
         }
     }
 
+    /// A track's persisted Soundfont Player settings, so an opening window shows
+    /// the `.sf2` and preset the engine is already playing rather than an empty
+    /// panel.
+    fn soundfont_track_state(
+        &self,
+        track_id: &str,
+        cx: &App,
+    ) -> crate::components::soundfont_player_window::SoundfontPlayerTrackState {
+        use crate::components::soundfont_player_window::SoundfontPlayerTrackState;
+        let timeline = self.timeline.read(cx);
+        let Some(track) = timeline.state.find_track(track_id) else {
+            return SoundfontPlayerTrackState::default();
+        };
+        SoundfontPlayerTrackState {
+            path: track.soundfont_path.clone(),
+            preset: track.soundfont_preset,
+            volume: track.soundfont_volume,
+            reverb_chorus: track.soundfont_reverb_chorus,
+            polyphony: track.soundfont_polyphony,
+        }
+    }
+
     /// Opens the built-in Soundfont Player MDI window, or focuses it (and its
     /// document) if already open. Called from the Inspector's Open button for
     /// an Instrument track whose `builtin_soundfont_player` marker is set.
@@ -889,10 +911,11 @@ impl StudioLayout {
         track_id: String,
         cx: &mut Context<Self>,
     ) {
+        let initial = self.soundfont_track_state(&track_id, cx);
         if let Some(handle) = self.external_windows.soundfont_player.clone() {
             let activated = handle
                 .update(cx, |window, w, cx| {
-                    window.focus_soundfont_player(track_id.clone());
+                    window.focus_soundfont_player(track_id.clone(), initial.clone(), cx);
                     w.activate_window();
                     cx.notify();
                 })
@@ -962,6 +985,7 @@ impl StudioLayout {
         match crate::components::soundfont_player_window::open_soundfont_player_window(
             owner_bounds,
             track_id,
+            initial,
             on_close,
             on_update_track,
             on_preview,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #49, which added v28 persistence for the built-in Soundfont Player but left the window unable to show it.

## The problem

The Soundfont Player window always started on "No .sf2 loaded", even for a track whose bank the engine had loaded since the project opened. Reopening a project therefore looked like it had lost its instrument, and the first gesture in the window published that empty panel back over the saved settings — so the data was persisted correctly and then destroyed by the UI.

## The fix

- Opening the window, or retargeting an already-open one at a different track, restores that track's `.sf2` path, preset, volume, reverb/chorus and polyphony. The bank is parsed off the UI thread the same way Browse does, so a 32 MB General MIDI file does not stall the first frame.
- The panel is now the authority for volume instead of reading it back from a freshly built synthesizer. That read reported RustySynth's internal `0.5` default as a "50%" the user never chose, and it disagreed with what the engine actually played — the engine takes volume from the track state, which defaults to unity.

## Tests

`cargo test -p sphere_ui_components --lib` — 547 passed (one new assertion covering the panel's volume default). `cargo fmt --all -- --check` clean.

## Manual verification

Loaded GeneralUser GS on a Soundfont Player track, saved, closed the project, and reopened it. The window now comes up on the saved bank and preset without touching Browse:

[Soundfont Player restored after reopening the project](https://cursor.com/agents/bc-0936b6b5-0bcd-4c79-9ce6-6e26ca6eee34/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsoundfont_restored_after_project_reopen.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0936b6b5-0bcd-4c79-9ce6-6e26ca6eee34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0936b6b5-0bcd-4c79-9ce6-6e26ca6eee34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

