### PR TITLE
fix(rodharerist dsp): replace every waveshaper with a solved circuit

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/amp.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/amp.rs
@@ -7,10 +7,19 @@
 //! models run the complete nonlinear core at 4×; the two high-gain models run
 //! at 8×.  Model changes use two preallocated lanes and an equal-power
 //! crossfade, so no allocation or coefficient construction occurs here.
+//!
+//! Every nonlinearity is a circuit stage from [`super::nonlinear`], never a
+//! transfer curve. Each preamp stage is a self-biasing triode with a cathode
+//! bypass, Miller pole and grid conduction; the output stage is a real push-pull
+//! pair against a sagging rail. The previous build shaped a low band and a high
+//! band through two static curves and summed them, which both muddied the low
+//! end (bass hit the same ceiling as the pick attack) and produced the flat,
+//! non-guitar break-up of a memoryless clipper.
 
 use builtin_dsp_core::time_constant;
 
 use super::AmpModel;
+use super::nonlinear::{PushPullParams, TriodeParams, TriodeState};
 use super::smooth::{Oversampler4x, Oversampler8x, Smoothed};
 
 const MAX_PREAMP_STAGES: usize = 4;
@@ -430,26 +439,16 @@ impl InputFilter {
 }
 
 #[derive(Debug, Clone, Copy, Default)]
-struct StageState {
-    coupling_x: f32,
-    coupling_y: f32,
-    spectral_low: f32,
-    envelope: f32,
-    bias_memory: f32,
-}
-
-#[derive(Debug, Clone, Copy, Default)]
 struct ToneState {
     low: f32,
     high_lp: f32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 struct ChannelCore {
-    stages: [StageState; MAX_PREAMP_STAGES],
+    stages: [TriodeState; MAX_PREAMP_STAGES],
+    inverter: TriodeState,
     tone: ToneState,
-    pi_env: f32,
-    pi_bias: f32,
     sag: f32,
     transformer_flux: f32,
     speaker_low: f32,
@@ -457,19 +456,15 @@ struct ChannelCore {
     previous_load: f32,
 }
 
-impl Default for ChannelCore {
-    fn default() -> Self {
-        Self {
-            stages: [StageState::default(); MAX_PREAMP_STAGES],
-            tone: ToneState::default(),
-            pi_env: 0.0,
-            pi_bias: 0.0,
-            sag: 0.0,
-            transformer_flux: 0.0,
-            speaker_low: 0.0,
-            feedback_high_lp: 0.0,
-            previous_load: 0.0,
+impl ChannelCore {
+    /// Start every valve at its own operating point instead of letting the
+    /// cathode RCs charge up audibly over the first few milliseconds.
+    fn prime(&mut self, voicing: &AmpVoicing) {
+        *self = Self::default();
+        for (state, params) in self.stages.iter_mut().zip(voicing.stages.iter()) {
+            state.prime(params);
         }
+        self.inverter.prime(&voicing.inverter);
     }
 }
 
@@ -479,25 +474,75 @@ struct AmpCore {
     right: ChannelCore,
 }
 
+impl AmpCore {
+    fn prime(&mut self, voicing: &AmpVoicing) {
+        self.left.prime(voicing);
+        self.right.prime(voicing);
+    }
+}
+
+/// The valve complement of one amp lane, solved on the control path.
+///
+/// Operating points, plate-load normalization and grid-conduction thresholds
+/// all take iteration to settle, so they are resolved here whenever the model
+/// or a knob changes and only read from the audio callback.
+#[derive(Debug, Clone)]
+struct AmpVoicing {
+    stages: [TriodeParams; MAX_PREAMP_STAGES],
+    inverter: TriodeParams,
+    power: PushPullParams,
+}
+
+impl Default for AmpVoicing {
+    fn default() -> Self {
+        let mut stage = TriodeParams {
+            grid_offset: 1.35,
+            knee: 0.05,
+            headroom: 3.4,
+            sat_knee: 0.06,
+            cathode_r: 0.20,
+            cathode_alpha: 0.01,
+            miller_alpha: 0.5,
+            grid_headroom: 1.2,
+            grid_soft: 0.22,
+            grid_attack: 0.02,
+            grid_release: 0.0002,
+            grid_clamp: 0.0,
+            plate_r: 1.0,
+            quiescent: 0.0,
+        };
+        stage.solve_operating_point();
+        let mut power = PushPullParams {
+            bias: 0.55,
+            knee: 0.05,
+            headroom: 2.4,
+            sat_knee: 0.06,
+            asymmetry: 0.06,
+            scale: 1.0,
+        };
+        power.normalize();
+        Self {
+            stages: [stage; MAX_PREAMP_STAGES],
+            inverter: stage,
+            power,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 struct HeldControls {
     stage_gain: f32,
     inter_gain: f32,
-    bias: f32,
-    bias_move: f32,
-    pre_compression: f32,
     coupling_pole: f32,
-    spectral_alpha: f32,
     tone_low_alpha: f32,
     tone_high_alpha: f32,
     bass: f32,
     middle: f32,
     treble: f32,
     presence: f32,
+    pi_drive: f32,
     master_drive: f32,
     master_level: f32,
-    pi_attack: f32,
-    pi_release: f32,
     sag_attack: f32,
     sag_release: f32,
     transformer_alpha: f32,
@@ -514,44 +559,6 @@ fn envelope_tick(state: &mut f32, input: f32, attack: f32, release: f32) -> f32 
         *state = 0.0;
     }
     *state
-}
-
-/// Four deliberately different stage transfer curves. Each has a soft knee
-/// and unequal positive/negative behavior; none is reused for adjacent stages.
-///
-/// The curve's own ceiling is the stage's level reference — there is no
-/// drive-dependent makeup. A `1/sqrt(drive)` normalization here (what this
-/// used to do) makes every stage quieter the harder it is driven, so the whole
-/// amp reads *louder with Gain down* and never reaches a saturated wall with
-/// Gain up. A valve stage does the opposite: more drive, more level, until the
-/// plate voltage runs out.
-#[inline]
-fn stage_shape(x: f32, shape: u8, bias: f32, drive: f32) -> f32 {
-    let d = drive.max(0.25);
-    let z = x * d + bias;
-    let zero = match shape & 3 {
-        0 => bias.tanh(),
-        1 => bias.atan() * 0.92,
-        2 => bias / (1.0 + bias.abs() * 0.72),
-        _ => {
-            let b = bias.clamp(-1.0, 1.0);
-            b - b * b * b * 0.18
-        }
-    };
-    let shaped = match shape & 3 {
-        0 => z.tanh(),
-        1 => z.atan() * 0.92,
-        2 => z / (1.0 + z.abs() * 0.72),
-        _ => {
-            let a = z.abs();
-            if a < 1.0 {
-                z - z * z * z * 0.18
-            } else {
-                z.signum() * (0.82 + (a - 1.0).tanh() * 0.18)
-            }
-        }
-    };
-    finite(shaped - zero)
 }
 
 impl AmpCore {
@@ -602,6 +609,7 @@ impl AmpCore {
         channel: &mut ChannelCore,
         input: f32,
         profile: AmpProfile,
+        voicing: &AmpVoicing,
         held: HeldControls,
     ) -> f32 {
         let mut x = input;
@@ -612,52 +620,30 @@ impl AmpCore {
             0.0
         };
 
+        // Cascaded valve stages. Each one carries its own cathode charge, grid
+        // charge and Miller state, so the cascade's break-up depends on what it
+        // has been fed — and the cathode bypass corner keeps the low end from
+        // being amplified into the next stage's cutoff, which is what used to
+        // turn a driven cascade to mud.
         for i in 0..profile.stages {
-            let state = &mut channel.stages[i];
-            let coupled = x - state.coupling_x + held.coupling_pole * state.coupling_y;
-            state.coupling_x = x;
-            state.coupling_y = finite(coupled);
-
-            // Frequency-dependent saturation: a low-passed body and the
-            // upper-frequency residual hit each stage at different levels.
-            state.spectral_low += held.spectral_alpha * (state.coupling_y - state.spectral_low);
-            let low = state.spectral_low;
-            let high = state.coupling_y - low;
-            let env = envelope_tick(&mut state.envelope, state.coupling_y, 0.92, 0.997);
-            let compression = 1.0 / (1.0 + env * held.pre_compression * (1.0 + i as f32 * 0.16));
-            state.bias_memory +=
-                0.0025 * (state.coupling_y.signum() * env * held.bias_move - state.bias_memory);
-            let bias = held.bias * (1.0 - i as f32 * 0.11) + state.bias_memory;
-            let stage_drive = if i == 0 {
+            let gain = if i == 0 {
                 held.stage_gain
             } else {
                 held.inter_gain * (1.0 + i as f32 * 0.08)
             };
-            let shape = profile.shape_seed.wrapping_add(i as u8) & 3;
-            let body = stage_shape(low * compression, shape, bias, stage_drive);
-            let edge = stage_shape(
-                high * compression,
-                shape.wrapping_add(2),
-                bias * 0.65,
-                stage_drive * (0.72 + i as f32 * 0.04),
-            );
-            x = finite(body + edge * (0.76 - i as f32 * 0.04));
+            x = finite(channel.stages[i].process(x, &voicing.stages[i], gain, held.coupling_pole));
         }
 
         x = Self::tone_stack(&mut channel.tone, x, profile.tone, held);
 
-        // The phase inverter compresses dynamically and develops bias shift
-        // independently of the preamp.
-        let pi_env = envelope_tick(&mut channel.pi_env, x, held.pi_attack, held.pi_release);
-        channel.pi_bias +=
-            0.0015 * (x.signum() * pi_env * profile.pi_compression - channel.pi_bias);
-        let pi_gain = 1.0 / (1.0 + pi_env * profile.pi_compression);
-        let pi = stage_shape(
-            x * pi_gain,
-            1,
-            profile.power_asymmetry + channel.pi_bias * 0.18,
-            profile.pi_drive,
-        );
+        // The phase inverter is its own valve: it compresses, shifts bias and
+        // blocks on hard transients independently of the preamp.
+        let pi = finite(channel.inverter.process(
+            x,
+            &voicing.inverter,
+            held.pi_drive,
+            held.coupling_pole,
+        ));
 
         // Reactive speaker/load feedback. Presence changes the high-frequency
         // amount returned around the power stage; resonance changes the
@@ -673,13 +659,11 @@ impl AmpCore {
         let demand = (pi * held.master_drive).abs() + channel.previous_load.abs() * 0.25;
         let sag_env = envelope_tick(&mut channel.sag, demand, held.sag_attack, held.sag_release);
         let supply = (1.0 - profile.sag_amount * sag_env.min(1.4)).max(0.42);
-        let power_in = pi * held.master_drive * supply - feedback;
-        let power = stage_shape(
-            power_in,
-            2,
-            profile.power_asymmetry * (1.0 + sag_env * 0.25),
-            profile.power_drive / profile.power_headroom,
-        );
+        // The sagging rail lowers the pair's *ceiling* rather than scaling the
+        // signal, so quiet passages keep their level and only the peaks give.
+        let power = voicing
+            .power
+            .process(pi * held.master_drive - feedback, supply);
 
         // Transformer flux provides low-frequency memory and demand-dependent
         // compression before the electrical speaker load.
@@ -706,11 +690,12 @@ impl AmpCore {
         left: f32,
         right: f32,
         profile: AmpProfile,
+        voicing: &AmpVoicing,
         held: HeldControls,
     ) -> (f32, f32) {
         (
-            Self::process_channel(&mut self.left, left, profile, held),
-            Self::process_channel(&mut self.right, right, profile, held),
+            Self::process_channel(&mut self.left, left, profile, voicing, held),
+            Self::process_channel(&mut self.right, right, profile, voicing, held),
         )
     }
 }
@@ -723,25 +708,21 @@ struct AmpLane {
     settings: Settings,
     input: InputFilter,
     core: AmpCore,
+    voicing: AmpVoicing,
     os4: Oversampler4x,
     os8: Oversampler8x,
     stage_gain: Smoothed,
     inter_gain: Smoothed,
-    bias: Smoothed,
-    bias_move: Smoothed,
-    pre_compression: Smoothed,
     coupling_pole: Smoothed,
-    spectral_alpha: Smoothed,
     tone_low_alpha: Smoothed,
     tone_high_alpha: Smoothed,
     bass: Smoothed,
     middle: Smoothed,
     treble: Smoothed,
     presence: Smoothed,
+    pi_drive: Smoothed,
     master_drive: Smoothed,
     master_level: Smoothed,
-    pi_attack_coeff: f32,
-    pi_release_coeff: f32,
     sag_attack_coeff: f32,
     sag_release_coeff: f32,
     transformer_alpha_coeff: f32,
@@ -760,25 +741,21 @@ impl AmpLane {
             settings: Settings::default(),
             input: InputFilter::new(),
             core: AmpCore::default(),
+            voicing: AmpVoicing::default(),
             os4: Oversampler4x::new(),
             os8: Oversampler8x::new(),
             stage_gain: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 1.0),
             inter_gain: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 1.0),
-            bias: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, p.bias),
-            bias_move: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, p.bias_move),
-            pre_compression: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, p.pre_compression),
             coupling_pole: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 0.99),
-            spectral_alpha: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 0.1),
             tone_low_alpha: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 0.1),
             tone_high_alpha: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 0.1),
             bass: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 0.5),
             middle: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 0.5),
             treble: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 0.5),
             presence: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 0.5),
+            pi_drive: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, p.pi_drive),
             master_drive: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 1.0),
             master_level: Smoothed::new(sr, CONTROL_SMOOTH_SECONDS, 0.5),
-            pi_attack_coeff: 0.0,
-            pi_release_coeff: 0.0,
             sag_attack_coeff: 0.0,
             sag_release_coeff: 0.0,
             transformer_alpha_coeff: 0.0,
