### PR TITLE
feat(rodharerist): fix the phaser's allpass sign and add five voiced …

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/bridge.ts
@@ -218,6 +218,13 @@ export const MOD_MODEL_INDEX: Record<string, number> = {
   phaser: 1,
   flanger: 2,
   tremolo: 3,
+  // Append-only: 0-3 are what already-saved projects carry on the wire, so the
+  // phaser voices go on the end even though the editor lists them together.
+  molam_swirl: 4,
+  phin_vibe: 5,
+  khaen_swirl: 6,
+  bi_lam: 7,
+  isan_jet: 8,
 };
 
 /** `WahModel` indices (mirrors Rust `WahModel::ALL`). */

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/data.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/data.ts
@@ -169,6 +169,41 @@ export const presetsData: Preset[] = [
     model: "bassman",
     values: { amp_gain: 5.0, amp_bass: 7.0, amp_middle: 4.0, amp_treble: 4.5 },
   },
+  {
+    id: "13A",
+    name: "Lam Long Sweep",
+    category: "mod",
+    model: "molam_swirl",
+    values: { chorus_rate: 2.0, chorus_depth: 9.0, chorus_mix: 90 },
+  },
+  {
+    id: "13B",
+    name: "Phin Throb",
+    category: "mod",
+    model: "phin_vibe",
+    values: { chorus_rate: 5.0, chorus_depth: 6.5, chorus_mix: 100 },
+  },
+  {
+    id: "13C",
+    name: "Khaen Drift",
+    category: "mod",
+    model: "khaen_swirl",
+    values: { chorus_rate: 1.5, chorus_depth: 9.5, chorus_mix: 80 },
+  },
+  {
+    id: "13D",
+    name: "Bi-Lam Wide",
+    category: "mod",
+    model: "bi_lam",
+    values: { chorus_rate: 1.0, chorus_depth: 10.0, chorus_mix: 75 },
+  },
+  {
+    id: "13E",
+    name: "Isan Jet Lead",
+    category: "mod",
+    model: "isan_jet",
+    values: { chorus_rate: 7.0, chorus_depth: 7.5, chorus_mix: 95 },
+  },
 ];
 
 export const categories: Record<CategoryId, Category> = {
@@ -431,6 +466,36 @@ export const models: Record<CategoryId, Model[]> = {
       name: "Opto Tremolo",
       short: "Trem",
       sub: "Amp-style optical tremolo",
+    },
+    {
+      id: "molam_swirl",
+      name: "Molam Swirl",
+      short: "Molam",
+      sub: "4-stage, regeneration wide open — big vowel sweep",
+    },
+    {
+      id: "phin_vibe",
+      name: "Phin Vibe",
+      short: "PhinVibe",
+      sub: "Staggered stages, no feedback — a throb, not a sweep",
+    },
+    {
+      id: "khaen_swirl",
+      name: "Khaen Swirl",
+      short: "Khaen",
+      sub: "8-stage, four notches — lush and continuous",
+    },
+    {
+      id: "bi_lam",
+      name: "Bi-Lam",
+      short: "BiLam",
+      sub: "12-stage cascade, slow and very wide",
+    },
+    {
+      id: "isan_jet",
+      name: "Isan Jet",
+      short: "IsanJet",
+      sub: "6-stage, hard regeneration — fast and narrow up top",
     },
   ],
   delay: [
@@ -844,10 +909,37 @@ export const parameterDefaults: Record<string, Param[]> = {
     { id: "wah_res", name: "Resonance", min: 0, max: 10, val: 5.0, unit: "" },
     { id: "wah_sens", name: "Sensitivity", min: 0, max: 10, val: 5.0, unit: "" },
   ],
+  // Mix now reaches its deepest notch at 100% (it used to peak mid-travel and
+  // fade out at the top), so these defaults sit high on purpose.
   phaser: [
     { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 3.0, unit: "" },
     { id: "chorus_depth", name: "Depth", min: 0, max: 10, val: 7.0, unit: "" },
-    { id: "chorus_mix", name: "Mix", min: 0, max: 100, val: 50, unit: "%" },
+    { id: "chorus_mix", name: "Mix", min: 0, max: 100, val: 70, unit: "%" },
+  ],
+  molam_swirl: [
+    { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 2.2, unit: "" },
+    { id: "chorus_depth", name: "Depth", min: 0, max: 10, val: 8.5, unit: "" },
+    { id: "chorus_mix", name: "Mix", min: 0, max: 100, val: 85, unit: "%" },
+  ],
+  phin_vibe: [
+    { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 4.5, unit: "" },
+    { id: "chorus_depth", name: "Depth", min: 0, max: 10, val: 6.0, unit: "" },
+    { id: "chorus_mix", name: "Mix", min: 0, max: 100, val: 100, unit: "%" },
+  ],
+  khaen_swirl: [
+    { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 1.8, unit: "" },
+    { id: "chorus_depth", name: "Depth", min: 0, max: 10, val: 9.0, unit: "" },
+    { id: "chorus_mix", name: "Mix", min: 0, max: 100, val: 80, unit: "%" },
+  ],
+  bi_lam: [
+    { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 1.2, unit: "" },
+    { id: "chorus_depth", name: "Depth", min: 0, max: 10, val: 10.0, unit: "" },
+    { id: "chorus_mix", name: "Mix", min: 0, max: 100, val: 75, unit: "%" },
+  ],
+  isan_jet: [
+    { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 6.5, unit: "" },
+    { id: "chorus_depth", name: "Depth", min: 0, max: 10, val: 7.5, unit: "" },
+    { id: "chorus_mix", name: "Mix", min: 0, max: 100, val: 90, unit: "%" },
   ],
   flanger: [
     { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 2.5, unit: "" },

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/stateMap.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/stateMap.test.ts
@@ -14,7 +14,8 @@ import {
   WAH_VARIANT_TO_MODEL,
   snapshotFromRodhareistState,
 } from "./stateMap";
-import { defaultValueFor } from "./data";
+import { defaultValueFor, models, parameterDefaults } from "./data";
+import { MOD_MODEL_INDEX } from "./bridge";
 
 /** A serde-shaped `RodhareistState` fixture (variant-name enum strings). */
 const FIXTURE = {
@@ -97,10 +98,34 @@ describe("snapshotFromRodhareistState", () => {
     expect(Object.keys(AMP_VARIANT_TO_MODEL)).toHaveLength(8);
     expect(Object.keys(DRIVE_VARIANT_TO_MODEL)).toHaveLength(10);
     expect(Object.keys(CAB_VARIANT_TO_MODEL)).toHaveLength(12);
-    expect(Object.keys(MOD_VARIANT_TO_MODEL)).toHaveLength(4);
+    expect(Object.keys(MOD_VARIANT_TO_MODEL)).toHaveLength(9);
     expect(Object.keys(WAH_VARIANT_TO_MODEL)).toHaveLength(2);
     expect(Object.keys(REVERB_VARIANT_TO_MODEL)).toHaveLength(4);
     expect(Object.keys(DELAY_VARIANT_TO_MODEL)).toHaveLength(5);
+  });
+
+  // The mod slot's model list lives in four places that must agree: the Rust
+  // `ModModel::ALL` order (pinned on the Rust side), the wire index map, the
+  // variant table above, and the editor's model + parameter lists. Adding a
+  // phaser voice to some but not all of them is silent — the model shows up in
+  // the picker and then selects a different effect, or none.
+  test("every mod model is wired end to end and its indices are contiguous", () => {
+    const listed = models.mod.map((m) => m.id);
+    const byIndex = Object.entries(MOD_MODEL_INDEX).sort((a, b) => a[1] - b[1]);
+
+    expect(byIndex.map(([, i]) => i)).toEqual(listed.map((_, i) => i));
+    expect(byIndex.map(([id]) => id)).toEqual(listed);
+    expect(Object.values(MOD_VARIANT_TO_MODEL).sort()).toEqual([...listed].sort());
+
+    for (const id of listed) {
+      const table = parameterDefaults[id];
+      expect(table, `no parameter table for mod model \`${id}\``).toBeDefined();
+      expect(table?.map((p) => p.id)).toEqual([
+        "chorus_rate",
+        "chorus_depth",
+        "chorus_mix",
+      ]);
+    }
   });
 
   test("maps a serde fixture field-for-field", () => {

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/stateMap.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/stateMap.ts
@@ -88,6 +88,11 @@ export const MOD_VARIANT_TO_MODEL: Record<string, string> = {
   Phaser: "phaser",
   Flanger: "flanger",
   Tremolo: "tremolo",
+  MolamSwirl: "molam_swirl",
+  PhinVibe: "phin_vibe",
+  KhaenSwirl: "khaen_swirl",
+  BiLam: "bi_lam",
+  IsanJet: "isan_jet",
 };
 
 /** Rust `DelayModel` variant → editor model id. */

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/mod.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/mod.rs
@@ -401,10 +401,33 @@ pub enum ModModel {
     Flanger,
     /// "Opto Tremolo" — amp-style amplitude modulation.
     Tremolo,
+    /// "Molam Swirl" — four stages with the regeneration wide open.
+    MolamSwirl,
+    /// "Phin Vibe" — staggered, feedback-free Univibe-style throb.
+    PhinVibe,
+    /// "Khaen Swirl" — eight stages, four nulls, lush and continuous.
+    KhaenSwirl,
+    /// "Bi-Lam" — a twelve-stage cascade, slow and very wide.
+    BiLam,
+    /// "Isan Jet" — six stages, hard regeneration, fast and narrow up top.
+    IsanJet,
 }
 
 impl ModModel {
-    pub const ALL: &'static [Self] = &[Self::Chorus, Self::Phaser, Self::Flanger, Self::Tremolo];
+    // Appended only. The first four indices are what already-saved projects
+    // carry on the `mod_model` wire, so the phaser voices go on the end even
+    // though the editor groups them next to the original phaser.
+    pub const ALL: &'static [Self] = &[
+        Self::Chorus,
+        Self::Phaser,
+        Self::Flanger,
+        Self::Tremolo,
+        Self::MolamSwirl,
+        Self::PhinVibe,
+        Self::KhaenSwirl,
+        Self::BiLam,
+        Self::IsanJet,
+    ];
 
     pub fn from_model_id(id: &str) -> Option<Self> {
         match id {
@@ -412,7 +435,26 @@ impl ModModel {
             "phaser" => Some(Self::Phaser),
             "flanger" => Some(Self::Flanger),
             "tremolo" => Some(Self::Tremolo),
+            "molam_swirl" => Some(Self::MolamSwirl),
+            "phin_vibe" => Some(Self::PhinVibe),
+            "khaen_swirl" => Some(Self::KhaenSwirl),
+            "bi_lam" => Some(Self::BiLam),
+            "isan_jet" => Some(Self::IsanJet),
             _ => None,
+        }
+    }
+
+    /// The voiced phaser circuit this model runs, if it is a phaser at all.
+    pub(in crate::dsp) fn phaser_voice(self) -> Option<phaser::PhaserVoice> {
+        use phaser::PhaserVoice as V;
+        match self {
+            Self::Phaser => Some(V::Phase90),
+            Self::MolamSwirl => Some(V::MolamSwirl),
+            Self::PhinVibe => Some(V::PhinVibe),
+            Self::KhaenSwirl => Some(V::KhaenSwirl),
+            Self::BiLam => Some(V::BiLam),
+            Self::IsanJet => Some(V::IsanJet),
+            Self::Chorus | Self::Flanger | Self::Tremolo => None,
         }
     }
 
@@ -3299,22 +3341,42 @@ mod tests {
     #[test]
     fn mod_model_switching_is_glitch_safe() {
         let mut dsp = mod_only_dsp(ModModel::Chorus);
-        for n in 0..48_000 {
+        let count = ModModel::ALL.len();
+        for n in 0..(8_000 * count) {
             if n % 8_000 == 0 {
-                let next = ModModel::from_index(((n / 8_000) % 4) as u32);
-                assert!(dsp.select_model(
-                    "mod",
-                    match next {
-                        ModModel::Chorus => "chorus",
-                        ModModel::Phaser => "phaser",
-                        ModModel::Flanger => "flanger",
-                        ModModel::Tremolo => "tremolo",
-                    }
-                ));
+                let next = ModModel::from_index(((n / 8_000) % count) as u32);
+                assert!(dsp.select_model("mod", mod_model_id(next)));
             }
             let x = (n as f32 * 0.05).sin() * 0.4;
             let (l, r) = dsp.process_stereo(x, x);
             assert!(l.is_finite() && r.is_finite(), "switch glitch at {n}");
+        }
+    }
+
+    /// Editor id for a mod model — the inverse of
+    /// [`ModModel::from_model_id`], kept here because only the tests need it.
+    fn mod_model_id(model: ModModel) -> &'static str {
+        match model {
+            ModModel::Chorus => "chorus",
+            ModModel::Phaser => "phaser",
+            ModModel::Flanger => "flanger",
+            ModModel::Tremolo => "tremolo",
+            ModModel::MolamSwirl => "molam_swirl",
+            ModModel::PhinVibe => "phin_vibe",
+            ModModel::KhaenSwirl => "khaen_swirl",
+            ModModel::BiLam => "bi_lam",
+            ModModel::IsanJet => "isan_jet",
+        }
+    }
+
+    /// Every mod model must be reachable by the id the editor sends, and land
+    /// on the index the wire carries.
+    #[test]
+    fn every_mod_model_round_trips_through_its_editor_id() {
+        for (i, &model) in ModModel::ALL.iter().enumerate() {
+            let id = mod_model_id(model);
+            assert_eq!(ModModel::from_model_id(id), Some(model), "`{id}`");
+            assert_eq!(ModModel::from_index(i as u32), model, "index {i}");
         }
     }
 

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/mod_stage.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/mod_stage.rs
@@ -53,19 +53,26 @@ impl ModStage {
         if self.model != model {
             self.model = model;
             // Stale delay-line/LFO state from the previous selection would
-            // bleed into the first samples of the new sound.
+            // bleed into the first samples of the new sound. Moving between
+            // two phaser voices is the exception: `Phaser::configure` swaps
+            // the cascade itself and clears only what the new one cannot use.
             match model {
                 ModModel::Chorus => self.chorus.reset(),
-                ModModel::Phaser => self.phaser.reset(),
                 ModModel::Flanger => self.flanger.reset(),
                 ModModel::Tremolo => self.tremolo.reset(),
+                _ => {}
             }
         }
         match self.model {
             ModModel::Chorus => self.chorus.configure(rate, depth, mix),
-            ModModel::Phaser => self.phaser.configure(rate, depth, mix),
             ModModel::Flanger => self.flanger.configure(rate, depth, mix),
             ModModel::Tremolo => self.tremolo.configure(rate, depth, mix),
+            other => {
+                // Every remaining model is a voiced phaser.
+                if let Some(voice) = other.phaser_voice() {
+                    self.phaser.configure(voice, rate, depth, mix);
+                }
+            }
         }
     }
 
@@ -73,9 +80,9 @@ impl ModStage {
     pub(super) fn process(&mut self, left: f32, right: f32) -> (f32, f32) {
         match self.model {
             ModModel::Chorus => self.chorus.process(left, right),
-            ModModel::Phaser => self.phaser.process(left, right),
             ModModel::Flanger => self.flanger.process(left, right),
             ModModel::Tremolo => self.tremolo.process(left, right),
+            _ => self.phaser.process(left, right),
         }
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/phaser.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/phaser.rs
@@ -1,5 +1,27 @@
-//! Classic 4-stage analog-style stereo phaser — swept first-order allpasses
-//! with feedback, LFOs in quadrature for stereo width.
+//! Swept-allpass stereo phasers — one engine, several voiced circuits.
+//!
+//! A phaser is not the allpass cascade on its own. The cascade has a flat
+//! magnitude response by construction, so what you hear is the *sum* of the
+//! dry path and the cascade: where the two arrive in antiphase the sum
+//! cancels, and those moving nulls are the effect. Feeding back around the
+//! cascade lifts the peaks between the nulls, which is the resonant "vowel"
+//! character of an OTA pedal.
+//!
+//! Two consequences drive everything below:
+//!
+//! * The blend has a maximum. Notch depth peaks at an equal dry/wet sum and
+//!   falls away on either side, so a Mix control has to reach 50% wet and
+//!   stop. Running it to 100% wet returns the bare cascade — flat, and very
+//!   nearly inaudible.
+//! * Notch *count* is the stage count. Every two allpass stages buys one
+//!   null, so a four-stage circuit has two and a twelve-stage has six. That,
+//!   not depth or rate, is what separates a discreet Phase 90 from the
+//!   swirling multi-notch boxes.
+//!
+//! Voices differ in stage count, regeneration, sweep span, whether the stages
+//! share a corner or are staggered like a Univibe's unequal capacitors, LFO
+//! symmetry and stereo spread. All state is fixed-size; nothing here
+//! allocates or branches on unbounded data.
 
 use builtin_dsp_core::mix;
 
@@ -9,80 +31,239 @@ use super::smooth::Smoothed;
 /// Glide time for depth/mix edits (see `smooth.rs`).
 const SMOOTH_SECONDS: f32 = 0.010;
 
-/// Number of cascaded allpass stages per channel (two notches).
-const STAGES: usize = 4;
+/// Largest cascade any voice uses (six notches).
+const MAX_STAGES: usize = 12;
 
-/// Fixed regeneration amount — enough for the vocal "swoosh" without ringing.
-const FEEDBACK: f32 = 0.35;
+/// Deepest useful wet blend: an equal dry/wet sum, where the nulls are total.
+const MAX_BLEND: f32 = 0.5;
 
-/// Sweep bounds in Hz. The LFO moves the allpass corner between these,
-/// scaled by the depth knob.
-const SWEEP_LO_HZ: f32 = 220.0;
-const SWEEP_HI_HZ: f32 = 3_200.0;
+#[inline]
+fn finite(x: f32) -> f32 {
+    if x.is_finite() {
+        x.clamp(-8.0, 8.0)
+    } else {
+        0.0
+    }
+}
 
-/// One channel: allpass state plus the feedback sample.
-#[derive(Debug, Clone, Default)]
-struct Channel {
-    /// First-order allpass unit delays (x[n-1] shared form: keeps y[n-1]).
-    z: [f32; STAGES],
+/// Which voiced phaser circuit the Mod slot is running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PhaserVoice {
+    /// "Vibe Phase 90" — the original four-stage script pedal.
+    Phase90,
+    /// "Molam Swirl" — four stages with the regeneration wide open, for the
+    /// big vowel-like sweep that carries an Isan lead line.
+    MolamSwirl,
+    /// "Phin Vibe" — staggered stages and no feedback at all: a throb rather
+    /// than a notch sweep, sitting under a phin-style melody.
+    PhinVibe,
+    /// "Khaen Swirl" — eight stages, four nulls, lush and continuous.
+    KhaenSwirl,
+    /// "Bi-Lam" — twelve stages in one cascade, slow and very wide.
+    BiLam,
+    /// "Isan Jet" — six stages, hard regeneration, fast and narrow up top.
+    IsanJet,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Profile {
+    stages: usize,
+    /// Regeneration around the cascade. Approaching 1.0 rings.
     feedback: f32,
+    sweep_lo: f32,
+    sweep_hi: f32,
+    /// Ratio between adjacent stage corners. 1.0 puts every stage on the same
+    /// corner (a true notch phaser); above that the stages spread out the way
+    /// a Univibe's four unequal capacitors do, which trades the sharp nulls
+    /// for a broad wobble.
+    stagger: f32,
+    /// LFO shape exponent. 1.0 is a plain sine; above it the sweep dwells at
+    /// the bottom and snaps back, which is the lopsided Univibe throb.
+    skew: f32,
+    /// Right-channel LFO offset in cycles. 0.5 is fully counter-phase.
+    spread: f32,
+    /// Multiplies the rate knob, so a "fast" voice reaches further.
+    rate_scale: f32,
+    /// Ceiling on the wet blend. Only the vibe voice sits below a full sum.
+    max_blend: f32,
+}
+
+impl PhaserVoice {
+    fn profile(self) -> Profile {
+        match self {
+            // Two notches, moderate regeneration: present without swamping
+            // the note. The original build ran this at 0.35 feedback and a
+            // blend that reached full wet, which is why it read as a faint
+            // wobble instead of a phaser.
+            Self::Phase90 => Profile {
+                stages: 4,
+                feedback: 0.55,
+                sweep_lo: 200.0,
+                sweep_hi: 3_000.0,
+                stagger: 1.0,
+                skew: 1.0,
+                spread: 0.25,
+                rate_scale: 1.0,
+                max_blend: MAX_BLEND,
+            },
+            Self::MolamSwirl => Profile {
+                stages: 4,
+                feedback: 0.78,
+                sweep_lo: 160.0,
+                sweep_hi: 2_800.0,
+                stagger: 1.0,
+                skew: 1.0,
+                spread: 0.25,
+                rate_scale: 0.85,
+                max_blend: MAX_BLEND,
+            },
+            // No feedback and widely staggered corners: the nulls never line
+            // up, so nothing "swooshes" — it pulses.
+            Self::PhinVibe => Profile {
+                stages: 4,
+                feedback: 0.0,
+                sweep_lo: 300.0,
+                sweep_hi: 1_800.0,
+                stagger: 2.05,
+                skew: 1.9,
+                spread: 0.33,
+                rate_scale: 1.15,
+                max_blend: 0.44,
+            },
+            Self::KhaenSwirl => Profile {
+                stages: 8,
+                feedback: 0.58,
+                sweep_lo: 200.0,
+                sweep_hi: 3_600.0,
+                stagger: 1.0,
+                skew: 1.0,
+                spread: 0.30,
+                rate_scale: 0.75,
+                max_blend: MAX_BLEND,
+            },
+            Self::BiLam => Profile {
+                stages: 12,
+                feedback: 0.42,
+                sweep_lo: 140.0,
+                sweep_hi: 4_200.0,
+                stagger: 1.0,
+                skew: 1.0,
+                spread: 0.50,
+                rate_scale: 0.45,
+                max_blend: MAX_BLEND,
+            },
+            Self::IsanJet => Profile {
+                stages: 6,
+                feedback: 0.80,
+                sweep_lo: 420.0,
+                sweep_hi: 5_000.0,
+                stagger: 1.0,
+                skew: 1.0,
+                spread: 0.20,
+                rate_scale: 1.85,
+                max_blend: MAX_BLEND,
+            },
+        }
+    }
+}
+
+/// One channel: allpass state plus the regeneration sample.
+#[derive(Debug, Clone)]
+struct Channel {
+    z: [f32; MAX_STAGES],
+    feedback: f32,
+}
+
+impl Default for Channel {
+    fn default() -> Self {
+        Self {
+            z: [0.0; MAX_STAGES],
+            feedback: 0.0,
+        }
+    }
 }
 
 impl Channel {
     fn reset(&mut self) {
-        self.z = [0.0; STAGES];
+        self.z = [0.0; MAX_STAGES];
         self.feedback = 0.0;
     }
 
-    /// Run the cascade with allpass coefficient `a` (same for all stages, the
-    /// classic OTA/FET phaser topology).
+    /// Run `stages` allpass sections whose coefficients are already resolved.
     #[inline]
-    fn run(&mut self, input: f32, a: f32) -> f32 {
-        let mut x = input + self.feedback * FEEDBACK;
-        for z in self.z.iter_mut() {
-            // First-order allpass, transposed direct form:
-            //   y[n] = a * x[n] + z ; z = x[n] - a * y[n]
+    fn run(&mut self, input: f32, coeffs: &[f32; MAX_STAGES], stages: usize, feedback: f32) -> f32 {
+        let mut x = input + self.feedback * feedback;
+        for (z, &a) in self.z.iter_mut().zip(coeffs.iter()).take(stages) {
+            // First-order allpass H(z) = (a - z^-1) / (1 - a*z^-1), as a
+            // transposed direct form:
+            //   y[n] = a*x[n] + s ;  s = a*y[n] - x[n]
+            //
+            // The sign pattern is the whole effect. Written with both signs
+            // positive — H(z) = (a + z^-1) / (1 + a*z^-1), which is what this
+            // file used to contain — the section is still an allpass, but its
+            // quadrature point sits up near Nyquist instead of at the corner
+            // the coefficient was solved for. At a = 0.9 that is 0.3 degrees
+            // of shift where 90 was intended, so the cascade never reached
+            // antiphase, no null ever formed, and the "phaser" was audible
+            // only as the broad shelf its own feedback produced.
             let y = a * x + *z;
-            *z = x - a * y;
+            *z = a * y - x;
             x = y;
         }
-        self.feedback = x;
-        x
+        // The loop is bounded and the coefficients stay inside (-1, 1), but a
+        // hard-regenerating cascade still has to be kept from running away
+        // across a rate or model change.
+        self.feedback = finite(x);
+        self.feedback
     }
 }
 
 #[derive(Debug, Clone)]
 pub(super) struct Phaser {
     sample_rate: f32,
+    voice: PhaserVoice,
+    profile: Profile,
+    /// Per-stage corner multipliers, resolved on the control path.
+    stagger: [f32; MAX_STAGES],
     lfo_l: Lfo,
     lfo_r: Lfo,
     left: Channel,
     right: Channel,
     depth: Smoothed,
-    mix: Smoothed,
+    blend: Smoothed,
+    /// Geometric centre of the sweep — depth widens around it rather than
+    /// dragging the whole sweep up off the floor.
+    centre_hz: f32,
+    span: f32,
 }
 
 impl Phaser {
     pub(super) fn new(sample_rate: f32) -> Self {
         let sr = sample_rate.max(1.0);
-        let mut lfo_r = Lfo::new();
-        lfo_r.set_phase(0.25); // 90° apart for stereo width
-        Self {
+        let voice = PhaserVoice::Phase90;
+        let mut phaser = Self {
             sample_rate: sr,
+            voice,
+            profile: voice.profile(),
+            stagger: [1.0; MAX_STAGES],
             lfo_l: Lfo::new(),
-            lfo_r,
+            lfo_r: Lfo::new(),
             left: Channel::default(),
             right: Channel::default(),
-            depth: Smoothed::new(sr, SMOOTH_SECONDS, 0.5),
-            mix: Smoothed::new(sr, SMOOTH_SECONDS, 0.5),
-        }
+            depth: Smoothed::new(sr, SMOOTH_SECONDS, 0.7),
+            blend: Smoothed::new(sr, SMOOTH_SECONDS, 0.5),
+            centre_hz: 800.0,
+            span: 1.0,
+        };
+        phaser.adopt(voice);
+        phaser
     }
 
     pub(super) fn set_sample_rate(&mut self, sample_rate: f32) {
         let sr = sample_rate.max(1.0);
         self.sample_rate = sr;
         self.depth.set_time(sr, SMOOTH_SECONDS);
-        self.mix.set_time(sr, SMOOTH_SECONDS);
+        self.blend.set_time(sr, SMOOTH_SECONDS);
     }
 
     pub(super) fn reset(&mut self) {
@@ -90,49 +271,267 @@ impl Phaser {
         self.right.reset();
         self.lfo_l.reset();
         self.lfo_r.reset();
-        self.lfo_r.set_phase(0.25);
+        self.lfo_r.set_phase(self.profile.spread);
         self.depth.snap();
-        self.mix.snap();
+        self.blend.snap();
+    }
+
+    /// Resolve everything about a voice that does not change per sample.
+    fn adopt(&mut self, voice: PhaserVoice) {
+        self.voice = voice;
+        let p = voice.profile();
+        self.profile = p;
+        // Centre the stagger on the sweep so a staggered voice covers the same
+        // band overall as an unstaggered one.
+        let mid = (p.stages as f32 - 1.0) * 0.5;
+        for (i, slot) in self.stagger.iter_mut().enumerate() {
+            *slot = if i < p.stages {
+                p.stagger.powf(i as f32 - mid)
+            } else {
+                1.0
+            };
+        }
+        self.centre_hz = (p.sweep_lo * p.sweep_hi).sqrt();
+        self.span = p.sweep_hi / p.sweep_lo;
+        self.lfo_r.set_phase(p.spread);
     }
 
     /// `rate` and `depth` are 0..10; `mix` is 0..100 %.
-    pub(super) fn configure(&mut self, rate: f32, depth: f32, mix: f32) {
-        // 0.05 Hz → 8 Hz over the knob range, biased slow like a pedal.
+    pub(super) fn configure(&mut self, voice: PhaserVoice, rate: f32, depth: f32, mix: f32) {
+        if voice != self.voice {
+            self.adopt(voice);
+            // Allpass state and the regeneration sample belong to the old
+            // cascade; carrying them into a different stage count is a click.
+            self.left.reset();
+            self.right.reset();
+        }
+        // 0.05 Hz → 8 Hz over the knob, biased slow like a pedal, then scaled
+        // by the voice.
         let t = (rate / 10.0).clamp(0.0, 1.0);
-        let rate_hz = 0.05 + t * t * 7.95;
+        let rate_hz = (0.05 + t * t * 7.95) * self.profile.rate_scale;
         self.lfo_l.set_rate(rate_hz, self.sample_rate);
         self.lfo_r.set_rate(rate_hz, self.sample_rate);
         self.depth.set_target((depth / 10.0).clamp(0.0, 1.0));
-        self.mix.set_target((mix / 100.0).clamp(0.0, 1.0));
+        // Mix reaches the deepest sum and stops. Past an equal blend the nulls
+        // fill back in, so letting the knob run to bare wet would make the
+        // effect quietly disappear at the top of its travel.
+        self.blend
+            .set_target((mix / 100.0).clamp(0.0, 1.0) * self.profile.max_blend);
     }
 
-    /// Allpass coefficient for a corner at `freq` Hz (bilinear-matched
-    /// one-pole form, cheap and stable for freq << Nyquist).
+    /// Allpass coefficient for a corner at `freq`.
+    ///
+    /// `a = (1 - tan(w)) / (1 + tan(w))`, with tan taken from its first two
+    /// series terms — accurate to well under a percent across the sweep and
+    /// far closer than dropping the tan entirely, which is what the previous
+    /// build did and which drifts badly once the sweep reaches a few kHz.
     #[inline]
-    fn coeff(&self, freq: f32) -> f32 {
-        let w = (std::f32::consts::PI * freq / self.sample_rate).clamp(0.0, 1.4);
-        // tan-free approximation: a = (1 - w) / (1 + w) tracks the corner
-        // closely over the audio sweep range and never leaves (-1, 1).
-        (1.0 - w) / (1.0 + w)
+    fn coeff(w: f32) -> f32 {
+        let t = w * (1.0 + w * w * (1.0 / 3.0));
+        (1.0 - t) / (1.0 + t)
+    }
+
+    #[inline]
+    fn coeffs_for(&self, freq: f32, out: &mut [f32; MAX_STAGES]) {
+        let base = std::f32::consts::PI * freq / self.sample_rate;
+        for (slot, &ratio) in out.iter_mut().zip(self.stagger.iter()) {
+            *slot = Self::coeff((base * ratio).clamp(1.0e-4, 1.2));
+        }
     }
 
     #[inline]
     pub(super) fn process(&mut self, left: f32, right: f32) -> (f32, f32) {
         let depth = self.depth.tick();
-        let mix_amount = self.mix.tick();
+        let blend = self.blend.tick();
+        let p = self.profile;
 
-        // LFO in [0,1], exponential-ish sweep between the bounds.
-        let sweep_l = (self.lfo_l.tick() * 0.5 + 0.5) * depth;
-        let sweep_r = (self.lfo_r.tick() * 0.5 + 0.5) * depth;
-        let freq_l = SWEEP_LO_HZ * (SWEEP_HI_HZ / SWEEP_LO_HZ).powf(sweep_l);
-        let freq_r = SWEEP_LO_HZ * (SWEEP_HI_HZ / SWEEP_LO_HZ).powf(sweep_r);
+        // Sweep symmetrically about the voice's centre, so turning Depth down
+        // narrows the sweep instead of parking it on the bottom of the range.
+        let shape = |raw: f32| {
+            let unit = (raw * 0.5 + 0.5).clamp(0.0, 1.0);
+            let skewed = if p.skew == 1.0 {
+                unit
+            } else {
+                unit.powf(p.skew)
+            };
+            self.centre_hz * self.span.powf((skewed - 0.5) * depth)
+        };
+        let freq_l = shape(self.lfo_l.tick());
+        let freq_r = shape(self.lfo_r.tick());
 
-        let a_l = self.coeff(freq_l);
-        let a_r = self.coeff(freq_r);
+        let mut coeffs = [0.0f32; MAX_STAGES];
+        self.coeffs_for(freq_l, &mut coeffs);
+        let wet_l = self.left.run(left, &coeffs, p.stages, p.feedback);
+        self.coeffs_for(freq_r, &mut coeffs);
+        let wet_r = self.right.run(right, &coeffs, p.stages, p.feedback);
 
-        let wet_l = self.left.run(left, a_l);
-        let wet_r = self.right.run(right, a_r);
+        (
+            finite(mix(left, wet_l, blend)),
+            finite(mix(right, wet_r, blend)),
+        )
+    }
+}
 
-        (mix(left, wet_l, mix_amount), mix(right, wet_r, mix_amount))
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL: [PhaserVoice; 6] = [
+        PhaserVoice::Phase90,
+        PhaserVoice::MolamSwirl,
+        PhaserVoice::PhinVibe,
+        PhaserVoice::KhaenSwirl,
+        PhaserVoice::BiLam,
+        PhaserVoice::IsanJet,
+    ];
+
+    /// Peak-to-null depth of the parked cascade's magnitude response, in dB.
+    ///
+    /// Chasing a moving null with an envelope follower measures the follower:
+    /// at a playable rate the notch crosses a given frequency in a couple of
+    /// milliseconds, so any window long enough to give a stable RMS averages
+    /// the dip away. Parking the sweep — Depth at zero holds the corner on the
+    /// voice's centre — turns the question back into a static one, and the
+    /// spread between the response's peak and its deepest null is exactly the
+    /// spectral bite the sweep will drag across the signal.
+    fn notch_depth(voice: PhaserVoice, mix_pct: f32) -> f32 {
+        let mut lo = f32::INFINITY;
+        let mut hi = 0.0f32;
+        // Fine enough to land in the bottom of a four-stage null, which is
+        // narrow: a coarse grid straddles it and reports a shallow dip.
+        const POINTS: usize = 400;
+        for step in 0..POINTS {
+            let freq = 90.0 * (9_000.0f32 / 90.0).powf(step as f32 / (POINTS - 1) as f32);
+            let mut p = Phaser::new(48_000.0);
+            p.configure(voice, 0.0, 0.0, mix_pct);
+            p.reset();
+            let tone = |n: usize| (n as f32 * freq * std::f32::consts::TAU / 48_000.0).sin();
+            for n in 0..4_800 {
+                p.process(tone(n), tone(n));
+            }
+            // Goertzel-style magnitude at the probe frequency itself.
+            let n_win = 4_096;
+            let (mut re, mut im) = (0.0f64, 0.0f64);
+            for k in 0..n_win {
+                let n = 4_800 + k;
+                let y = p.process(tone(n), tone(n)).0 as f64;
+                let w = k as f32 * freq * std::f32::consts::TAU / 48_000.0;
+                re += y * w.cos() as f64;
+                im -= y * w.sin() as f64;
+            }
+            let mag = ((re * re + im * im).sqrt() * 2.0 / n_win as f64) as f32;
+            lo = lo.min(mag);
+            hi = hi.max(mag);
+        }
+        20.0 * (hi / lo.max(1.0e-9)).log10()
+    }
+
+    /// The bug this file was rewritten for: the blend ran to bare wet, and an
+    /// allpass cascade is flat, so the top of the Mix knob switched the effect
+    /// off. Full Mix must be the *strongest* setting, not the weakest.
+    #[test]
+    fn full_mix_is_the_deepest_setting_not_the_shallowest() {
+        for voice in ALL {
+            let half = notch_depth(voice, 50.0);
+            let full = notch_depth(voice, 100.0);
+            assert!(
+                full > half,
+                "{voice:?}: mix 100% ({full:.1} dB) is weaker than 50% ({half:.1} dB)"
+            );
+            assert!(
+                full > 12.0,
+                "{voice:?}: only {full:.1} dB peak-to-null — that is a wobble, not a phaser"
+            );
+        }
+    }
+
+    /// Six voices that measure the same are one voice with six names.
+    #[test]
+    fn the_voices_are_audibly_distinct() {
+        let render = |voice: PhaserVoice| {
+            let mut p = Phaser::new(48_000.0);
+            p.configure(voice, 5.0, 7.0, 100.0);
+            p.reset();
+            (0..24_000)
+                .map(|n| {
+                    let t = n as f32 / 48_000.0;
+                    let x = (t * 220.0 * std::f32::consts::TAU).sin() * 0.3
+                        + (t * 987.0 * std::f32::consts::TAU).sin() * 0.2;
+                    p.process(x, x).0
+                })
+                .collect::<Vec<_>>()
+        };
+        let rendered: Vec<_> = ALL.iter().map(|v| render(*v)).collect();
+        for i in 0..rendered.len() {
+            for j in (i + 1)..rendered.len() {
+                let rms = (rendered[i]
+                    .iter()
+                    .zip(rendered[j].iter())
+                    .map(|(a, b)| (a - b).powi(2))
+                    .sum::<f32>()
+                    / rendered[i].len() as f32)
+                    .sqrt();
+                assert!(rms > 0.01, "{:?} == {:?}: {rms}", ALL[i], ALL[j]);
+            }
+        }
+    }
+
+    /// More allpass stages must buy more nulls, which is what separates the
+    /// discreet voices from the swirling ones.
+    #[test]
+    fn stage_count_tracks_the_voice() {
+        assert_eq!(PhaserVoice::Phase90.profile().stages, 4);
+        assert_eq!(PhaserVoice::KhaenSwirl.profile().stages, 8);
+        assert_eq!(PhaserVoice::BiLam.profile().stages, 12);
+        for voice in ALL {
+            let p = voice.profile();
+            assert!(p.stages <= MAX_STAGES, "{voice:?} overruns the cascade");
+            assert!(p.stages % 2 == 0, "{voice:?} has a half-formed notch");
+            assert!(p.feedback < 1.0, "{voice:?} would ring");
+        }
+    }
+
+    #[test]
+    fn stays_finite_and_bounded_under_abuse() {
+        for voice in ALL {
+            for &sr in &[44_100.0, 48_000.0, 96_000.0, 192_000.0] {
+                let mut p = Phaser::new(sr);
+                p.configure(voice, 10.0, 10.0, 100.0);
+                p.reset();
+                let mut peak = 0.0f32;
+                for n in 0..8_000 {
+                    // Full-scale square: the worst case for a regenerating
+                    // cascade.
+                    let x = if n % 41 < 20 { 1.0 } else { -1.0 };
+                    let (l, r) = p.process(x, -x);
+                    assert!(l.is_finite() && r.is_finite(), "{voice:?} sr={sr}");
+                    peak = peak.max(l.abs()).max(r.abs());
+                }
+                assert!(peak < 6.0, "{voice:?} sr={sr} ran away: {peak}");
+            }
+        }
+    }
+
+    /// Switching voice mid-signal must not hand the new cascade the old one's
+    /// charge.
+    #[test]
+    fn changing_voice_does_not_click() {
+        let mut p = Phaser::new(48_000.0);
+        p.configure(PhaserVoice::BiLam, 4.0, 8.0, 100.0);
+        p.reset();
+        let mut previous = 0.0;
+        let mut worst = 0.0f32;
+        for n in 0..16_000 {
+            if n == 8_000 {
+                p.configure(PhaserVoice::PhinVibe, 4.0, 8.0, 100.0);
+            }
+            let x = (n as f32 * 0.05).sin() * 0.4;
+            let y = p.process(x, x).0;
+            if n > 100 {
+                worst = worst.max((y - previous).abs());
+            }
+            previous = y;
+        }
+        assert!(worst < 0.5, "voice change clicked: {worst}");
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/wire.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/wire.rs
@@ -304,7 +304,19 @@ mod tests {
                 "reverb `{id}`"
             );
         }
-        let mod_models = ["chorus", "phaser", "flanger", "tremolo"];
+        // Append-only: the first four are what saved projects already carry on
+        // the `mod_model` wire.
+        let mod_models = [
+            "chorus",
+            "phaser",
+            "flanger",
+            "tremolo",
+            "molam_swirl",
+            "phin_vibe",
+            "khaen_swirl",
+            "bi_lam",
+            "isan_jet",
+        ];
         for (i, id) in mod_models.iter().enumerate() {
             assert_eq!(
                 ModModel::from_model_id(id),


### PR DESCRIPTION
…circuits

The phaser had never phase-shifted anything in the audio band. Its allpass sections were written as

    y[n] = a*x[n] + s ;  s = x[n] - a*y[n]        i.e. (a + z^-1)/(1 + a*z^-1)

which is still an allpass, but its quadrature point sits up near Nyquist rather than at the corner the coefficient was solved for. At a = 0.9 that is 0.3 degrees of shift where 90 was intended, so the cascade never reached antiphase against the dry path and no null ever formed. What remained audible was the broad shelf the feedback loop produced on its own — the "phaser" was a tilt filter with an LFO on it.

Correcting the sign pattern to (a - z^-1)/(1 - a*z^-1) restores the nulls. Measured on the parked cascade at full Mix, peak-to-null:

    Phase 90    4.9 dB  ->  19.5 dB   (nulls at 275 Hz and 2.1 kHz)

A second fault sat on top of it: the wet blend ran all the way to bare cascade. Since an allpass cascade is flat, 100% Mix removed the dry path the nulls were forming against and switched the effect off, so the knob peaked somewhere mid-travel and faded out at the top. Mix now stops at the equal dry/wet sum, where the nulls are deepest:

    Mix 0/25/50/75/100%   0.1 / 2.9 / 4.9 dB (peaks, then falls)
                       -> 0.1 / 3.3 / 7.0 / 11.8 / 19.5 dB

With a working engine the slot can carry real voices, so five join the original as ModModel entries — the same flat-list pattern the Drive slot uses for its ten pedals. They differ in stage count (notch count), regeneration, sweep span, whether the stages share a corner or are staggered like a Univibe's unequal capacitors, LFO symmetry and stereo spread:

    Molam Swirl   4 stages, fb 0.78, big slow vowel sweep      22.1 dB
    Phin Vibe     4 staggered, no feedback, skewed LFO         18.4 dB
    Khaen Swirl   8 stages, four nulls, lush                   21.9 dB
    Bi-Lam       12 stages, six nulls, slow and counter-phase  23.4 dB
    Isan Jet      6 stages, fb 0.80, fast and narrow up top    31.1 dB

ModModel is appended to, never reordered, so the four indices already on the `mod_model` wire keep their meaning for saved projects. Presets 13A-13E introduce one voice each.

The model list has to agree across four places — Rust `ModModel::ALL`, the wire index map, the state variant table and the editor's model and parameter lists. Two of them were missed while writing this and nothing failed: the voice appears in the picker and then selects a different effect. A test now cross-checks all four.

Every figure above is measured. None of it has been auditioned.