@@ -795,17 +772,14 @@ impl AmpLane {
         for value in [
             &mut self.stage_gain,
             &mut self.inter_gain,
-            &mut self.bias,
-            &mut self.bias_move,
-            &mut self.pre_compression,
             &mut self.coupling_pole,
-            &mut self.spectral_alpha,
             &mut self.tone_low_alpha,
             &mut self.tone_high_alpha,
             &mut self.bass,
             &mut self.middle,
             &mut self.treble,
             &mut self.presence,
+            &mut self.pi_drive,
             &mut self.master_drive,
             &mut self.master_level,
         ] {
@@ -824,26 +798,18 @@ impl AmpLane {
         let m = (settings.master / 10.0).clamp(0.0, 1.0);
         let osr = self.sample_rate * self.profile.oversample as f32;
 
-        // Gain moves stage gain, interstage drive, bias, compression and the
-        // coupling corner together. It is deliberately not an input multiply.
-        // Wide open every stage is well past its knee, so the cascade reaches a
-        // real saturated wall instead of asymptoting a few dB above clean.
+        // Gain moves stage gain, interstage drive and the coupling corner
+        // together. It is deliberately not an input multiply. Wide open every
+        // valve is well past its knee, so the cascade reaches a real saturated
+        // wall instead of asymptoting a few dB above clean.
         self.stage_gain
             .set_target(self.profile.pre_gain * (0.22 + g * 2.60));
         self.inter_gain
             .set_target(self.profile.inter_gain * (0.30 + g * 1.95));
-        self.bias.set_target(self.profile.bias * (0.65 + g * 0.85));
-        self.bias_move
-            .set_target(self.profile.bias_move * (0.30 + g * 1.05));
-        // Stage compression tracks Gain only loosely: coupled too tightly it
-        // becomes an automatic gain control that spends the drive it was
-        // given, which is how the knob went inert above ~4.
-        self.pre_compression
-            .set_target(self.profile.pre_compression * (0.55 + g * 0.55));
+        self.pi_drive.set_target(self.profile.pi_drive);
         let coupling_hz = self.profile.coupling_hpf * (1.0 + g * self.profile.tightness * 1.45);
         self.coupling_pole.set_target(pole(coupling_hz, osr));
-        self.spectral_alpha
-            .set_target(alpha(self.profile.stage_lpf * (1.0 - g * 0.12), osr));
+        self.resolve_voicing(g, osr);
 
         let b = (settings.bass / 10.0).clamp(0.0, 1.0);
         let mid = (settings.middle / 10.0).clamp(0.0, 1.0);
@@ -871,8 +837,6 @@ impl AmpLane {
 
         // All time constants are prepared on the control path. The audio
         // callback only reads these scalars.
-        self.pi_attack_coeff = time_constant(osr, 0.0015);
-        self.pi_release_coeff = time_constant(osr, 0.055);
         self.sag_attack_coeff = time_constant(osr, self.profile.sag_attack);
         self.sag_release_coeff = time_constant(osr, self.profile.sag_release);
         self.transformer_alpha_coeff = alpha(72.0, osr);
@@ -880,21 +844,105 @@ impl AmpLane {
         self.feedback_high_alpha_coeff = alpha(3_100.0, osr);
     }
 
+    /// Resolve the lane's valve complement: component values, operating points
+    /// and the normalizations that depend on them.
+    ///
+    /// Everything here needs iteration or a square root chain, so it happens
+    /// once per configure and never in the audio callback.
+    fn resolve_voicing(&mut self, g: f32, osr: f32) {
+        let p = self.profile;
+
+        // Cathode bypass corner. Below it the cathode follows the signal and
+        // degenerates the stage's own gain, so the low end reaches the next
+        // grid smaller than the mids do. This is the amp's real tightness
+        // mechanism and the reason a driven cascade stays articulate instead
+        // of turning to mud — no band split required.
+        let cathode_alpha = alpha(70.0 + p.tightness * 320.0 + g * 60.0, osr);
+        // Grid current builds fast and leaks away over tens of milliseconds.
+        let grid_attack = alpha(400.0 + p.bias_move * 2_600.0, osr);
+        let grid_release = alpha(5.0 + g * 12.0, osr);
+        let grid_headroom = (1.95 - p.pre_compression * 3.0).max(0.55);
+        let grid_soft = (0.32 - p.pre_compression * 0.40).clamp(0.10, 0.40);
+        let cathode_r = 0.12 + p.pre_compression * 0.50;
+
+        for i in 0..MAX_PREAMP_STAGES {
+            // Adjacent stages are deliberately not identical valves: the seed
+            // walks the operating point, cutoff softness and plate ceiling.
+            let variant = (p.shape_seed.wrapping_add(i as u8) & 3) as f32;
+            let mut stage = TriodeParams {
+                grid_offset: 1.22 + p.bias * 2.2 + variant * 0.06,
+                knee: 0.030 + variant * 0.008,
+                headroom: 2.45 - variant * 0.14,
+                sat_knee: 0.05 + variant * 0.01,
+                cathode_r,
+                cathode_alpha,
+                // Miller capacitance rolls the plate off inside the stage, so
+                // the next grid never receives a raw clipping edge to re-clip
+                // into fizz. Later stages sit darker, as they do in a real amp.
+                miller_alpha: alpha(
+                    p.stage_lpf * (1.0 - g * 0.12) * (1.0 - i as f32 * 0.12),
+                    osr,
+                ),
+                grid_headroom,
+                grid_soft,
+                grid_attack,
+                grid_release,
+                grid_clamp: 0.0,
+                plate_r: 1.0,
+                quiescent: 0.0,
+            };
+            stage.solve_operating_point();
+            self.voicing.stages[i] = stage;
+        }
+
+        // The phase inverter is a long-tailed pair: a large unbypassed tail
+        // resistor, so it degenerates hard and compresses on its own.
+        let mut inverter = TriodeParams {
+            grid_offset: 1.30 + p.power_asymmetry * 1.4,
+            knee: 0.040,
+            headroom: 2.20 + p.power_headroom * 0.35,
+            sat_knee: 0.05,
+            cathode_r: cathode_r * (1.2 + p.pi_compression * 1.4),
+            cathode_alpha: alpha(22.0, osr),
+            miller_alpha: alpha(p.stage_lpf * 1.15, osr),
+            grid_headroom: grid_headroom + 0.45,
+            grid_soft,
+            grid_attack: grid_attack * 0.6,
+            grid_release,
+            grid_clamp: 0.0,
+            plate_r: 1.0,
+            quiescent: 0.0,
+        };
+        inverter.solve_operating_point();
+        self.voicing.inverter = inverter;
+
+        // Output pair. A low idle current is class B: the halves hand over
+        // through a real crossover region, which is the grind of a cranked
+        // output stage rather than a curve pretending to have one.
+        let mut power = PushPullParams {
+            bias: 0.30 + p.power_headroom * 0.28,
+            knee: 0.045,
+            headroom: 1.60 + p.power_headroom * 1.20,
+            sat_knee: (0.10 / p.power_headroom.max(0.1)).clamp(0.02, 0.20),
+            asymmetry: p.power_asymmetry.clamp(0.0, 0.4),
+            scale: 1.0,
+        };
+        power.normalize();
+        self.voicing.power = power;
+    }
+
     fn snap_controls(&mut self) {
         for value in [
             &mut self.stage_gain,
             &mut self.inter_gain,
-            &mut self.bias,
-            &mut self.bias_move,
-            &mut self.pre_compression,
             &mut self.coupling_pole,
-            &mut self.spectral_alpha,
             &mut self.tone_low_alpha,
             &mut self.tone_high_alpha,
             &mut self.bass,
             &mut self.middle,
             &mut self.treble,
             &mut self.presence,
+            &mut self.pi_drive,
             &mut self.master_drive,
             &mut self.master_level,
         ] {
@@ -904,7 +952,7 @@ impl AmpLane {
 
     fn reset(&mut self) {
         self.input.reset();
-        self.core = AmpCore::default();
+        self.core.prime(&self.voicing);
         self.os4.reset();
         self.os8.reset();
         self.snap_controls();
@@ -915,21 +963,16 @@ impl AmpLane {
         HeldControls {
             stage_gain: self.stage_gain.tick(),
             inter_gain: self.inter_gain.tick(),
-            bias: self.bias.tick(),
-            bias_move: self.bias_move.tick(),
-            pre_compression: self.pre_compression.tick(),
             coupling_pole: self.coupling_pole.tick(),
-            spectral_alpha: self.spectral_alpha.tick(),
             tone_low_alpha: self.tone_low_alpha.tick(),
             tone_high_alpha: self.tone_high_alpha.tick(),
             bass: self.bass.tick(),
             middle: self.middle.tick(),
             treble: self.treble.tick(),
             presence: self.presence.tick(),
+            pi_drive: self.pi_drive.tick(),
             master_drive: self.master_drive.tick(),
             master_level: self.master_level.tick(),
-            pi_attack: self.pi_attack_coeff,
-            pi_release: self.pi_release_coeff,
             sag_attack: self.sag_attack_coeff,
             sag_release: self.sag_release_coeff,
             transformer_alpha: self.transformer_alpha_coeff,
@@ -943,13 +986,16 @@ impl AmpLane {
         let (left, right) = self.input.process(left, right);
         let held = self.held_controls();
         let profile = self.profile;
+        let voicing = &self.voicing;
         let core = &mut self.core;
         if profile.oversample == 8 {
-            self.os8
-                .process_stereo(left, right, |l, r| core.process_stereo(l, r, profile, held))
+            self.os8.process_stereo(left, right, |l, r| {
+                core.process_stereo(l, r, profile, voicing, held)
+            })
         } else {
-            self.os4
-                .process_stereo(left, right, |l, r| core.process_stereo(l, r, profile, held))
+            self.os4.process_stereo(left, right, |l, r| {
+                core.process_stereo(l, r, profile, voicing, held)
+            })
         }
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/drive.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/drive.rs
@@ -1,30 +1,32 @@
 //! Overdrive / boost / fuzz pedals — multiple voicings sharing one processor.
 //!
-//! The legacy six voicings share a TS-inspired split topology: a phase-coherent
-//! one-pole split keeps the low band clean while the high band is mid-emphasized
-//! *before* the clipper (voicing into, not after, the nonlinearity — full-band
-//! clipping is what made these muddy), then re-blends the clean lows on the way
-//! out so the pedal stays tight without going thin. An envelope-driven bias
-//! shifts the shaper's operating point with pick attack, so harmonics bloom
-//! with dynamics instead of a static waveshape; the resulting moving DC offset
-//! is absorbed by a post DC blocker. The waveshaper runs 2× oversampled
-//! ([`Oversampler2x`]) so high-gain voicings (Rat, Fuzz) fold back far less
-//! aliasing, and the gain/mix controls are smoothed ([`Smoothed`]) so live
-//! knob drags don't zipper.
+//! The legacy six voicings model the real pedal topology instead of drawing a
+//! curve. The Drive knob feeds a gain stage whose coupling network only lifts
+//! the band *above* its corner, so the low end arrives at the diodes at unity
+//! and never reaches their threshold at all. That is how a pedal keeps its bass
+//! clean — by not driving it — and it replaces the old split-band trick, which
+//! re-blended a full-level clean low band onto a compressed clipped one and so
+//! grew muddier the harder it was driven.
+//!
+//! The clipper itself is [`DiodeClipper`]: an implicit diode node solved per
+//! sample, not a `tanh`. Its state is the charge held by the fixed capacitor
+//! *and* by the junctions themselves, so the node's history moves where the
+//! next sample lands, edges round off instead of cornering into
+//! digital-sounding fizz, and the two diodes leave conduction at their own
+//! rates — which is where the even harmonics come from. The diode exponential,
+//! not a chosen clamp, sets the ceiling. It runs 2× oversampled
+//! ([`Oversampler2x`]) with its state at that rate, and the gain/mix controls
+//! are smoothed ([`Smoothed`]) so live knob drags don't zipper.
 
 use builtin_dsp_core::{make_eq_coefficients, mix};
 
-use super::drive_models::{DcBlock, DsClassic, EnvFollower, MetalCore, SuperDrive, TightRift};
+use super::drive_models::{DcBlock, DsClassic, MetalCore, SuperDrive, TightRift};
+use super::nonlinear::{DiodeClipper, DiodeParams};
 use super::smooth::{Oversampler2x, Smoothed};
-use super::{DriveModel, StereoBiquad, soft_clip};
+use super::{DriveModel, StereoBiquad};
 
 /// Glide time for gain/level/mix edits (fast enough to feel immediate).
 const SMOOTH_SECONDS: f32 = 0.010;
-
-/// Dynamic-bias envelope: fast enough to catch pick attack, slow enough that
-/// the bloom rides the note instead of buzzing.
-const ENV_ATTACK_SECONDS: f32 = 0.002;
-const ENV_RELEASE_SECONDS: f32 = 0.060;
 
 /// Drive taper for the legacy voicings.
 ///
@@ -39,16 +41,104 @@ fn drive_taper(g01: f32) -> f32 {
     g01.clamp(0.0, 1.0).powf(2.1)
 }
 
-/// Stereo one-pole low-pass used as a phase-coherent band splitter:
-/// `low = lp(x)`, `high = x - low` reconstructs exactly.
+/// The diode pair, its charge storage, and the clipping corner per voicing.
+///
+/// The diode voltages are normalized so a nominal drop is 1.0 — that puts the
+/// clipping threshold at plugin unity, so the node is transparent under it and
+/// its ceiling needs no makeup gain. Everything here is a component choice, not
+/// a tone control: matched silicon has a tight knee, germanium is much softer,
+/// and an unequal pair is a genuinely asymmetric pedal.
+///
+/// `tau_pos`/`tau_neg` are junction transit times, which decide how much
+/// diffusion charge each diode holds while it conducts. This is the parameter
+/// that separates the family: a fast silicon switching part (nanoseconds)
+/// stores essentially nothing and clips cleanly, while germanium and rectifier
+/// junctions (microseconds) hold enough charge to leave conduction slowly,
+/// which thickens the tone and — because the two diodes are unequal — skews the
+/// half-cycle durations into real even harmonics that survive DC blocking.
+///
+/// `bass_hz` is the corner of the gain stage's own coupling network. Below it
+/// the Drive knob adds no gain at all, so the low end never reaches the diodes
+/// and cannot be turned to mud — a TS-9 really does leave everything under
+/// ~720 Hz at unity, which is why it stays tight wherever the knob sits.
+#[derive(Debug, Clone, Copy)]
+struct DiodeVoicing {
+    v_pos: f32,
+    v_neg: f32,
+    knee_pos: f32,
+    knee_neg: f32,
+    tau_pos: f32,
+    tau_neg: f32,
+    smooth_hz: f32,
+    bass_hz: f32,
+}
+
+impl DiodeVoicing {
+    #[allow(clippy::too_many_arguments)]
+    const fn new(
+        v_pos: f32,
+        v_neg: f32,
+        knee_pos: f32,
+        knee_neg: f32,
+        tau_pos: f32,
+        tau_neg: f32,
+        smooth_hz: f32,
+        bass_hz: f32,
+    ) -> Self {
+        Self {
+            v_pos,
+            v_neg,
+            knee_pos,
+            knee_neg,
+            tau_pos,
+            tau_neg,
+            smooth_hz,
+            bass_hz,
+        }
+    }
+
+    fn for_model(model: DriveModel) -> Self {
+        match model {
+            // Matched silicon in the feedback loop, boosting from the classic
+            // 720 Hz corner up.
+            DriveModel::Screamer => {
+                Self::new(1.0, 0.97, 0.075, 0.074, 1.2e-8, 1.6e-8, 11_000.0, 720.0)
+            }
+            // Germanium: soft knee and a low corner, so it stays transparent
+            // rather than mid-honky.
+            DriveModel::Minotaur => {
+                Self::new(1.0, 1.02, 0.190, 0.190, 1.1e-6, 1.5e-6, 16_000.0, 380.0)
+            }
+            // Silicon to ground with a hard knee and a low corner — the whole
+            // guitar band gets driven, which is where the filth comes from.
+            DriveModel::Rat => Self::new(1.0, 0.965, 0.042, 0.041, 4.0e-7, 6.5e-7, 7_000.0, 180.0),
+            // Two diodes up against one down: real asymmetry.
+            DriveModel::Breaker => {
+                Self::new(0.70, 1.30, 0.045, 0.043, 1.5e-7, 4.0e-7, 9_000.0, 300.0)
+            }
+            // Leaky germanium, very soft, and a corner low enough that
+            // everything reaches the diodes.
+            DriveModel::Fuzz => Self::new(0.76, 1.24, 0.250, 0.220, 3.0e-6, 1.4e-6, 5_000.0, 70.0),
+            // Germanium like the Minotaur but voiced brighter.
+            DriveModel::Centurion => {
+                Self::new(1.0, 0.975, 0.160, 0.158, 8.0e-7, 1.05e-6, 14_000.0, 540.0)
+            }
+            // Dedicated-topology models never reach this table.
+            _ => Self::new(1.0, 1.0, 0.075, 0.075, 2.0e-8, 2.0e-8, 12_000.0, 400.0),
+        }
+    }
+}
+
+/// Stereo one-pole high-pass. The gain stage's feedback network: it decides
+/// which band the Drive knob actually boosts.
 #[derive(Debug, Clone)]
-struct StereoOnePoleLp {
+struct StereoOnePoleHp {
     a: f32,
     y_l: f32,
     y_r: f32,
 }
 
-impl StereoOnePoleLp {
+impl StereoOnePoleHp {
     fn new() -> Self {
         Self {
             a: 1.0,
@@ -68,6 +158,7 @@ impl StereoOnePoleLp {
         self.y_r = 0.0;
     }
 
+    /// Returns the *high* band; the low band is `x - high`.
     #[inline]
     fn run(&mut self, l: f32, r: f32) -> (f32, f32) {
         self.y_l += self.a * (l - self.y_l);
@@ -78,7 +169,7 @@ impl StereoOnePoleLp {
         if !self.y_r.is_finite() {
             self.y_r = 0.0;
         }
-        (self.y_l, self.y_r)
+        (l - self.y_l, r - self.y_r)
     }
 }
 
@@ -86,18 +177,15 @@ impl StereoOnePoleLp {
 pub(super) struct Drive {
     sample_rate: f32,
     model: DriveModel,
+    /// Gain applied to the band above the clipping corner only. The bass keeps
+    /// unity all the way up the knob, so it can never be driven into mud.
     pre_gain: Smoothed,
     out_gain: Smoothed,
     mix: Smoothed,
-    /// Clean low band level re-blended after the clipper (TS-style: lows pass
-    /// un-clipped instead of being discarded or muddying the shaper).
-    low_mix: Smoothed,
-    /// How far the envelope pushes the shaper's operating point (per model).
-    bias: f32,
-    low_split: StereoOnePoleLp,
+    gain_hp: StereoOnePoleHp,
     mid_boost: StereoBiquad,
     tone_lpf: StereoBiquad,
-    env: EnvFollower,
+    clipper: DiodeClipper,
     dc: DcBlock,
     oversampler: Oversampler2x,
     // The four modern models own full dedicated topologies (multi-stage,
@@ -112,18 +200,26 @@ pub(super) struct Drive {
 impl Drive {
     pub(super) fn new(sample_rate: f32) -> Self {
         let sr = sample_rate.max(1.0);
+        let voicing = DiodeVoicing::for_model(DriveModel::Screamer);
         Self {
             sample_rate: sr,
             model: DriveModel::Screamer,
             pre_gain: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
             out_gain: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
             mix: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
-            low_mix: Smoothed::new(sr, SMOOTH_SECONDS, 0.0),
-            bias: 0.0,
-            low_split: StereoOnePoleLp::new(),
+            gain_hp: StereoOnePoleHp::new(),
             mid_boost: StereoBiquad::none(),
             tone_lpf: StereoBiquad::none(),
-            env: EnvFollower::new(sr, ENV_ATTACK_SECONDS, ENV_RELEASE_SECONDS),
+            clipper: DiodeClipper::new(DiodeParams::new(
+                voicing.v_pos,
+                voicing.v_neg,
+                voicing.knee_pos,
+                voicing.knee_neg,
+                voicing.tau_pos,
+                voicing.tau_neg,
+                voicing.smooth_hz,
+                sr * 2.0,
+            )),
             dc: DcBlock::new(sr),
             oversampler: Oversampler2x::new(),
             ds_one: DsClassic::new(sr),
@@ -138,8 +234,6 @@ impl Drive {
         self.pre_gain.set_time(self.sample_rate, SMOOTH_SECONDS);
         self.out_gain.set_time(self.sample_rate, SMOOTH_SECONDS);
         self.mix.set_time(self.sample_rate, SMOOTH_SECONDS);
-        self.low_mix.set_time(self.sample_rate, SMOOTH_SECONDS);
-        self.env.set_sample_rate(self.sample_rate);
         self.dc.set_sample_rate(self.sample_rate);
         self.ds_one.set_sample_rate(self.sample_rate);
         self.super_drive.set_sample_rate(self.sample_rate);
@@ -148,16 +242,15 @@ impl Drive {
     }
 
     pub(super) fn reset(&mut self) {
-        self.low_split.reset();
+        self.gain_hp.reset();
         self.mid_boost.reset();
         self.tone_lpf.reset();
-        self.env.reset();
+        self.clipper.reset();
         self.dc.reset();
         self.oversampler.reset();
         self.pre_gain.snap();
         self.out_gain.snap();
         self.mix.snap();
-        self.low_mix.snap();
         self.ds_one.reset();
         self.super_drive.reset();
         self.metal_core.reset();
@@ -181,50 +274,50 @@ impl Drive {
         let lvl = (level / 10.0).clamp(0.0, 1.0);
         let sr = self.sample_rate;
 
-        // (pre_gain, out_gain, low_mix, mix, bias) targets — the continuous
-        // ones glide, `bias` steps with the (already discontinuous) model swap.
-        // `low_mix` re-blends the clean low band post-clip: near-unity for
-        // TS/Klon-style pedals whose lows famously pass un-clipped, low for
-        // Rat, zero for Fuzz (a fuzz clips everything).
-        //
-        // The low end of each `pre` range sits *below* unity so Drive at 0 is
-        // genuinely close to clean — starting at 1.0 with these slopes meant a
-        // 2/10 setting was already fully saturated and the rest of the knob only
-        // changed the tone filters.
-        let (pre, out, low, mix_amount, bias) = match model {
-            DriveModel::Screamer => (0.40 + g * 24.0, 0.25 + lvl * 1.1, 0.85, 1.0, 0.10),
-            // Minotaur and Breaker used to run 3–5 dB hotter than the rest of
-            // the family, hot enough to clip the output at their own defaults.
-            DriveModel::Minotaur => (0.45 + g * 11.0, 0.23 + lvl * 0.76, 0.90, 0.85, 0.05),
-            DriveModel::Rat => (0.35 + g * 60.0, 0.18 + lvl * 0.95, 0.50, 1.0, 0.18),
-            DriveModel::Breaker => (0.45 + g * 14.0, 0.24 + lvl * 0.78, 0.60, 0.92, 0.12),
-            DriveModel::Fuzz => (0.35 + g * 54.0, 0.15 + lvl * 0.85, 0.0, 1.0, 0.30),
-            DriveModel::Centurion => (0.42 + g * 16.0, 0.32 + lvl * 1.2, 0.75, 0.88, 0.07),
+        let voicing = DiodeVoicing::for_model(model);
+        let params = DiodeParams::new(
+            voicing.v_pos,
+            voicing.v_neg,
+            voicing.knee_pos,
+            voicing.knee_neg,
+            voicing.tau_pos,
+            voicing.tau_neg,
+            voicing.smooth_hz,
+            sr * 2.0,
+        );
+        self.clipper.set_params(params);
+        // The gain stage boosts exactly the band the diodes can see.
+        self.gain_hp.set(voicing.bass_hz, sr);
+
+        // (pre_gain, out_gain, mix) targets. The low end of each `pre` range
+        // sits *below* unity so Drive at 0 is genuinely close to clean.
+        let (pre, out, mix_amount) = match model {
+            DriveModel::Screamer => (0.40 + g * 24.0, 0.17 + lvl * 0.75, 1.0),
+            DriveModel::Minotaur => (0.45 + g * 11.0, 0.20 + lvl * 0.66, 0.85),
+            DriveModel::Rat => (0.35 + g * 60.0, 0.16 + lvl * 0.82, 1.0),
+            DriveModel::Breaker => (0.45 + g * 14.0, 0.21 + lvl * 0.68, 0.92),
+            DriveModel::Fuzz => (0.35 + g * 54.0, 0.10 + lvl * 0.55, 1.0),
+            DriveModel::Centurion => (0.42 + g * 16.0, 0.20 + lvl * 0.74, 0.88),
             // Dedicated-topology models returned above.
-            _ => (1.0, 1.0, 0.0, 1.0, 0.0),
+            _ => (1.0, 1.0, 1.0),
         };
         self.pre_gain.set_target(pre);
-        // Slight upward trim with Drive. The shaper's ceiling fixes the output
-        // level once it saturates, and the duty asymmetry below costs a few
-        // tenths of a dB of RMS, so without this the top of the knob drifts
-        // very slightly *down* — the one direction a drive control must never go.
-        self.out_gain.set_target(out * (1.0 + g * 0.22));
-        self.low_mix.set_target(low);
+        // No inverse compensation for the pre-gain: the diodes are their own
+        // level reference, so subtracting the gain that was added would take
+        // back level the clipper already removed and leave the pedal loudest
+        // with the knob at zero. The small rise with `g` keeps a harder setting
+        // reading a little hotter, which is the one direction Drive may move.
+        self.out_gain.set_target(out * (1.0 + g * 0.18));
         self.mix.set_target(mix_amount);
-        // Bias grows with Drive as well. Past the point where the shaper is
-        // fully saturated, extra pre-gain changes nothing, so the top half of
-        // the knob has to earn its travel with duty-cycle asymmetry — even
-        // harmonics thickening — rather than more clipping that isn't there.
-        self.bias = bias * (0.35 + g * 1.65);
 
-        // Split frequency (lows kept clean below it), pre-clip mid emphasis,
-        // and post tone low-pass per model.
+        // Pre-clip mid emphasis and the post tone low-pass per model. Both are
+        // opened up relative to the waveshaper era: the diode branch rounds its
+        // own top end, so the low-pass no longer has to hide fizz by being dark.
         match model {
             DriveModel::Screamer => {
-                self.low_split.set(250.0, sr);
                 self.mid_boost
                     .set(make_eq_coefficients("bell", 720.0, 6.0, 0.7, sr));
-                let cutoff = 2_400.0 + t * 5_600.0;
+                let cutoff = 3_200.0 + t * 6_800.0;
                 self.tone_lpf.set(make_eq_coefficients(
                     "lowpass",
                     cutoff.min(sr * 0.45),
@@ -234,17 +327,15 @@ impl Drive {
                 ));
             }
             DriveModel::Minotaur => {
-                self.low_split.set(120.0, sr);
                 self.mid_boost.set(None);
-                let cutoff = (4_000.0 + t * 8_000.0).min(sr * 0.45);
+                let cutoff = (5_000.0 + t * 9_000.0).min(sr * 0.45);
                 self.tone_lpf
                     .set(make_eq_coefficients("lowpass", cutoff, 0.0, 0.707, sr));
             }
             DriveModel::Rat => {
-                self.low_split.set(150.0, sr);
                 self.mid_boost
                     .set(make_eq_coefficients("bell", 1_100.0, 5.0, 0.9, sr));
-                let cutoff = 1_200.0 + t * 6_300.0;
+                let cutoff = 1_600.0 + t * 7_400.0;
                 self.tone_lpf.set(make_eq_coefficients(
                     "lowpass",
                     cutoff.min(sr * 0.45),
@@ -254,10 +345,9 @@ impl Drive {
                 ));
             }
             DriveModel::Breaker => {
-                self.low_split.set(110.0, sr);
                 self.mid_boost
                     .set(make_eq_coefficients("bell", 650.0, 2.5, 0.8, sr));
-                let cutoff = 2_800.0 + t * 7_000.0;
+                let cutoff = 3_600.0 + t * 8_000.0;
                 self.tone_lpf.set(make_eq_coefficients(
                     "lowpass",
                     cutoff.min(sr * 0.45),
@@ -267,18 +357,16 @@ impl Drive {
                 ));
             }
             DriveModel::Fuzz => {
-                self.low_split.set(60.0, sr);
                 self.mid_boost
                     .set(make_eq_coefficients("bell", 400.0, 4.0, 0.6, sr));
-                let cutoff = 900.0 + t * 3_500.0;
+                let cutoff = (1_200.0 + t * 4_600.0).min(sr * 0.45);
                 self.tone_lpf
                     .set(make_eq_coefficients("lowpass", cutoff, 0.0, 0.707, sr));
             }
             DriveModel::Centurion => {
-                self.low_split.set(130.0, sr);
                 self.mid_boost
                     .set(make_eq_coefficients("bell", 780.0, 4.5, 0.75, sr));
-                let cutoff = 3_000.0 + t * 7_000.0;
+                let cutoff = 4_000.0 + t * 8_000.0;
                 self.tone_lpf.set(make_eq_coefficients(
                     "lowpass",
                     cutoff.min(sr * 0.45),
@@ -289,36 +377,6 @@ impl Drive {
             }
             // Dedicated-topology models returned above.
             _ => {}
-        }
-    }
-
-    #[inline]
-    fn shape(model: DriveModel, x: f32) -> f32 {
-        match model {
-            DriveModel::Screamer => soft_clip(x + 0.05 * x * x),
-            DriveModel::Minotaur => soft_clip(x * 0.7) / 0.7f32.tanh(),
-            DriveModel::Rat => {
-                // An overdrive stacked in front of the distortion: an
-                // asymmetric soft stage (positive half saturates harder → even
-                // harmonics + grit) feeds a harder cascaded fold, so the pedal
-                // reads thick and filthy instead of thin and fizzy.
-                let od = if x >= 0.0 {
-                    (x * 1.9).tanh()
-                } else {
-                    (x * 1.55).tanh()
-                };
-                let y = soft_clip(od * 1.7);
-                soft_clip(y * 1.15)
-            }
-            DriveModel::Breaker => soft_clip(x * 0.85) / 0.85f32.tanh(),
-            DriveModel::Fuzz => {
-                // Heavy asymmetric square-ish fuzz.
-                let biased = x + 0.18 * x.abs() * x;
-                soft_clip(biased * 1.8)
-            }
-            DriveModel::Centurion => soft_clip(x + 0.02 * x * x),
-            // Dedicated-topology models never reach the generic shaper.
-            _ => x,
         }
     }
 
@@ -333,37 +391,28 @@ impl Drive {
         }
         let pre = self.pre_gain.tick();
         let out = self.out_gain.tick();
-        let low_mix = self.low_mix.tick();
         let mix_amount = self.mix.tick();
-        let model = self.model;
-        let bias = self.bias;
 
-        // Phase-coherent band split: lows stay clean, highs feed the clipper.
-        let (lo_l, lo_r) = self.low_split.run(left, right);
-        let (hi_l, hi_r) = (left - lo_l, right - lo_r);
         // Voicing goes *into* the clipper (pre-emphasis), not after it.
-        let (em_l, em_r) = self.mid_boost.run(hi_l, hi_r);
-        // Envelope-driven bias: pick attack shifts the operating point, so
-        // even harmonics bloom with dynamics instead of a static waveshape.
-        //
-        // Metered and applied *before* the pre-gain, so the offset stays the
-        // same fraction of the waveform at any Drive setting. Metering after it
-        // made the bias a shrinking fraction of an ever-hotter signal, so the
-        // wave grew more symmetric — thinner — the harder it was clipped, which
-        // is backwards.
-        let (env_l, env_r) = self.env.tick(em_l, em_r);
-        let (bias_l, bias_r) = (bias * env_l.min(1.5), bias * env_r.min(1.5));
-        let (dr_l, dr_r) = ((em_l + bias_l) * pre, (em_r + bias_r) * pre);
-        // Waveshape at 2× rate: the shaper is memoryless, so only the
-        // up/down half-band filters carry state across the doubled rate.
-        let (sh_l, sh_r) = self.oversampler.process_stereo(dr_l, dr_r, |a, b| {
-            (Self::shape(model, a), Self::shape(model, b))
-        });
+        let (em_l, em_r) = self.mid_boost.run(left, right);
+        // The gain stage only lifts the band the diodes will see. Below the
+        // corner the signal stays at unity and arrives at the node too small to
+        // turn a diode on, so the low end passes clean without a parallel band
+        // to re-blend and without getting louder as the clipped band compresses.
+        let (hi_l, hi_r) = self.gain_hp.run(em_l, em_r);
+        let dr_l = em_l + (pre - 1.0) * hi_l;
+        let dr_r = em_r + (pre - 1.0) * hi_r;
+        // Solve the diode node at 2× rate — its capacitor state lives there.
+        let clipper = &mut self.clipper;
+        let (sh_l, sh_r) = self
+            .oversampler
+            .process_stereo(dr_l, dr_r, |a, b| clipper.process(a, b));
         let (t_l, t_r) = self.tone_lpf.run(sh_l, sh_r);
-        // The moving bias offset leaves a moving DC component — block it here.
+        // Unequal diodes leave a standing charge on the coupling capacitor —
+        // wanted as duty-cycle asymmetry, not as an offset in the mix.
         let (d_l, d_r) = self.dc.run(t_l, t_r);
-        let wet_l = (d_l + lo_l * low_mix) * out;
-        let wet_r = (d_r + lo_r * low_mix) * out;
+        let wet_l = d_l * out;
+        let wet_r = d_r * out;
         (mix(left, wet_l, mix_amount), mix(right, wet_r, mix_amount))
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/drive_models.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/drive_models.rs
@@ -23,10 +23,17 @@
 //! place and keeps the filter's history — necessary here, because `configure`
 //! re-sets every filter on any parameter change, and a zeroed history ahead of
 //! this much gain steps the signal hard enough to flip the clipped sign.
+//!
+//! Every clipping stage is a [`DiodeClipper`] node solved per sample, never a
+//! transfer curve. Asymmetry is an unequal diode pair rather than an envelope
+//! offset injected ahead of a symmetric shaper, and each node's capacitor gives
+//! the stage memory, so the break-up rounds and moves with playing instead of
+//! folding at a fixed level the way a static clipper does.
 
 use builtin_dsp_core::{db_to_linear, make_eq_coefficients, time_constant};
 
 use super::StereoBiquad;
+use super::nonlinear::{DiodeClipper, DiodeParams};
 use super::smooth::{Oversampler4x, Oversampler8x, Smoothed};
 
 /// Glide time for all smoothed drive internals.
@@ -155,38 +162,6 @@ impl EnvFollower {
     }
 }
 
-/// Hard clip with a small tanh knee and independent positive/negative
-/// thresholds (both given as positive numbers). `knee = 0` degenerates to a
-/// pure clamp.
-#[inline]
-fn hard_clip_asym(x: f32, t_pos: f32, t_neg: f32, knee: f32) -> f32 {
-    let (sign, mag, th) = if x >= 0.0 {
-        (1.0, x, t_pos)
-    } else {
-        (-1.0, -x, t_neg)
-    };
-    if knee <= 1.0e-6 {
-        return sign * mag.min(th);
-    }
-    let knee_start = (th - knee).max(0.0);
-    if mag <= knee_start {
-        x
-    } else {
-        sign * (knee_start + knee * ((mag - knee_start) / knee).tanh())
-    }
-}
-
-/// Soft asymmetric saturation: separate drive per half-cycle, normalized so
-/// small signals pass at ~unity.
-#[inline]
-fn soft_asym(x: f32, k_pos: f32, k_neg: f32) -> f32 {
-    if x >= 0.0 {
-        (x * k_pos).tanh() / k_pos.max(1.0e-6)
-    } else {
-        (x * k_neg).tanh() / k_neg.max(1.0e-6)
-    }
-}
-
 /// Equal-power dry/wet: keeps perceived level steady across the mix knob
 /// (the legacy models' linear crossfade dips in the middle).
 #[inline]
@@ -216,42 +191,6 @@ fn drive_makeup(d: f32) -> f32 {
 /// the same "turn it up, it gets quieter" trap as an inverse makeup gain.
 const OD_CEILING: f32 = 0.62;
 
-/// Overdrive soft clip stacked *in front* of the main distortion: an
-/// asymmetric tanh (hotter on the negative half for even harmonics) into a
-/// fixed ceiling, so raising its drive raises both level and grit. This is the
-/// tube screamer trick — tighten, thicken and grit the signal, then let the
-/// model's own pre-gain slam it into the real clipper. Runs inside the model's
-/// oversampler (memoryless), so its harmonics don't alias.
-#[inline]
-fn od_clip(x: f32, drive: f32) -> f32 {
-    let d = drive.max(1.0);
-    let g = x * d;
-    let y = if g >= 0.0 {
-        g.tanh()
-    } else {
-        // Negative half saturates ~25% hotter → even harmonics + a little DC
-        // (each model's `dc_out` strips the offset downstream).
-        (g * 0.8).tanh() * (1.0 / 0.8)
-    };
-    y * OD_CEILING
-}
-
-/// Bias offset for a clipper's *input*, driven by a pre-gain envelope.
-///
-/// Unequal clip thresholds alone do not survive DC blocking: once a clipper is
-/// fully engaged its two halves differ only by a constant, which is exactly
-/// what the blocker removes — leaving a purely odd-harmonic square, thin and
-/// fizzy no matter how hard it is driven (measured: h2 sixty-odd dB below the
-/// fundamental at full drive). Offsetting the *input* changes the pulse width
-/// instead, and pulse-width asymmetry is real even-harmonic content that
-/// survives DC blocking. Driving it from the envelope keeps the offset
-/// proportional to what is being played, so the duty shift is level-invariant
-/// and blooms with pick attack rather than sitting there as a static buzz.
-#[inline]
-fn duty_bias(env: f32, depth: f32) -> f32 {
-    depth * env.min(1.5)
-}
-
 /// Supply sag from an envelope of the *pre-gain* signal, bounded.
 ///
 /// Detecting on the post-gain signal turns sag into an automatic gain control:
@@ -276,6 +215,7 @@ fn sag_supply(env: f32, amount: f32, floor: f32) -> f32 {
 pub(super) struct OdBoost {
     tighten_hpf: StereoBiquad,
     mid_push: StereoBiquad,
+    clipper: DiodeClipper,
     drive: Smoothed,
 }
 
@@ -284,6 +224,7 @@ impl OdBoost {
         Self {
             tighten_hpf: StereoBiquad::none(),
             mid_push: StereoBiquad::none(),
+            clipper: DiodeClipper::new(Self::diodes(sample_rate)),
             drive: Smoothed::new(sample_rate.max(1.0), SMOOTH_SECONDS, 1.0),
         }
     }
@@ -295,13 +236,40 @@ impl OdBoost {
     pub(super) fn reset(&mut self) {
         self.tighten_hpf.reset();
         self.mid_push.reset();
+        self.clipper.reset();
         self.drive.snap();
+    }
+
+    /// A soft germanium pair: plenty of grit, no corner. The node runs at the
+    /// host model's oversampled rate, so `node_rate` is the caller's rate times
+    /// its oversampling factor.
+    fn diodes(node_rate: f32) -> DiodeParams {
+        DiodeParams::new(
+            1.0,
+            1.04,
+            0.20,
+            0.19,
+            1.0e-6,
+            1.3e-6,
+            18_000.0,
+            node_rate.max(1.0),
+        )
     }
 
     /// `amount` (0..1, typically the drive curve) scales both the soft-clip
     /// hardness and the mid push; `mid_hz` voices the honk that cuts through.
-    pub(super) fn configure(&mut self, amount: f32, mid_hz: f32, sample_rate: f32) {
+    /// `oversample` is the host model's factor, so the clipping node's own
+    /// capacitor is tuned to the rate it actually runs at.
+    pub(super) fn configure(
+        &mut self,
+        amount: f32,
+        mid_hz: f32,
+        sample_rate: f32,
+        oversample: f32,
+    ) {
         let a = amount.clamp(0.0, 1.0);
+        self.clipper
+            .set_params(Self::diodes(sample_rate.max(1.0) * oversample));
         // Gentle grit at low drive, screaming at full.
         self.drive.set_target(1.5 + a * 7.5);
         // Tighten the lows entering the clipper so bass doesn't turn to mush;
@@ -335,6 +303,16 @@ impl OdBoost {
     pub(super) fn tick_drive(&mut self) -> f32 {
         self.drive.tick()
     }
+
+    /// Solve the boost's clipping node. Call inside the host model's
+    /// oversampler; the fixed ceiling keeps the stage a grit/voicing stage and
+    /// leaves raw level to the model's own pre-gain.
+    #[inline]
+    pub(super) fn clip(&mut self, l: f32, r: f32, drive: f32) -> (f32, f32) {
+        let d = drive.max(1.0);
+        let (a, b) = self.clipper.process(l * d, r * d);
+        (a * OD_CEILING, b * OD_CEILING)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -353,12 +331,8 @@ pub(super) struct DsClassic {
     edge: StereoBiquad,
     post_lpf: StereoBiquad,
     os: Oversampler4x,
-    env: EnvFollower,
+    clipper: DiodeClipper,
     pre_gain: Smoothed,
-    t_pos: Smoothed,
-    t_neg: Smoothed,
-    knee: Smoothed,
-    bias_depth: Smoothed,
     out_gain: Smoothed,
     mix: Smoothed,
 }
@@ -375,12 +349,8 @@ impl DsClassic {
             edge: StereoBiquad::none(),
             post_lpf: StereoBiquad::none(),
             os: Oversampler4x::new(),
-            env: EnvFollower::new(sr, 0.003, 0.070),
+            clipper: DiodeClipper::new(Self::diodes(sr)),
             pre_gain: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
-            t_pos: Smoothed::new(sr, SMOOTH_SECONDS, 0.6),
-            t_neg: Smoothed::new(sr, SMOOTH_SECONDS, 0.75),
-            knee: Smoothed::new(sr, SMOOTH_SECONDS, 0.12),
-            bias_depth: Smoothed::new(sr, SMOOTH_SECONDS, 0.1),
             out_gain: Smoothed::new(sr, SMOOTH_SECONDS, 0.5),
             mix: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
         }
@@ -390,16 +360,8 @@ impl DsClassic {
         self.sample_rate = sample_rate.max(1.0);
         self.dc.set_sample_rate(self.sample_rate);
         self.dc_out.set_sample_rate(self.sample_rate);
-        self.env.set_sample_rate(self.sample_rate);
-        for s in [
-            &mut self.pre_gain,
-            &mut self.t_pos,
-            &mut self.t_neg,
-            &mut self.knee,
-            &mut self.bias_depth,
-            &mut self.out_gain,
-            &mut self.mix,
-        ] {
+        self.clipper.set_params(Self::diodes(self.sample_rate));
+        for s in [&mut self.pre_gain, &mut self.out_gain, &mut self.mix] {
             s.set_time(self.sample_rate, SMOOTH_SECONDS);
         }
     }
@@ -412,18 +374,26 @@ impl DsClassic {
         self.edge.reset();
         self.post_lpf.reset();
         self.os.reset();
-        self.env.reset();
-        for s in [
-            &mut self.pre_gain,
-            &mut self.t_pos,
-            &mut self.t_neg,
-            &mut self.knee,
-            &mut self.bias_depth,
-            &mut self.out_gain,
-            &mut self.mix,
-        ] {
+        self.clipper.reset();
+        for s in [&mut self.pre_gain, &mut self.out_gain, &mut self.mix] {
             s.snap();
         }
+    }
+
+    /// Silicon pair to ground, two diodes up against one down — the orange
+    /// box's actual asymmetry, which is where its rude even-harmonic bite
+    /// comes from. Voltages are normalized so a nominal drop is 1.0.
+    fn diodes(sample_rate: f32) -> DiodeParams {
+        DiodeParams::new(
+            0.84,
+            1.16,
+            0.048,
+            0.046,
+            2.5e-7,
+            5.5e-7,
+            7_000.0,
+            sample_rate.max(1.0) * 4.0,
+        )
     }
 
     /// Editor knobs 0..10. Drive maps onto gain, thresholds, knee hardness,
@@ -437,19 +407,11 @@ impl DsClassic {
 
         let gain_db = 10.0 + d * 30.0; // 10..40 dB into the clipper
         self.pre_gain.set_target(db_to_linear(gain_db));
-        // Thresholds stay near-fixed (they are what sets the output level);
-        // the halves stay deliberately unequal for the rude even-harmonic bite.
-        self.t_pos.set_target(0.60 - d * 0.05);
-        self.t_neg.set_target(0.76 - d * 0.04);
-        // Knee hardens as drive rises — full drive is a bare clamp.
-        self.knee.set_target(0.17 - d * 0.16);
-        // ...which is exactly when unequal thresholds stop producing even
-        // harmonics, so the duty-cycle bias takes over as drive climbs.
-        self.bias_depth.set_target(0.06 + d * 0.15);
-        // No inverse compensation: the clamp already sets the level, so the
-        // knob only has to nudge it up. See `drive_makeup`.
+        // The diodes set the ceiling and the asymmetry; Drive only decides how
+        // hard they are hit. No inverse compensation on the output — see
+        // `drive_makeup`.
         self.out_gain
-            .set_target(drive_makeup(d) * (0.40 + lvl * 1.25));
+            .set_target(drive_makeup(d) * (0.18 + lvl * 0.57));
         self.mix.set_target(1.0);
 
         self.dc.set_sample_rate(sr);
@@ -481,29 +443,16 @@ impl DsClassic {
     #[inline]
     pub(super) fn process(&mut self, left: f32, right: f32) -> (f32, f32) {
         let pre = self.pre_gain.tick();
-        let t_pos = self.t_pos.tick();
-        let t_neg = self.t_neg.tick();
-        let knee = self.knee.tick().max(0.0);
-        let depth = self.bias_depth.tick();
         let out = self.out_gain.tick();
         let mix = self.mix.tick();
 
         let (l, r) = self.dc.run(left, right);
         let (l, r) = self.input_hpf.run(l, r);
         let (l, r) = self.pre_emph.run(l, r);
-        // Bias the clipper's input (pre-gain, so the duty shift is the same at
-        // any playing level) — see `duty_bias`; `dc_out` strips the offset.
-        let (el, er) = self.env.tick(l, r);
-        let bias_l = duty_bias(el, depth);
-        let bias_r = duty_bias(er, depth);
-        let (mut wl, mut wr) =
-            self.os
-                .process_stereo((l + bias_l) * pre, (r + bias_r) * pre, |a, b| {
-                    (
-                        hard_clip_asym(a, t_pos, t_neg, knee),
-                        hard_clip_asym(b, t_pos, t_neg, knee),
-                    )
-                });
+        let clipper = &mut self.clipper;
+        let (mut wl, mut wr) = self
+            .os
+            .process_stereo(l * pre, r * pre, |a, b| clipper.process(a, b));
         (wl, wr) = self.edge.run(wl, wr);
         (wl, wr) = self.post_lpf.run(wl, wr);
         // Asymmetric clipping generates DC — strip it before it eats
@@ -535,11 +484,11 @@ pub(super) struct SuperDrive {
     low_keep: StereoBiquad,
     post_lpf: StereoBiquad,
     os: Oversampler4x,
+    clipper: DiodeClipper,
     env: EnvFollower,
     pre_gain: Smoothed,
     sag_amount: Smoothed,
     low_blend: Smoothed,
-    bias_depth: Smoothed,
     out_gain: Smoothed,
     mix: Smoothed,
 }
@@ -556,11 +505,11 @@ impl SuperDrive {
             low_keep: StereoBiquad::none(),
             post_lpf: StereoBiquad::none(),
             os: Oversampler4x::new(),
+            clipper: DiodeClipper::new(Self::diodes(sr)),
             env: EnvFollower::new(sr, 0.005, 0.090),
             pre_gain: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
             sag_amount: Smoothed::new(sr, SMOOTH_SECONDS, 0.0),
             low_blend: Smoothed::new(sr, SMOOTH_SECONDS, 0.18),
-            bias_depth: Smoothed::new(sr, SMOOTH_SECONDS, 0.05),
             out_gain: Smoothed::new(sr, SMOOTH_SECONDS, 0.6),
             mix: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
         }
@@ -571,11 +520,11 @@ impl SuperDrive {
         self.dc.set_sample_rate(self.sample_rate);
         self.dc_out.set_sample_rate(self.sample_rate);
         self.env.set_sample_rate(self.sample_rate);
+        self.clipper.set_params(Self::diodes(self.sample_rate));
         for s in [
             &mut self.pre_gain,
             &mut self.sag_amount,
             &mut self.low_blend,
-            &mut self.bias_depth,
             &mut self.out_gain,
             &mut self.mix,
         ] {
@@ -591,17 +540,35 @@ impl SuperDrive {
         self.low_keep.reset();
         self.post_lpf.reset();
         self.os.reset();
+        self.clipper.reset();
         self.env.reset();
         for s in [
             &mut self.pre_gain,
             &mut self.sag_amount,
             &mut self.low_blend,
-            &mut self.bias_depth,
             &mut self.out_gain,
             &mut self.mix,
         ] {
             s.snap();
         }
+    }
+
+    /// Two soft diodes one way against one the other, in the feedback loop of
+    /// an overdrive: a gentle knee and a real, static asymmetry. The touch
+    /// sensitivity this model is built around comes from the supply sag and
+    /// from the node's own capacitor, not from an envelope steering the shape
+    /// of a symmetric curve.
+    fn diodes(sample_rate: f32) -> DiodeParams {
+        DiodeParams::new(
+            0.80,
+            1.20,
+            0.115,
+            0.105,
+            6.0e-7,
+            1.1e-6,
+            13_000.0,
+            sample_rate.max(1.0) * 4.0,
+        )
     }
 
     /// Tone shifts the mid hump up and opens the top together.
@@ -618,13 +585,8 @@ impl SuperDrive {
         self.sag_amount.set_target(0.20 + d * 0.30);
         // Clean-low blend stays subtle and eases off as drive saturates.
         self.low_blend.set_target(0.22 - d * 0.10);
-        // Unequal half-cycle ceilings alone read as symmetric once both halves
-        // flat-top and the DC blocker centres them, so the touch-sensitive even
-        // harmonics this model is built around need a duty shift too — gentler
-        // than the hard-clipping models, since this one is meant to stay smooth.
-        self.bias_depth.set_target(0.05 + d * 0.13);
         self.out_gain
-            .set_target(drive_makeup(d) * (0.38 + lvl * 1.15));
+            .set_target(drive_makeup(d) * (0.18 + lvl * 0.54));
         self.mix.set_target(1.0);
 
         self.dc.set_sample_rate(sr);
@@ -652,7 +614,6 @@ impl SuperDrive {
         let pre = self.pre_gain.tick();
         let sag = self.sag_amount.tick();
         let low_amt = self.low_blend.tick();
-        let depth = self.bias_depth.tick();
         let out = self.out_gain.tick();
         let mix = self.mix.tick();
 
@@ -660,31 +621,21 @@ impl SuperDrive {
         let (low_l, low_r) = self.low_keep.run(l, r);
         let (l, r) = self.input_hpf.run(l, r);
 
-        // Envelope drives both the sag and the asymmetry: dig in → more
-        // compression, more even harmonics. The detector sits *before* the
-        // pre-gain so playing dynamics move it, not the Drive knob.
-        //
-        // `soft_asym` normalizes by `1/k`, so a *lower* k is a *higher*
-        // ceiling. The asymmetry therefore has to stay in a narrow band around
-        // `SOFT_K`: an SD-1's extra diode offsets one half by a couple of dB,
-        // and a wide range here instead produces a wildly lopsided wave
-        // (+0.7/-2.0 at the extreme) that slews hard enough to read as a click.
-        const SOFT_K: f32 = 1.45;
-        // Metered before the mid hump, so dynamics move it and pitch does not.
+        // The supply sags with playing: dig in and the rail feeding the gain
+        // stage droops, so the diodes are reached later and the pedal
+        // compresses. Metered before the mid hump, so dynamics move it and
+        // pitch does not.
         let (el, er) = self.env.tick(l, r);
         let sag_l = sag_supply(el, sag, 0.55);
         let sag_r = sag_supply(er, sag, 0.55);
-        let asym_l = (SOFT_K - el * 0.55).clamp(1.0, SOFT_K);
-        let asym_r = (SOFT_K - er * 0.55).clamp(1.0, SOFT_K);
-        let bias_l = duty_bias(el, depth);
-        let bias_r = duty_bias(er, depth);
 
         let (l, r) = self.mid_hump.run(l, r);
-        let (mut wl, mut wr) = self.os.process_stereo(
-            (l + bias_l) * pre * sag_l,
-            (r + bias_r) * pre * sag_r,
-            |a, b| (soft_asym(a, SOFT_K, asym_l), soft_asym(b, SOFT_K, asym_r)),
-        );
+        let clipper = &mut self.clipper;
+        let (mut wl, mut wr) = self
+            .os
+            .process_stereo(l * pre * sag_l, r * pre * sag_r, |a, b| {
+                clipper.process(a, b)
+            });
         (wl, wr) = self.post_lpf.run(wl, wr);
         wl = sanitize(wl + low_l * low_amt);
         wr = sanitize(wr + low_r * low_amt);
@@ -723,12 +674,12 @@ pub(super) struct MetalCore {
     resonance: StereoBiquad,
     fizz_lpf: StereoBiquad,
     os: Oversampler8x,
+    body: DiodeClipper,
+    wall: DiodeClipper,
     env: EnvFollower,
     od: OdBoost,
     pre_gain: Smoothed,
     inter_gain: Smoothed,
-    ceiling: Smoothed,
-    bias_depth: Smoothed,
     out_gain: Smoothed,
     mix: Smoothed,
 }
@@ -748,12 +699,12 @@ impl MetalCore {
             resonance: StereoBiquad::none(),
             fizz_lpf: StereoBiquad::none(),
             os: Oversampler8x::new(),
+            body: DiodeClipper::new(Self::body_diodes(sr)),
+            wall: DiodeClipper::new(Self::wall_diodes(sr)),
             env: EnvFollower::new(sr, 0.002, 0.060),
             od: OdBoost::new(sr),
             pre_gain: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
             inter_gain: Smoothed::new(sr, SMOOTH_SECONDS, 2.0),
-            ceiling: Smoothed::new(sr, SMOOTH_SECONDS, 0.85),
-            bias_depth: Smoothed::new(sr, SMOOTH_SECONDS, 0.1),
             out_gain: Smoothed::new(sr, SMOOTH_SECONDS, 0.4),
             mix: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
         }
@@ -765,11 +716,11 @@ impl MetalCore {
         self.dc_out.set_sample_rate(self.sample_rate);
         self.env.set_sample_rate(self.sample_rate);
         self.od.set_sample_rate(self.sample_rate);
+        self.body.set_params(Self::body_diodes(self.sample_rate));
+        self.wall.set_params(Self::wall_diodes(self.sample_rate));
         for s in [
             &mut self.pre_gain,
             &mut self.inter_gain,
-            &mut self.ceiling,
-            &mut self.bias_depth,
             &mut self.out_gain,
             &mut self.mix,
         ] {
@@ -788,18 +739,49 @@ impl MetalCore {
         self.resonance.reset();
         self.fizz_lpf.reset();
         self.os.reset();
+        self.body.reset();
+        self.wall.reset();
         self.env.reset();
         self.od.reset();
         for s in [
             &mut self.pre_gain,
             &mut self.inter_gain,
-            &mut self.ceiling,
-            &mut self.bias_depth,
             &mut self.out_gain,
             &mut self.mix,
         ] {
             s.snap();
         }
+    }
+
+    /// Stage 1: an unequal soft pair that keeps transient shape and supplies
+    /// the even harmonics. A real component mismatch, so the asymmetry no
+    /// longer has to be faked with an envelope-driven offset at the input.
+    fn body_diodes(sample_rate: f32) -> DiodeParams {
+        DiodeParams::new(
+            0.82,
+            1.18,
+            0.120,
+            0.110,
+            3.0e-7,
+            5.5e-7,
+            15_000.0,
+            sample_rate.max(1.0) * 8.0,
+        )
+    }
+
+    /// Stage 2: a matched pair with a very tight knee, which is the wall. Its
+    /// capacitor is what keeps that wall from cornering into digital fizz.
+    fn wall_diodes(sample_rate: f32) -> DiodeParams {
+        DiodeParams::new(
+            1.0,
+            0.98,
+            0.030,
+            0.029,
+            1.5e-8,
+            2.2e-8,
+            6_000.0,
+            sample_rate.max(1.0) * 8.0,
+        )
     }
 
     /// Tone rebalances scoop depth ↔ presence ↔ fizz ceiling in one gesture:
@@ -817,18 +799,14 @@ impl MetalCore {
         let stage2_db = 6.0 + d * 21.0; // 6..27 dB more
         self.pre_gain.set_target(db_to_linear(stage1_db));
         self.inter_gain.set_target(db_to_linear(stage2_db));
-        // The ceiling is this model's level reference — it must not move with
-        // the knob, or the wall gets quieter exactly as it gets meaner. Even
-        // harmonics come from the duty-cycle bias instead (see `duty_bias`),
-        // which is the only asymmetry a fully-engaged clipper keeps.
-        self.ceiling.set_target(0.82);
-        self.bias_depth.set_target(0.06 + d * 0.22);
+        // The diodes are this model's level reference and they do not move with
+        // the knob, so the wall can never get quieter as it gets meaner.
         self.out_gain
-            .set_target(drive_makeup(d) * (0.45 + lvl * 1.45));
+            .set_target(drive_makeup(d) * (0.37 + lvl * 1.19));
         self.mix.set_target(1.0);
         // Overdrive stacked in front: mid-focused grit that tightens the lows
         // and thickens the body before the metal clipper — kills the fizz.
-        self.od.configure(d, 750.0, sr);
+        self.od.configure(d, 750.0, sr, 8.0);
 
         self.dc.set_sample_rate(sr);
         self.dc_out.set_sample_rate(sr);
@@ -876,8 +854,6 @@ impl MetalCore {
     pub(super) fn process(&mut self, left: f32, right: f32) -> (f32, f32) {
         let pre = self.pre_gain.tick();
         let inter = self.inter_gain.tick();
-        let ceiling = self.ceiling.tick().max(0.2);
-        let depth = self.bias_depth.tick();
         let out = self.out_gain.tick();
         let mix = self.mix.tick();
         let od_drive = self.od.tick_drive();
@@ -886,41 +862,35 @@ impl MetalCore {
         let (l, r) = self.input_hpf.run(l, r);
         let (l, r) = self.tighten.run(l, r);
 
-        // Detectors read the signal *before* the voicing bells. The OD mid push
-        // is up to +10 dB at its centre, so metering after it would make sag
-        // and duty bias swing with the pitch of the note rather than how hard
-        // it was played (measured: 12 dB of h2 between a 375 and a 750 Hz tone).
-        // Subtle sag only: enough to feel alive, never enough to pump — and
-        // detected pre-gain, so it never claws back what Drive just added.
+        // The sag detector reads the signal *before* the voicing bells. The OD
+        // mid push is up to +10 dB at its centre, so metering after it would
+        // make sag swing with the pitch of the note rather than how hard it was
+        // played. Subtle sag only: enough to feel alive, never enough to pump —
+        // and detected pre-gain, so it never claws back what Drive just added.
         let (el, er) = self.env.tick(l, r);
         let sag_l = sag_supply(el, 0.22, 0.7);
         let sag_r = sag_supply(er, 0.22, 0.7);
-        let bias_l = duty_bias(el, depth);
-        let bias_r = duty_bias(er, depth);
 
         // Overdrive voicing EQ (base rate) ahead of the clipper.
         let (l, r) = self.od.pre_eq(l, r);
 
         let inter_hpf = &mut self.inter_hpf;
         let inter_presence = &mut self.inter_presence;
-        // The OD clip runs at near-unity level *inside* the oversampler, then
+        let od = &mut self.od;
+        let body = &mut self.body;
+        let wall = &mut self.wall;
+        // The OD node runs at near-unity level *inside* the oversampler, then
         // the model's pre-gain slams its output into the two clip stages.
         let (mut wl, mut wr) = self.os.process_stereo(l * sag_l, r * sag_r, |a, b| {
-            // Overdrive stacked in front: boost + grit + tighten. The bias
-            // goes in ahead of the first clipper so the pulse-width asymmetry
-            // it creates is carried by every stage after it.
-            let a = od_clip(a + bias_l, od_drive) * pre;
-            let b = od_clip(b + bias_r, od_drive) * pre;
+            // Overdrive stacked in front: boost + grit + tighten.
+            let (a, b) = od.clip(a, b, od_drive);
             // Stage 1: asymmetric body — keeps transient shape.
-            let a1 = soft_asym(a, 1.2, 0.78);
-            let b1 = soft_asym(b, 1.2, 0.78);
-            // Interstage EQ at 8×: no bass into stage 2, presence in.
+            let (a1, b1) = body.process(a * pre, b * pre);
+            // Interstage EQ at 8x: no bass into stage 2, presence in.
             let (a2, b2) = inter_hpf.run(a1, b1);
             let (a3, b3) = inter_presence.run(a2, b2);
-            // Stage 2: harder, symmetric, near-bare clamp — the wall.
-            let a4 = hard_clip_asym((a3 * inter).tanh() * 1.4, ceiling, ceiling, 0.03);
-            let b4 = hard_clip_asym((b3 * inter).tanh() * 1.4, ceiling, ceiling, 0.03);
-            (a4, b4)
+            // Stage 2: harder, matched, tight-kneed. The wall.
+            wall.process(a3 * inter, b3 * inter)
         });
         (wl, wr) = self.scoop.run(wl, wr);
         (wl, wr) = self.resonance.run(wl, wr);
@@ -961,16 +931,16 @@ pub(super) struct TightRift {
     pick_bite: StereoBiquad,
     fizz_lpf: StereoBiquad,
     os: Oversampler8x,
+    body: DiodeClipper,
+    wall: DiodeClipper,
+    /// The transient path gets its own soft node so the sharpened attack is
+    /// limited by a circuit rather than clamped by a curve.
+    transient_clip: DiodeClipper,
     /// Sag detector — high-passed, so lows never pump the gain.
     env: EnvFollower,
-    /// Bias detector — full band, because duty-cycle asymmetry has to track
-    /// the note being played, not just its pick attack.
-    bias_env: EnvFollower,
     od: OdBoost,
     pre_gain: Smoothed,
-    ceiling: Smoothed,
     trans_amt: Smoothed,
-    bias_depth: Smoothed,
     out_gain: Smoothed,
     mix: Smoothed,
 }
@@ -990,13 +960,13 @@ impl TightRift {
             pick_bite: StereoBiquad::none(),
             fizz_lpf: StereoBiquad::none(),
             os: Oversampler8x::new(),
+            body: DiodeClipper::new(Self::body_diodes(sr)),
+            wall: DiodeClipper::new(Self::wall_diodes(sr)),
+            transient_clip: DiodeClipper::new(Self::transient_diodes(sr)),
             env: EnvFollower::new(sr, 0.001, 0.030),
-            bias_env: EnvFollower::new(sr, 0.002, 0.055),
             od: OdBoost::new(sr),
             pre_gain: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
-            ceiling: Smoothed::new(sr, SMOOTH_SECONDS, 0.85),
             trans_amt: Smoothed::new(sr, SMOOTH_SECONDS, 0.12),
-            bias_depth: Smoothed::new(sr, SMOOTH_SECONDS, 0.08),
             out_gain: Smoothed::new(sr, SMOOTH_SECONDS, 0.4),
             mix: Smoothed::new(sr, SMOOTH_SECONDS, 1.0),
         }
@@ -1007,13 +977,14 @@ impl TightRift {
         self.dc.set_sample_rate(self.sample_rate);
         self.dc_out.set_sample_rate(self.sample_rate);
         self.env.set_sample_rate(self.sample_rate);
-        self.bias_env.set_sample_rate(self.sample_rate);
         self.od.set_sample_rate(self.sample_rate);
+        self.body.set_params(Self::body_diodes(self.sample_rate));
+        self.wall.set_params(Self::wall_diodes(self.sample_rate));
+        self.transient_clip
+            .set_params(Self::transient_diodes(self.sample_rate));
         for s in [
             &mut self.pre_gain,
-            &mut self.ceiling,
             &mut self.trans_amt,
-            &mut self.bias_depth,
             &mut self.out_gain,
             &mut self.mix,
         ] {
@@ -1032,19 +1003,64 @@ impl TightRift {
         self.pick_bite.reset();
         self.fizz_lpf.reset();
         self.os.reset();
+        self.body.reset();
+        self.wall.reset();
+        self.transient_clip.reset();
         self.env.reset();
-        self.bias_env.reset();
         self.od.reset();
         for s in [
             &mut self.pre_gain,
-            &mut self.ceiling,
             &mut self.trans_amt,
-            &mut self.bias_depth,
             &mut self.out_gain,
             &mut self.mix,
         ] {
             s.snap();
         }
+    }
+
+    /// Stage 1: a lightly unequal soft pair for body without smearing the
+    /// attack. The mismatch is the asymmetry, so no envelope has to fake one.
+    fn body_diodes(sample_rate: f32) -> DiodeParams {
+        DiodeParams::new(
+            0.87,
+            1.13,
+            0.130,
+            0.125,
+            1.8e-7,
+            3.0e-7,
+            17_000.0,
+            sample_rate.max(1.0) * 8.0,
+        )
+    }
+
+    /// Stage 2: matched, very tight knee, small capacitor. Tight and modern,
+    /// but still a node with memory rather than a clamp.
+    fn wall_diodes(sample_rate: f32) -> DiodeParams {
+        DiodeParams::new(
+            1.0,
+            0.98,
+            0.028,
+            0.027,
+            1.0e-8,
+            1.4e-8,
+            6_500.0,
+            sample_rate.max(1.0) * 8.0,
+        )
+    }
+
+    /// The parallel transient path runs at base rate and only needs a ceiling
+    /// so the sharpened attack cannot become a click layer.
+    fn transient_diodes(sample_rate: f32) -> DiodeParams {
+        DiodeParams::new(
+            1.0,
+            1.0,
+            0.150,
+            0.150,
+            2.0e-8,
+            2.0e-8,
+            20_000.0,
+            sample_rate.max(1.0),
+        )
     }
 
     /// Tone rebalances definition ↔ pick bite ↔ high damping.
@@ -1057,20 +1073,15 @@ impl TightRift {
 
         let gain_db = 14.0 + d * 29.0; // 14..43 dB
         self.pre_gain.set_target(db_to_linear(gain_db));
-        // Fixed ceiling: this model's level reference, not a drive-dependent
-        // one (see `drive_makeup`).
-        self.ceiling.set_target(0.80);
         self.trans_amt.set_target(0.08 + d * 0.14);
-        // Tight means controlled, not sterile: less duty-cycle bias than the
-        // Metal Core wall, but enough that the top of the knob keeps some even
-        // harmonic weight instead of collapsing to a bare odd-harmonic square.
-        self.bias_depth.set_target(0.06 + d * 0.20);
+        // The diodes are this model's level reference, not a drive-dependent
+        // ceiling (see `drive_makeup`).
         self.out_gain
-            .set_target(drive_makeup(d) * (0.28 + lvl * 0.82));
+            .set_target(drive_makeup(d) * (0.22 + lvl * 0.66));
         self.mix.set_target(1.0);
         // Overdrive stacked in front: mid focus + tight lows before the tight
         // high-gain clipper, so the tone thickens instead of thinning to fizz.
-        self.od.configure(d, 800.0, sr);
+        self.od.configure(d, 800.0, sr, 8.0);
 
         self.dc.set_sample_rate(sr);
         self.dc_out.set_sample_rate(sr);
@@ -1112,9 +1123,7 @@ impl TightRift {
     #[inline]
     pub(super) fn process(&mut self, left: f32, right: f32) -> (f32, f32) {
         let pre = self.pre_gain.tick();
-        let ceiling = self.ceiling.tick().max(0.2);
         let trans_amt = self.trans_amt.tick();
-        let depth = self.bias_depth.tick();
         let out = self.out_gain.tick();
         let mix = self.mix.tick();
         let od_drive = self.od.tick_drive();
@@ -1127,40 +1136,34 @@ impl TightRift {
 
         // Fast-recovery sag on a high-passed, pre-gain detector: palm mutes
         // recover instantly, lows never pump the gain, and the Drive knob is
-        // not silently undone by its own envelope. The bias detector is full
-        // band but still reads the signal before the OD's mid push, so the duty
-        // shift tracks playing dynamics rather than the pitch of the note.
+        // not silently undone by its own envelope.
         let (el, er) = self.env.tick(tl, tr);
         let sag_l = sag_supply(el, 0.18, 0.75);
         let sag_r = sag_supply(er, 0.18, 0.75);
-        let (bl, br) = self.bias_env.tick(l, r);
-        let bias_l = duty_bias(bl, depth);
-        let bias_r = duty_bias(br, depth);
 
         // Overdrive voicing EQ (base rate) ahead of the clipper.
         let (l, r) = self.od.pre_eq(l, r);
 
         let inter_hpf = &mut self.inter_hpf;
-        // OD clip at near-unity level inside the oversampler, then pre-gain
+        let od = &mut self.od;
+        let body = &mut self.body;
+        let wall = &mut self.wall;
+        // OD node at near-unity level inside the oversampler, then pre-gain
         // drives its output into the tight clipper stages.
         let (mut wl, mut wr) = self.os.process_stereo(l * sag_l, r * sag_r, |a, b| {
-            // Overdrive stacked in front: boost + grit + tighten, biased ahead
-            // of the first clipper so the duty-cycle asymmetry carries through.
-            let a = od_clip(a + bias_l, od_drive) * pre;
-            let b = od_clip(b + bias_r, od_drive) * pre;
-            // Stage 1: light asym for body...
-            let a1 = soft_asym(a, 1.15, 0.83);
-            let b1 = soft_asym(b, 1.15, 0.83);
+            // Overdrive stacked in front: boost + grit + tighten.
+            let (a, b) = od.clip(a, b, od_drive);
+            // Stage 1: light asymmetry for body...
+            let (a1, b1) = body.process(a * pre, b * pre);
             // ...then keep stage 2 tight...
             let (a2, b2) = inter_hpf.run(a1, b1);
-            // ...into a near-bare clamp with a hard ceiling.
-            let a3 = hard_clip_asym((a2 * 3.2).tanh() * 1.3, ceiling, ceiling, 0.025);
-            let b3 = hard_clip_asym((b2 * 3.2).tanh() * 1.3, ceiling, ceiling, 0.025);
-            (a3, b3)
+            // ...into the tight-kneed node that sets the wall.
+            wall.process(a2 * 3.2, b2 * 3.2)
         });
         // Subtle transient recombination: sharpened attack, not a click layer.
-        wl += soft_asym(tl * 2.0, 1.0, 1.0) * trans_amt;
-        wr += soft_asym(tr * 2.0, 1.0, 1.0) * trans_amt;
+        let (trans_l, trans_r) = self.transient_clip.process(tl * 2.0, tr * 2.0);
+        wl += trans_l * trans_amt;
+        wr += trans_r * trans_amt;
         (wl, wr) = self.definition.run(wl, wr);
         (wl, wr) = self.pick_bite.run(wl, wr);
         (wl, wr) = self.fizz_lpf.run(wl, wr);

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/mod.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/mod.rs
@@ -37,6 +37,7 @@ mod handoff;
 mod ir;
 mod mod_stage;
 mod nam;
+mod nonlinear;
 mod phaser;
 mod rate;
 mod reverb;

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/nonlinear.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/nonlinear.rs
@@ -1,0 +1,772 @@
+//! Circuit-level nonlinear stages — no memoryless waveshapers.
+//!
+//! Everything the distortion and amp paths used to do with a static curve
+//! (`tanh`, `atan`, hard clip with a knee) is replaced here by a small circuit
+//! that is *solved* per sample and carries its own state. That difference is
+//! not cosmetic:
+//!
+//! * A waveshaper corners instantly and identically every time it is reached,
+//!   which is the sound of digital clipping rather than a pedal. Both stages
+//!   here are solved against a reactive element — the capacitor across the
+//!   diodes, the cathode and Miller networks around the valve — so an edge can
+//!   only round as fast as the circuit allows.
+//! * A waveshaper's break-up is level-locked: the same input amplitude always
+//!   produces the same harmonics, and asymmetry has to be faked by offsetting
+//!   the input. The stages here move their own operating point (capacitor
+//!   charge, cathode self-bias, grid conduction), so the *history* of what was
+//!   played changes how the next sample breaks up, and an unequal diode pair or
+//!   a self-biasing valve is asymmetric because its parts are.
+//!
+//! Neither stage decides *which band* gets distorted — that stays with the
+//! callers' filters, where a real circuit puts it: a pedal's gain network lifts
+//! only the band above its corner, and a valve stage's cathode bypass
+//! degenerates its own low end. Driving the whole spectrum into one ceiling is
+//! what made the previous build muddy, and no amount of curve-shaping fixes it.
+//!
+//! Both solvers are realtime-safe: fixed iteration counts, no allocation, no
+//! branching on unbounded data, and every state guarded for finiteness.
+
+/// Clamp to a sane audio range and kill non-finite values.
+#[inline]
+fn finite(x: f32) -> f32 {
+    if x.is_finite() {
+        x.clamp(-64.0, 64.0)
+    } else {
+        0.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Diode clipper (pedals)
+// ---------------------------------------------------------------------------
+
+/// An antiparallel diode pair with its smoothing capacitor, shunting a node
+/// fed through a series resistor — the clipping section of a real pedal.
+///
+/// ```text
+///        Rs = 1
+///   x ---/\/\/--+--- v (out)
+///               |
+///          +----+----+
+///          |         |
+///         === C     ### D+ || D-   (asymmetric pair)
+///          |         |
+///         gnd       gnd
+/// ```
+///
+/// The node stores charge in two places: the fixed capacitor, and the diodes
+/// themselves. A conducting junction holds a diffusion charge proportional to
+/// its own current (`q = tau * i`, `tau` the transit time), so its capacitance
+/// is not a constant — it is near zero while the diode is off and large while
+/// it conducts. That is modelled by integrating *charge*, not by inserting a
+/// capacitance into the node equation, which would be wrong for a nonlinear
+/// element:
+///
+/// ```text
+///   q(v) = C*v + tau_p*i_p(v) - tau_n*i_n(v)
+///   F(v) = (v - x) + fs * (q(v) - q_prev) + i_p(v) - i_n(v) = 0
+/// ```
+///
+/// What this buys is reverse recovery: a junction that has been conducting
+/// cannot turn off until its stored charge is swept out, so it keeps conducting
+/// briefly after the drive reverses. Slow parts therefore soften the corners
+/// and hold the node up on the way out of clipping, which is a real part of why
+/// builders hear diode types — a fast silicon switching diode stores almost
+/// nothing and stays tight, while germanium and rectifier junctions run into
+/// microseconds and audibly round the break-up. Two unequal parts recover at
+/// different rates, so the two edges of the wave differ as well.
+///
+/// It is *not* a large source of even harmonics, and the measurements say so:
+/// the effect lives in the transitions, which are a few samples out of a cycle,
+/// so a strongly mismatched pair contributes h2 around −68 dB. Amplitude
+/// asymmetry does not help either — a hard-clipped wave with unequal flat tops
+/// is a symmetric square plus a constant, and the downstream blocker takes the
+/// constant. The previous build's stronger h2 came from injecting an
+/// envelope-driven offset ahead of a symmetric curve, which is not a circuit
+/// and is not reproduced here.
+///
+/// `F` is smooth and strictly increasing in `v` (every derivative term is
+/// positive), so a damped Newton iteration converges in a handful of steps.
+///
+/// Voltages are normalized so a nominal diode drop is `1.0`, which puts the
+/// clipping threshold at plugin unity and makes the stage transparent below it.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct DiodeParams {
+    v_pos: f32,
+    v_neg: f32,
+    inv_knee_pos: f32,
+    inv_knee_neg: f32,
+    knee_pos: f32,
+    knee_neg: f32,
+    /// Fixed capacitor conductance `Gc = C * fs`, normalized against `Rs = 1`.
+    gc: f32,
+    /// Transit time × rate for each diode: how much diffusion charge the
+    /// junction stores per unit of its own current.
+    k_pos: f32,
+    k_neg: f32,
+}
+
+impl DiodeParams {
+    /// * `v_pos` / `v_neg` — forward voltage of each diode, normalized so a
+    ///   nominal drop is 1.0. Unequal values are a real asymmetric pair.
+    /// * `knee_pos` / `knee_neg` — emission coefficient × thermal voltage, in
+    ///   the same normalized units. Larger is a softer, germanium-like knee.
+    /// * `tau_pos` / `tau_neg` — junction transit time in seconds, which sets
+    ///   the diffusion charge each diode stores while conducting. Fast silicon
+    ///   switching parts are a few nanoseconds and do essentially nothing here;
+    ///   germanium and rectifier junctions run into microseconds and are what
+    ///   thicken and skew the break-up. The current scale is normalized rather
+    ///   than in amps, so these are device-ballpark figures, not datasheet
+    ///   extractions.
+    /// * `smooth_hz` — corner of the fixed capacitor across the diodes. This is
+    ///   the part that keeps hard clipping from sounding like a digital fold
+    ///   even when nothing is conducting.
+    /// * `node_rate` — the rate the solver actually runs at, i.e. the
+    ///   *oversampled* rate.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        v_pos: f32,
+        v_neg: f32,
+        knee_pos: f32,
+        knee_neg: f32,
+        tau_pos: f32,
+        tau_neg: f32,
+        smooth_hz: f32,
+        node_rate: f32,
+    ) -> Self {
+        let kp = knee_pos.clamp(0.005, 0.5);
+        let kn = knee_neg.clamp(0.005, 0.5);
+        let rate = node_rate.max(1.0);
+        // Rs is normalized to 1, so C follows from the corner alone:
+        // Gc = C * fs = fs / (2*pi*f_c).
+        let gc = (rate / (std::f32::consts::TAU * smooth_hz.clamp(20.0, rate * 0.45))).min(64.0);
+        Self {
+            v_pos: v_pos.max(0.02),
+            v_neg: v_neg.max(0.02),
+            inv_knee_pos: 1.0 / kp,
+            inv_knee_neg: 1.0 / kn,
+            knee_pos: kp,
+            knee_neg: kn,
+            gc,
+            k_pos: (tau_pos.max(0.0) * rate).min(16.0),
+            k_neg: (tau_neg.max(0.0) * rate).min(16.0),
+        }
+    }
+
+    /// Forward current of each diode, as positive quantities.
+    #[inline]
+    fn currents(&self, v: f32) -> (f32, f32) {
+        (
+            ((v - self.v_pos) * self.inv_knee_pos).min(24.0).exp(),
+            ((-v - self.v_neg) * self.inv_knee_neg).min(24.0).exp(),
+        )
+    }
+
+    /// Total charge stored on the node, already scaled by the sample rate so it
+    /// reads as a current.
+    #[inline]
+    fn charge(&self, v: f32, ep: f32, en: f32) -> f32 {
+        self.gc * v + self.k_pos * ep - self.k_neg * en
+    }
+
+    /// Log-domain first guess. Deep in conduction the diode fixes `v` to within
+    /// a few millivolts of `v_f + knee*ln(i)`, so starting there keeps Newton
+    /// out of the region where the exponential's curvature stalls it.
+    #[inline]
+    fn guess(&self, target: f32) -> f32 {
+        if target > self.v_pos {
+            (self.v_pos + self.knee_pos * (target * (1.0 + self.gc)).max(1.0e-9).ln())
+                .clamp(0.0, target)
+        } else if target < -self.v_neg {
+            (-(self.v_neg + self.knee_neg * (-target * (1.0 + self.gc)).max(1.0e-9).ln()))
+                .clamp(target, 0.0)
+        } else {
+            target
+        }
+    }
+}
+
+/// Per-channel node state: the solved voltage and the current each junction was
+/// carrying, which is what the diffusion charge is computed from.
+#[derive(Debug, Clone, Copy, Default)]
+struct DiodeState {
+    v: f32,
+    ep: f32,
+    en: f32,
+}
+
+/// Stereo clipping node. State is the charge the node is holding — that is the
+/// whole reason this is not a waveshaper.
+#[derive(Debug, Clone)]
+pub(super) struct DiodeClipper {
+    params: DiodeParams,
+    left: DiodeState,
+    right: DiodeState,
+}
+
+impl DiodeClipper {
+    pub(super) fn new(params: DiodeParams) -> Self {
+        Self {
+            params,
+            left: DiodeState::default(),
+            right: DiodeState::default(),
+        }
+    }
+
+    pub(super) fn set_params(&mut self, params: DiodeParams) {
+        self.params = params;
+    }
+
+    pub(super) fn reset(&mut self) {
+        self.left = DiodeState::default();
+        self.right = DiodeState::default();
+    }
+
+    #[inline]
+    fn one(p: &DiodeParams, st: &mut DiodeState, x: f32) -> f32 {
+        let q_prev = p.charge(st.v, st.ep, st.en);
+        // While the junctions are holding charge the node cannot move far in a
+        // sample, so the previous solution is the better starting point;
+        // otherwise the log-domain estimate is near-exact.
+        let stored = p.k_pos * st.ep + p.k_neg * st.en;
+        let mut v = if stored > p.gc {
+            st.v
+        } else {
+            p.guess((x + p.gc * st.v) / (1.0 + p.gc))
+        };
+        for _ in 0..6 {
+            let (ep, en) = p.currents(v);
+            let f = (v - x) + (p.charge(v, ep, en) - q_prev) + ep - en;
+            let df = 1.0
+                + p.gc
+                + ep * p.inv_knee_pos * (1.0 + p.k_pos)
+                + en * p.inv_knee_neg * (1.0 + p.k_neg);
+            let step = (f / df).clamp(-0.5, 0.5);
+            v -= step;
+            if step.abs() < 1.0e-6 {
+                break;
+            }
+        }
+        let (ep, en) = p.currents(v);
+        st.v = finite(v);
+        st.ep = if ep.is_finite() { ep } else { 0.0 };
+        st.en = if en.is_finite() { en } else { 0.0 };
+        st.v
+    }
+
+    /// Solve both channels for one sample at the node's own rate. Call this
+    /// *inside* an oversampler and construct [`DiodeParams`] with the
+    /// oversampled rate.
+    #[inline]
+    pub(super) fn process(&mut self, l: f32, r: f32) -> (f32, f32) {
+        let p = self.params;
+        (
+            Self::one(&p, &mut self.left, l),
+            Self::one(&p, &mut self.right, r),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Triode stage (amp)
+// ---------------------------------------------------------------------------
+
+/// Smooth `max(e, 0)` — the valve's cutoff region, rounded by `knee`.
+#[inline]
+fn smooth_max(e: f32, knee: f32) -> f32 {
+    0.5 * (e + (e * e + knee).sqrt())
+}
+
+/// Smooth `min(i, ceiling)` — the plate running out of supply voltage.
+#[inline]
+fn smooth_min(i: f32, ceiling: f32, knee: f32) -> f32 {
+    let d = i - ceiling;
+    0.5 * (i + ceiling - (d * d + knee).sqrt())
+}
+
+/// Plate current: zero below cutoff, three-halves law above it.
+///
+/// The asymmetry that makes a valve stage sound like one falls straight out of
+/// this: the cutoff side rounds off gradually while the conduction side grows
+/// faster than linear until the plate saturates. No curve is being drawn — the
+/// operating point is supplied by the caller's cathode and grid state, so the
+/// same input voltage produces different current depending on what came before.
+#[inline]
+fn plate_current(e: f32, knee: f32) -> f32 {
+    let s = smooth_max(e, knee);
+    s * s.sqrt()
+}
+
+/// Everything about a triode stage that only changes when the model or a knob
+/// is reconfigured. The two things that move per sample — the stage's gain and
+/// its coupling pole — are passed to [`TriodeState::process`] instead, so the
+/// operating point never has to be re-solved on the audio thread.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct TriodeParams {
+    /// Quiescent operating point above cutoff.
+    pub(super) grid_offset: f32,
+    /// Cutoff rounding.
+    pub(super) knee: f32,
+    /// Plate current ceiling — where the stage runs out of supply.
+    pub(super) headroom: f32,
+    /// Rounding of that ceiling.
+    pub(super) sat_knee: f32,
+    /// Cathode resistor: how much of the plate current feeds back as bias.
+    pub(super) cathode_r: f32,
+    /// Cathode bypass corner as a one-pole coefficient. Below it the cathode
+    /// follows the signal and degenerates the gain — this is why a real preamp
+    /// amplifies bass *less* than mids and does not turn to mud when driven.
+    pub(super) cathode_alpha: f32,
+    /// Miller capacitance at the plate: HF rolloff *inside* the stage, so the
+    /// next stage never gets the raw clipping edge to re-clip into fizz.
+    pub(super) miller_alpha: f32,
+    /// How far above the quiescent point the stage can be driven before grid
+    /// current starts flowing. Derived into `grid_clamp` at configure time.
+    pub(super) grid_headroom: f32,
+    /// Instantaneous grid-current loading above that point.
+    pub(super) grid_soft: f32,
+    /// How fast grid current charges the coupling capacitor.
+    pub(super) grid_attack: f32,
+    /// How fast the grid-leak resistor discharges it again. Together with
+    /// `grid_attack` this is blocking distortion: hit it hard and the stage
+    /// chokes, then recovers over milliseconds. A waveshaper cannot do this.
+    pub(super) grid_release: f32,
+    /// Operating point at which grid conduction begins (derived).
+    pub(super) grid_clamp: f32,
+    /// Plate load, normalized at configure time so small-signal gain == `gain`.
+    pub(super) plate_r: f32,
+    /// Quiescent current, subtracted so the stage is DC-free at rest.
+    pub(super) quiescent: f32,
+}
+
+impl TriodeParams {
+    /// Solve the self-bias operating point: the cathode voltage and the plate
+    /// current determine each other, so damped fixed-point iteration on the
+    /// control path (never in the audio callback) settles it.
+    pub(super) fn solve_operating_point(&mut self) {
+        let mut i = 1.0f32;
+        for _ in 0..64 {
+            let e = self.grid_offset - self.cathode_r * i;
+            let target = smooth_min(plate_current(e, self.knee), self.headroom, self.sat_knee);
+            i += 0.35 * (target - i);
+            if !i.is_finite() {
+                i = 0.0;
+                break;
+            }
+        }
+        self.quiescent = i;
+        let e_q = (self.grid_offset - self.cathode_r * i).max(1.0e-3);
+        self.grid_clamp = e_q + self.grid_headroom.max(0.05);
+        // d(i)/d(e) = 1.5 * sqrt(e) at the operating point; normalizing by it
+        // makes `gain` an honest voltage gain instead of an arbitrary scalar.
+        self.plate_r = 1.0 / (1.5 * e_q.sqrt()).max(1.0e-3);
+    }
+
+    pub(super) fn cathode_rest(&self) -> f32 {
+        self.cathode_r * self.quiescent
+    }
+}
+
+/// Per-channel state of one triode stage.
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct TriodeState {
+    coupling_x: f32,
+    coupling_y: f32,
+    grid_charge: f32,
+    cathode: f32,
+    miller: f32,
+}
+
+impl TriodeState {
+    /// Seed the cathode at its resting bias so the stage is at its operating
+    /// point on the first sample instead of fading in over the RC.
+    pub(super) fn prime(&mut self, params: &TriodeParams) {
+        *self = Self::default();
+        self.cathode = params.cathode_rest();
+    }
+
+    /// `gain` is the stage's small-signal voltage gain and `coupling_pole` its
+    /// interstage AC-coupling pole; both are smoothed control values, so they
+    /// arrive per sample rather than living in [`TriodeParams`].
+    #[inline]
+    pub(super) fn process(
+        &mut self,
+        x: f32,
+        p: &TriodeParams,
+        gain: f32,
+        coupling_pole: f32,
+    ) -> f32 {
+        // Interstage coupling capacitor.
+        let coupled = x - self.coupling_x + coupling_pole * self.coupling_y;
+        self.coupling_x = x;
+        self.coupling_y = finite(coupled);
+
+        // Operating point = fixed offset, the amplified signal, the cathode's
+        // own memory, and whatever charge previous grid current left behind.
+        let raw = p.grid_offset + self.coupling_y * gain - self.cathode - self.grid_charge;
+        // Drive the grid positive and it draws current: the source is loaded
+        // (instantaneous squash) *and* the coupling capacitor charges, dragging
+        // the whole stage toward cutoff for milliseconds afterwards. That is
+        // blocking distortion, and it is why a cranked amp coughs on a hard
+        // chord and clears as it decays.
+        let over = raw - p.grid_clamp;
+        let e = if over > 0.0 {
+            self.grid_charge += p.grid_attack * over;
+            p.grid_clamp + over * p.grid_soft
+        } else {
+            raw
+        };
+        self.grid_charge = finite(self.grid_charge - self.grid_charge * p.grid_release);
+
+        let i = smooth_min(plate_current(e, p.knee), p.headroom, p.sat_knee);
+
+        // Cathode RC. `cathode_alpha` is the bypass capacitor: fast for the
+        // band it shorts (full gain), slow below it (degenerated gain).
+        self.cathode = finite(self.cathode + p.cathode_alpha * (p.cathode_r * i - self.cathode));
+
+        // Inverting plate output, then the Miller pole.
+        let out = (p.quiescent - i) * p.plate_r;
+        self.miller = finite(self.miller + p.miller_alpha * (out - self.miller));
+        self.miller
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Push-pull output stage
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct PushPullParams {
+    /// Idle current. Low bias is class B — the halves hand over with a real
+    /// crossover notch, which is the grind of a cranked output stage.
+    pub(super) bias: f32,
+    pub(super) knee: f32,
+    pub(super) headroom: f32,
+    pub(super) sat_knee: f32,
+    /// Mismatch between the two halves.
+    pub(super) asymmetry: f32,
+    pub(super) scale: f32,
+}
+
+impl PushPullParams {
+    pub(super) fn normalize(&mut self) {
+        let slope = 1.5 * self.bias.max(1.0e-3).sqrt() * (2.0 - self.asymmetry);
+        self.scale = 1.0 / slope.max(1.0e-3);
+    }
+
+    /// `x` is the already-driven grid voltage; `supply` is the sagged rail
+    /// (1.0 = full). The supply scales the *ceiling*, so a collapsing rail
+    /// compresses the peaks and leaves the small signal alone — which is what
+    /// a sagging amp actually does. Small-signal gain through the pair is
+    /// normalized to unity, so Master remains the one drive control.
+    #[inline]
+    pub(super) fn process(&self, x: f32, supply: f32) -> f32 {
+        let drive = x;
+        let ceiling = (self.headroom * supply).max(1.0e-3);
+        let a = smooth_min(
+            plate_current(self.bias + drive, self.knee),
+            ceiling,
+            self.sat_knee,
+        );
+        let b = smooth_min(
+            plate_current(self.bias - drive * (1.0 - self.asymmetry), self.knee),
+            ceiling * (1.0 - self.asymmetry * 0.5),
+            self.sat_knee,
+        );
+        finite((a - b) * self.scale)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rms(x: &[f32]) -> f32 {
+        (x.iter().map(|v| v * v).sum::<f32>() / x.len().max(1) as f32).sqrt()
+    }
+
+    fn render_clipper(params: DiodeParams, freq: f32, amp: f32, rate: f32) -> Vec<f32> {
+        let mut clipper = DiodeClipper::new(params);
+        let n = (rate * 0.25) as usize;
+        let mut out = Vec::with_capacity(n);
+        for k in 0..n {
+            let phase = std::f32::consts::TAU * freq * k as f32 / rate;
+            let (l, _) = clipper.process(amp * phase.sin(), 0.0);
+            out.push(l);
+        }
+        // Drop the first 50 ms so the capacitor has settled.
+        out.split_off((rate * 0.05) as usize)
+    }
+
+    #[test]
+    fn diode_node_is_transparent_below_the_knee_and_clamps_above_it() {
+        let rate = 96_000.0;
+        let params = DiodeParams::new(1.0, 1.0, 0.075, 0.075, 1.0e-8, 1.0e-8, 12_000.0, rate);
+        let clean = render_clipper(params, 400.0, 0.25, rate);
+        let slammed = render_clipper(params, 400.0, 40.0, rate);
+        let clean_peak = clean.iter().fold(0.0f32, |m, v| m.max(v.abs()));
+        let slammed_peak = slammed.iter().fold(0.0f32, |m, v| m.max(v.abs()));
+        assert!(
+            (clean_peak - 0.25).abs() < 0.02,
+            "well under the knee the node should pass unchanged, got {clean_peak}"
+        );
+        // 44 dB of extra input buys well under 6 dB of extra output: the diode
+        // exponential sets the ceiling, not a chosen clamp value.
+        assert!(
+            (1.0..1.6).contains(&slammed_peak),
+            "hard drive should land near the diode drop, got {slammed_peak}"
+        );
+    }
+
+    #[test]
+    fn diode_clipper_is_finite_and_bounded_under_abuse() {
+        let rate = 192_000.0;
+        let params = DiodeParams::new(0.9, 1.1, 0.05, 0.12, 2.0e-6, 5.0e-7, 9_000.0, rate);
+        let mut clipper = DiodeClipper::new(params);
+        let mut peak = 0.0f32;
+        for k in 0..20_000 {
+            let x = if k % 97 < 48 { 400.0 } else { -400.0 };
+            let (l, r) = clipper.process(x, -x);
+            assert!(l.is_finite() && r.is_finite());
+            peak = peak.max(l.abs()).max(r.abs());
+        }
+        assert!(peak < 2.5, "clipped square should stay bounded, got {peak}");
+    }
+
+    #[test]
+    fn asymmetric_diodes_skew_the_two_halves() {
+        let rate = 96_000.0;
+        let params = DiodeParams::new(0.70, 1.30, 0.05, 0.05, 1.0e-8, 1.0e-8, 12_000.0, rate);
+        let out = render_clipper(params, 400.0, 12.0, rate);
+        let high = out.iter().fold(0.0f32, |m, v| m.max(*v));
+        let low = out.iter().fold(0.0f32, |m, v| m.min(*v)).abs();
+        assert!(
+            low > high * 1.4,
+            "unequal diodes should clip the halves at different levels: {high} vs {low}"
+        );
+    }
+
+    /// Harmonic magnitude at `harmonic * freq`, measured about the signal's own
+    /// mean so a DC offset cannot be mistaken for even-harmonic content — the
+    /// same thing the downstream DC blocker does.
+    fn harmonic(out: &[f32], freq: f32, rate: f32, harmonic: usize) -> f32 {
+        let mean = out.iter().sum::<f32>() / out.len().max(1) as f32;
+        let w = std::f32::consts::TAU * freq * harmonic as f32 / rate;
+        let (mut re, mut im) = (0.0f32, 0.0f32);
+        for (k, v) in out.iter().enumerate() {
+            let phase = w * k as f32;
+            re += (v - mean) * phase.cos();
+            im += (v - mean) * phase.sin();
+        }
+        (re * re + im * im).sqrt() / out.len().max(1) as f32
+    }
+
+    /// Pins the *measured size* of the junction-charge contribution to even
+    /// harmonics, so the claim in the module docs stays honest. Unequal transit
+    /// times do generate h2, and they generate more of it than a matched fast
+    /// pair — but the effect lives in the edges, so it stays tiny. Anything
+    /// that made this assertion pass by an order of magnitude would not be a
+    /// diode any more.
+    #[test]
+    fn junction_charge_skews_the_edges_but_is_a_minor_source_of_even_harmonics() {
+        let rate = 192_000.0;
+        let freq = 400.0;
+        // Identical forward voltages, so there is no amplitude asymmetry at all
+        // and the only difference between the pairs is stored junction charge.
+        let matched = DiodeParams::new(1.0, 1.0, 0.05, 0.05, 8.0e-9, 8.0e-9, 9_000.0, rate);
+        let mismatched = DiodeParams::new(1.0, 1.0, 0.05, 0.05, 2.5e-6, 6.0e-7, 9_000.0, rate);
+
+        let ratio = |p: DiodeParams| {
+            let out = render_clipper(p, freq, 20.0, rate);
+            harmonic(&out, freq, rate, 2) / harmonic(&out, freq, rate, 1).max(1.0e-12)
+        };
+        let matched_h2 = ratio(matched);
+        let mismatched_h2 = ratio(mismatched);
+
+        assert!(
+            mismatched_h2 > matched_h2 * 4.0,
+            "unequal junction charge should skew the halves: {mismatched_h2} vs {matched_h2}"
+        );
+        // ...and this is the honest ceiling of the mechanism: about -60 dB.
+        assert!(
+            mismatched_h2 < 0.005,
+            "junction charge is an edge effect, not a thickener: h2 {mismatched_h2}"
+        );
+    }
+
+    #[test]
+    fn a_slow_junction_holds_the_node_in_conduction_after_the_drive_stops() {
+        let rate = 192_000.0;
+        let fast = DiodeParams::new(1.0, 1.0, 0.05, 0.05, 5.0e-9, 5.0e-9, 9_000.0, rate);
+        let slow = DiodeParams::new(1.0, 1.0, 0.05, 0.05, 3.0e-6, 3.0e-6, 9_000.0, rate);
+        // Drive hard, then drop to zero: the stored diffusion charge has to be
+        // removed before the junction can turn off, so a slow part sits higher
+        // on the sample after the drive is gone.
+        let recover = |p: DiodeParams| {
+            let mut c = DiodeClipper::new(p);
+            for _ in 0..256 {
+                c.process(30.0, 0.0);
+            }
+            c.process(0.0, 0.0).0
+        };
+        let fast_after = recover(fast);
+        let slow_after = recover(slow);
+        assert!(
+            slow_after > fast_after + 0.02,
+            "the slow junction should still be conducting: {slow_after} vs {fast_after}"
+        );
+    }
+
+    #[test]
+    fn the_smoothing_capacitor_gives_the_node_memory() {
+        let rate = 192_000.0;
+        let sharp = DiodeParams::new(1.0, 1.0, 0.05, 0.05, 1.0e-8, 1.0e-8, 30_000.0, rate);
+        let smooth = DiodeParams::new(1.0, 1.0, 0.05, 0.05, 1.0e-8, 1.0e-8, 4_000.0, rate);
+        // Step to the knee: with a bigger capacitor the node cannot corner as
+        // fast, so it takes more samples to reach its settled value.
+        let settle = |p: DiodeParams| {
+            let mut c = DiodeClipper::new(p);
+            for _ in 0..64 {
+                c.process(0.0, 0.0);
+            }
+            let mut samples = 0;
+            for _ in 0..512 {
+                let before = c.process(1.2, 0.0).0;
+                let after = c.process(1.2, 0.0).0;
+                samples += 1;
+                if (after - before).abs() < 1.0e-4 {
+                    break;
+                }
+            }
+            samples
+        };
+        let fast = settle(sharp);
+        let slow = settle(smooth);
+        assert!(
+            slow > fast,
+            "the capacitor should round the edge: settled in {slow} vs {fast} samples"
+        );
+    }
+
+    #[test]
+    fn triode_gain_matches_its_normalized_small_signal_target() {
+        let rate = 192_000.0;
+        let mut p = TriodeParams {
+            grid_offset: 1.4,
+            knee: 0.05,
+            headroom: 6.0,
+            sat_knee: 0.05,
+            cathode_r: 0.20,
+            cathode_alpha: 0.01,
+            miller_alpha: 0.5,
+            grid_headroom: 1.2,
+            grid_soft: 0.25,
+            grid_attack: 0.02,
+            grid_release: 0.0002,
+            grid_clamp: 0.0,
+            plate_r: 1.0,
+            quiescent: 0.0,
+        };
+        p.solve_operating_point();
+        let mut state = TriodeState::default();
+        state.prime(&p);
+        let n = (rate * 0.2) as usize;
+        let mut input = Vec::with_capacity(n);
+        let mut output = Vec::with_capacity(n);
+        for k in 0..n {
+            let x = 0.01 * (std::f32::consts::TAU * 1_000.0 * k as f32 / rate).sin();
+            let y = state.process(x, &p, 3.0, 0.999);
+            input.push(x);
+            output.push(y);
+        }
+        let skip = (rate * 0.05) as usize;
+        let measured = rms(&output[skip..]) / rms(&input[skip..]).max(1.0e-9);
+        // Cathode degeneration takes a little off the raw transconductance;
+        // the point is that it lands near the requested gain, not 10x off.
+        assert!(
+            (1.5..3.2).contains(&measured),
+            "small-signal gain should track the parameter, got {measured}"
+        );
+    }
+
+    #[test]
+    fn triode_blocking_recovers_after_a_hard_transient() {
+        let rate = 192_000.0;
+        let mut p = TriodeParams {
+            grid_offset: 1.4,
+            knee: 0.05,
+            headroom: 5.0,
+            sat_knee: 0.05,
+            cathode_r: 0.22,
+            cathode_alpha: 0.004,
+            miller_alpha: 0.4,
+            grid_headroom: 0.8,
+            grid_soft: 0.20,
+            grid_attack: 0.05,
+            grid_release: 0.00004,
+            grid_clamp: 0.0,
+            plate_r: 1.0,
+            quiescent: 0.0,
+        };
+        p.solve_operating_point();
+        let mut state = TriodeState::default();
+        state.prime(&p);
+        let tone =
+            |k: usize, amp: f32| amp * (std::f32::consts::TAU * 220.0 * k as f32 / rate).sin();
+        // The probe rides a DC transient from the coupling capacitor for a few
+        // milliseconds after any level change, so every window is measured
+        // about its own mean.
+        let ac_rms = |w: &[f32]| {
+            let mean = w.iter().sum::<f32>() / w.len().max(1) as f32;
+            rms(&w.iter().map(|v| v - mean).collect::<Vec<_>>())
+        };
+        let probe = |state: &mut TriodeState, seconds: f32, amp: f32| {
+            let n = (rate * seconds) as usize;
+            (0..n)
+                .map(|k| state.process(tone(k, amp), &p, 6.0, 0.999))
+                .collect::<Vec<_>>()
+        };
+
+        let settled = probe(&mut state, 0.30, 0.05);
+        let reference = ac_rms(&settled[(rate * 0.2) as usize..]);
+        // Slam it, then go quiet again.
+        probe(&mut state, 0.05, 6.0);
+        let recovery = probe(&mut state, 0.40, 0.05);
+        let just_after = ac_rms(&recovery[(rate * 0.01) as usize..(rate * 0.03) as usize]);
+        let long_after = ac_rms(&recovery[(rate * 0.30) as usize..]);
+
+        assert!(
+            just_after < reference * 0.9,
+            "the stage should choke right after a slam: {just_after} vs {reference}"
+        );
+        assert!(
+            long_after > just_after * 1.05,
+            "and recover afterwards: {long_after} vs {just_after}"
+        );
+    }
+
+    #[test]
+    fn push_pull_supply_sag_compresses_peaks_not_small_signal() {
+        let mut p = PushPullParams {
+            bias: 0.55,
+            knee: 0.04,
+            headroom: 2.4,
+            sat_knee: 0.05,
+            asymmetry: 0.06,
+            scale: 1.0,
+        };
+        p.normalize();
+        let small_full = p.process(0.01, 1.0);
+        let small_sag = p.process(0.01, 0.6);
+        let loud_full = p.process(3.0, 1.0);
+        let loud_sag = p.process(3.0, 0.6);
+        assert!(
+            (small_full - small_sag).abs() < small_full.abs() * 0.05 + 1.0e-4,
+            "sag must not act as a volume control on quiet signal"
+        );
+        assert!(
+            loud_sag < loud_full * 0.9,
+            "sag must compress the peaks: {loud_sag} vs {loud_full}"
+        );
+    }
+}


### PR DESCRIPTION
The distortion and amp paths both drove the whole spectrum into one static transfer curve, which made the low end mush ("อู้ๆ") and gave the break-up the flat, level-locked character of digital clipping rather than a guitar rig. Neither is fixable by reshaping the curve, so the curves are gone.

New `dsp/nonlinear.rs`:

- `DiodeClipper` — an antiparallel diode pair with its smoothing capacitor, solved per sample by damped Newton from a log-domain first guess. Charge is integrated rather than a capacitance inserted into the node equation, so the junctions' own diffusion charge (`q = tau * i`) is included and slow parts show real reverse recovery: they keep conducting until the stored charge is swept out. The diode exponential sets the ceiling; no clamp value does.
- `TriodeState`/`TriodeParams` — a self-biasing valve stage: coupling cap, grid conduction that loads the source and charges the cap (blocking distortion), three-halves plate law with smooth cutoff and plate saturation, cathode RC with a bypass corner, and a Miller pole. Operating point, plate-load normalization and grid threshold are solved on the control path.
- `PushPullParams` — a class-AB output pair with a real crossover region. Sag scales the ceiling, so quiet passages keep their level and only peaks give.

Where the band-splitting now lives, which is the actual mud fix:

- `drive.rs` drops the split-and-reblend entirely. It re-blended a full-level clean low band onto a compressed clipped one, so it grew muddier as Drive rose. The Drive knob now feeds a shelf that only lifts above the pedal's coupling corner (TS-9 720 Hz, Rat 180, Fuzz 70), so bass reaches the diodes at unity and never crosses their threshold — by not being driven, which is how a real pedal does it. No band split, no phase seam.
- `amp.rs` drops `stage_shape` and the per-stage low/high shape-and-sum. Each stage's cathode bypass corner degenerates its own low end instead.

`drive_models.rs`: the four modern models and the shared `OdBoost` move to the same node. `hard_clip_asym`, `soft_asym`, `od_clip` and `duty_bias` are deleted — asymmetry is an unequal diode pair now, not an envelope offset injected ahead of a symmetric curve.

Measured, via examples/drive_diagnostic:

- Every drive model rises monotonically across the knob; peaks land 1.0–1.2.
- Even harmonics stay where the physics puts them: −30 dB for Breaker's real 2-up/1-down pair, −55…−63 dB for the rest. Junction charge contributes about −68 dB on its own because the effect lives in the transitions; a test pins that so the docs cannot drift into overclaiming it. The previous build's stronger h2 came from the injected bias and is not reproduced.

cargo test -p rodharerist: 132 passed. clippy and fmt clean; BuiltinAudioPlugins checks. No listening test and no native run — measurements only.