### PR TITLE
refactor(cef): improve cross-platform runtime initialization

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -97,11 +97,7 @@ package-exclusive = [
     "exclusive",
 ]
 
-[env]
-# bindgen, used by asio-sys, loads libclang.dll from this directory.
-LIBCLANG_PATH = { value = ".bin/bin", relative = true, force = false }
-
-# cef-dll-sys reads CEF_PATH during compilation.
-# This is the Windows developer default. Linux/macOS builds export their
-# platform-specific versioned path (as CI does) before invoking Cargo.
-CEF_PATH = { value = "build/cef/150.0.11/cef_windows_x86_64", relative = true, force = false }
+# Do not set CEF_PATH or LIBCLANG_PATH globally here. Cargo has no target-scoped
+# [env] support, so a platform-specific default contaminates builds for every
+# other host and cross-compilation target. CI and developer shells must export
+# paths that match Cargo's TARGET before invoking Cargo.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10417,6 +10417,7 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 name = "xtask"
 version = "0.1.0"
 dependencies = [
+ "SphereWebView",
  "anyhow",
  "cargo_metadata",
  "chrono",

--- a/apps/native/studio/src/main.rs
+++ b/apps/native/studio/src/main.rs
@@ -12,9 +12,6 @@ use sphere_ui_components::boot;
 use sphere_ui_components::embedded_assets::EmbeddedAssets;
 
 fn main() {
-    #[cfg(feature = "builtin-plugin-editor")]
-    sphere_webview::runtime::log_process_entry();
-
     // ── Phase -1 — CEF process dispatch ───────────────────────────────────────
     // CEF re-launches THIS executable for its own helper processes (renderer,
     // GPU, utility). Those launches must be detected and serviced before any
@@ -23,24 +20,11 @@ fn main() {
     // returns >= 0 only in a helper, and in that case the only correct action is
     // to exit with the code it hands back.
     //
-    // The app passed here declares the `mikoplugin://` scheme. CEF requires that
-    // declaration in *every* process, so the same app type is used again when
-    // the browser-side runtime initializes.
+    // The app passed here declares the `mikoplugin://` scheme. CEF requires the
+    // same object to be handed to browser-process initialization, so ownership
+    // is transferred to the UI-thread host after dispatch.
     #[cfg(feature = "builtin-plugin-editor")]
-    {
-        use sphere_webview::runtime::ProcessDispatch;
-        let mut scheme_app = sphere_webview::scheme::plugin_scheme_app();
-        if let ProcessDispatch::SubprocessExit(code) =
-            sphere_webview::runtime::execute_subprocess(Some(&mut scheme_app))
-        {
-            eprintln!(
-                "[cef-process] subprocess_exit pid={} code={} before_futureboard_startup=true",
-                std::process::id(),
-                code
-            );
-            std::process::exit(code);
-        }
-    }
+    dispatch_cef_process();
 
     // Privilege safety — must run before audio, plugins, settings, or project I/O.
     // Community and Exclusive Edition both block elevated launches. Developer
@@ -136,6 +120,53 @@ fn main() {
         discord_rpc.shutdown();
     }
     boot::log("gpui application exited");
+}
+
+#[cfg(feature = "builtin-plugin-editor")]
+fn dispatch_cef_process() {
+    use sphere_webview::runtime::ProcessDispatch;
+
+    sphere_webview::runtime::log_process_entry();
+    let mut scheme_app = match sphere_webview::scheme::plugin_scheme_app() {
+        Ok(app) => app,
+        Err(error) => {
+            handle_cef_process_setup_failure(&error);
+            return;
+        }
+    };
+    match sphere_webview::runtime::execute_subprocess(Some(&mut scheme_app)) {
+        Ok(ProcessDispatch::SubprocessExit(code)) => {
+            eprintln!(
+                "[cef-process] subprocess_exit pid={} code={} before_futureboard_startup=true",
+                std::process::id(),
+                code
+            );
+            std::process::exit(code);
+        }
+        Ok(ProcessDispatch::BrowserProcess) => {
+            if let Err(error) =
+                sphere_ui_components::components::builtin_plugin_editor::install_process_app(
+                    scheme_app,
+                )
+            {
+                eprintln!("[cef-process] browser_app_install_failed error={error}");
+            }
+        }
+        Err(error) => handle_cef_process_setup_failure(&error),
+    }
+}
+
+#[cfg(feature = "builtin-plugin-editor")]
+fn handle_cef_process_setup_failure(error: &sphere_webview::runtime::CefRuntimeError) {
+    let subprocess = sphere_webview::runtime::is_subprocess_command_line();
+    eprintln!(
+        "[cef-process] setup_failed pid={} subprocess={} error={error}",
+        std::process::id(),
+        subprocess
+    );
+    if subprocess {
+        std::process::exit(1);
+    }
 }
 
 /// Builds a GPUI [`Application`] with the correct OS platform backend.

--- a/crates/SphereUIComponents/examples/osr_editor_probe.rs
+++ b/crates/SphereUIComponents/examples/osr_editor_probe.rs
@@ -39,11 +39,14 @@ fn run() {
     sphere_webview::runtime::log_process_entry();
 
     // CEF re-launches this executable for its helpers; they must exit here.
-    let mut scheme_app = sphere_webview::scheme::plugin_scheme_app();
-    if let ProcessDispatch::SubprocessExit(code) =
-        sphere_webview::runtime::execute_subprocess(Some(&mut scheme_app))
+    let mut scheme_app = sphere_webview::scheme::plugin_scheme_app()
+        .expect("failed to prepare CEF before process dispatch");
+    match sphere_webview::runtime::execute_subprocess(Some(&mut scheme_app))
+        .expect("CEF process dispatch failed")
     {
-        std::process::exit(code);
+        ProcessDispatch::SubprocessExit(code) => std::process::exit(code),
+        ProcessDispatch::BrowserProcess => host::install_process_app(scheme_app)
+            .expect("failed to transfer the browser process application"),
     }
 
     let plugin_id = "rodharerist";

--- a/crates/SphereUIComponents/src/components/builtin_plugin_editor.rs
+++ b/crates/SphereUIComponents/src/components/builtin_plugin_editor.rs
@@ -568,6 +568,9 @@ mod imp {
         closing_views: HashMap<ViewId, ClosingView>,
         warmup: Option<WarmupBrowser>,
         runtime: CefRuntime,
+        // The exact CefApp passed to execute_process in the browser process.
+        // Keep it alive until after the runtime shuts down.
+        _application: sphere_webview::runtime::cef::App,
     }
 
     struct PendingOpen {
@@ -597,6 +600,12 @@ mod imp {
         /// Browser-process CEF state, owned by the UI thread because
         /// `CefRuntime` is `!Send`.
         static HOST: RefCell<Option<Host>> = const { RefCell::new(None) };
+        /// Browser-process app transferred from the executable after
+        /// `execute_process` returns the browser-process sentinel.
+        static PROCESS_APP: RefCell<Option<sphere_webview::runtime::cef::App>> = const { RefCell::new(None) };
+        /// CEF initialization is process-global and must not be retried after a
+        /// partial failure.
+        static RUNTIME_FAILURE: RefCell<Option<String>> = const { RefCell::new(None) };
         /// Native operations are queued separately from `HOST`. GPUI/Win32 can
         /// re-enter while CEF is working; nested callbacks may enqueue commands,
         /// but must never try to borrow or call CEF synchronously.
@@ -743,14 +752,40 @@ mod imp {
         HostAvailability::Ready
     }
 
+    /// Transfer ownership of the browser process's `CefApp` into the UI-thread
+    /// host. CEF requires this exact object for both `execute_process` and
+    /// `initialize`.
+    pub fn install_process_app(
+        app: sphere_webview::runtime::cef::App,
+    ) -> Result<(), HostAvailability> {
+        PROCESS_APP.with(|cell| {
+            let mut slot = cell.borrow_mut();
+            if slot.is_some() || HOST.with(|host| host.borrow().is_some()) {
+                return Err(HostAvailability::RuntimeFailed(
+                    "CEF process application was installed more than once".to_owned(),
+                ));
+            }
+            *slot = Some(app);
+            Ok(())
+        })
+    }
+
     /// Start CEF if it is not already running. Idempotent.
     fn ensure_runtime(slot: &mut Option<Host>) -> Result<(), HostAvailability> {
         if slot.is_some() {
             return Ok(());
         }
+        if let Some(error) = RUNTIME_FAILURE.with(|failure| failure.borrow().clone()) {
+            return Err(HostAvailability::RuntimeFailed(error));
+        }
 
-        // The same scheme declaration the helper processes made in `main`.
-        let mut app = sphere_webview::scheme::plugin_scheme_app();
+        let mut app = PROCESS_APP
+            .with(|cell| cell.borrow_mut().take())
+            .ok_or_else(|| {
+                HostAvailability::RuntimeFailed(
+                    "CEF process application was not installed before UI startup".to_owned(),
+                )
+            })?;
         let config = CefRuntimeConfig {
             cache_path: cef_cache_dir(),
             remote_debugging_port: debug_port(),
@@ -759,22 +794,33 @@ mod imp {
             windowless_rendering: OFFSCREEN_HOSTING,
             ..Default::default()
         };
-        let runtime = CefRuntime::initialize(config, Some(&mut app))
-            .map_err(|e| HostAvailability::RuntimeFailed(e.to_string()))?;
+        let runtime = match CefRuntime::initialize(config, Some(&mut app)) {
+            Ok(runtime) => runtime,
+            Err(error) => return remember_runtime_failure(error.to_string()),
+        };
 
         // The factory can only be installed once initialize has succeeded.
         let resolver: sphere_webview::scheme::SchemeResolver =
             Arc::new(|origin: &str, path: &str| resolve_asset(origin, path));
-        register_plugin_scheme_factory(resolver, Some(bridge_sink()))
-            .map_err(|e| HostAvailability::RuntimeFailed(e.to_string()))?;
+        if let Err(error) = register_plugin_scheme_factory(resolver, Some(bridge_sink())) {
+            return remember_runtime_failure(error.to_string());
+        }
 
         *slot = Some(Host {
             views: HashMap::new(),
             closing_views: HashMap::new(),
             warmup: None,
             runtime,
+            _application: app,
         });
         Ok(())
+    }
+
+    fn remember_runtime_failure(error: String) -> Result<(), HostAvailability> {
+        RUNTIME_FAILURE.with(|failure| {
+            *failure.borrow_mut() = Some(error.clone());
+        });
+        Err(HostAvailability::RuntimeFailed(error))
     }
 
     /// Hidden 2×2 native window to parent the warm-up browser to on windowed
@@ -1407,18 +1453,10 @@ mod imp {
     /// Per-user cache directory. CEF requires a writable path; an unwritable or
     /// missing one degrades to in-memory, which is acceptable for an editor UI.
     fn cef_cache_dir() -> Option<std::path::PathBuf> {
-        let base = std::env::var_os("LOCALAPPDATA")
-            .map(std::path::PathBuf::from)
-            .or_else(dirs_cache_fallback)?;
+        let base = dirs::cache_dir()?;
         let dir = base.join("Futureboard").join("cef");
         std::fs::create_dir_all(&dir).ok()?;
         Some(dir)
-    }
-
-    fn dirs_cache_fallback() -> Option<std::path::PathBuf> {
-        std::env::var_os("HOME")
-            .map(std::path::PathBuf::from)
-            .map(|home| home.join(".cache"))
     }
 
     /// Optional normal-page control. The exact URL is also whitelisted by the
@@ -1438,6 +1476,8 @@ mod imp {
     }
 }
 
+#[cfg(feature = "builtin-plugin-editor")]
+pub use imp::install_process_app;
 pub use imp::{
     availability, close_view, init_at_boot, is_view_open, open_view, preload, pump, reload_view,
     send_to_view, send_view_input, set_view_bounds, take_inbound, take_view_events,

--- a/crates/SphereWebView/README.md
+++ b/crates/SphereWebView/README.md
@@ -23,7 +23,10 @@ export CEF_PATH="$PWD/build/cef/150.0.11/cef_linux_x86_64"
 
 CI resolves the equivalent Windows, Linux, Intel macOS, and Apple Silicon macOS
 paths in `.github/workflows/set-cef-path.sh`. macOS bindgen builds must also set
-`LIBCLANG_PATH` to the installed LLVM library directory.
+`LIBCLANG_PATH` to the installed LLVM library directory. Windows ASIO builds
+using the repository-local LLVM tools should set `LIBCLANG_PATH` to the absolute
+`.bin/bin` directory. This is intentionally not a global Cargo setting because
+that Windows path breaks bindgen discovery on other hosts.
 
 The executable owns process dispatch and must:
 

--- a/crates/SphereWebView/README.md
+++ b/crates/SphereWebView/README.md
@@ -1,19 +1,46 @@
 # SphereWebView
 
-Native, windowed CEF web views for Futureboard Studio on Windows, Linux, and
-macOS. The library embeds CEF as a real child window; off-screen rendering is
-deliberately disabled.
+CEF hosting for built-in Futureboard plugin editors. Windows uses a native child
+window. Linux and macOS use windowless rendering into a host-owned framebuffer.
 
-Normal workspace builds do not download or link CEF. Install the pinned SDK
-explicitly:
+Normal workspace builds do not download the pinned SDK. Install it explicitly:
 
-```powershell
+```sh
 cargo run -p SphereWebView --example install_cef --features installer
 ```
 
-Pass `-- --force` to replace an existing `build/cef` installation. Consumers
-that own the browser-process lifecycle enable `cef-runtime`; `.cargo/config.toml`
-then points `cef-dll-sys` at the installed workspace SDK.
+Pass `-- --force` to replace the current host installation under
+`build/cef/150.0.11/<platform>`.
 
-Call `runtime::execute_subprocess` before application startup, initialize one
-`CefRuntime`, and create native child views with `CefRuntime::create_webview`.
+`cef-dll-sys` reads `CEF_PATH` during compilation. Export the path for the Cargo
+target before invoking Cargo; the repository deliberately has no global
+platform default:
+
+```sh
+# Linux x86_64
+export CEF_PATH="$PWD/build/cef/150.0.11/cef_linux_x86_64"
+```
+
+CI resolves the equivalent Windows, Linux, Intel macOS, and Apple Silicon macOS
+paths in `.github/workflows/set-cef-path.sh`. macOS bindgen builds must also set
+`LIBCLANG_PATH` to the installed LLVM library directory.
+
+The executable owns process dispatch and must:
+
+1. create the scheme `CefApp`;
+2. pass that exact object to `runtime::execute_subprocess` before any normal app
+   startup;
+3. exit immediately when CEF returns a subprocess code;
+4. transfer the same object to browser-process `CefRuntime::initialize`;
+5. drive `CefRuntime::do_message_loop_work` from the initializing UI thread.
+
+Futureboard uses CEF's integrated subprocess model. The
+`browser_subprocess_path` setting is intentionally empty, which means CEF
+re-launches the current executable and enters the dispatch gate above. A
+separate helper path belongs to packaging and must not be selected unless that
+helper is actually shipped.
+
+Set `FUTUREBOARD_PLUGIN_VIEW_DEBUG=1` for detailed browser lifecycle, resource,
+reference-count, and console diagnostics. Initialization failures, browser
+creation failures, load failures, blocked navigation, renderer termination, and
+shutdown remain visible without debug logging.

--- a/crates/SphereWebView/src/client.rs
+++ b/crates/SphereWebView/src/client.rs
@@ -145,28 +145,34 @@ wrap_life_span_handler! {
         fn on_after_created(&self, browser: Option<&mut Browser>) {
             let id = browser_id(browser);
             self.lifecycle.mark_after_created(id);
-            eprintln!(
-                "[cef-lifecycle] event=OnAfterCreated browser_id={id} thread={:?}",
-                std::thread::current().id()
-            );
+            if cef_diagnostics_enabled() {
+                eprintln!(
+                    "[cef-lifecycle] event=OnAfterCreated browser_id={id} thread={:?}",
+                    std::thread::current().id()
+                );
+            }
         }
 
         fn do_close(&self, browser: Option<&mut Browser>) -> ::std::os::raw::c_int {
             let id = browser_id(browser);
-            eprintln!(
-                "[cef-lifecycle] event=DoClose browser_id={id} return=false thread={:?}",
-                std::thread::current().id()
-            );
+            if cef_diagnostics_enabled() {
+                eprintln!(
+                    "[cef-lifecycle] event=DoClose browser_id={id} return=false thread={:?}",
+                    std::thread::current().id()
+                );
+            }
             0
         }
 
         fn on_before_close(&self, browser: Option<&mut Browser>) {
             let id = browser_id(browser);
             self.lifecycle.mark_before_close();
-            eprintln!(
-                "[cef-lifecycle] event=OnBeforeClose browser_id={id} thread={:?}",
-                std::thread::current().id()
-            );
+            if cef_diagnostics_enabled() {
+                eprintln!(
+                    "[cef-lifecycle] event=OnBeforeClose browser_id={id} thread={:?}",
+                    std::thread::current().id()
+                );
+            }
         }
     }
 }
@@ -186,13 +192,15 @@ wrap_load_handler! {
             can_go_forward: ::std::os::raw::c_int,
         ) {
             let id = browser_id(browser);
-            eprintln!(
-                "[cef-lifecycle] event=OnLoadingStateChange browser_id={id} is_loading={} can_go_back={} can_go_forward={} thread={:?}",
-                is_loading != 0,
-                can_go_back != 0,
-                can_go_forward != 0,
-                std::thread::current().id()
-            );
+            if cef_diagnostics_enabled() {
+                eprintln!(
+                    "[cef-lifecycle] event=OnLoadingStateChange browser_id={id} is_loading={} can_go_back={} can_go_forward={} thread={:?}",
+                    is_loading != 0,
+                    can_go_back != 0,
+                    can_go_forward != 0,
+                    std::thread::current().id()
+                );
+            }
         }
 
         fn on_load_start(
@@ -203,10 +211,12 @@ wrap_load_handler! {
         ) {
             let id = browser_id(browser);
             let url = frame_url(frame);
-            eprintln!(
-                "[cef-lifecycle] event=OnLoadStart browser_id={id} url={url:?} transition={transition_type:?} thread={:?}",
-                std::thread::current().id()
-            );
+            if cef_diagnostics_enabled() {
+                eprintln!(
+                    "[cef-lifecycle] event=OnLoadStart browser_id={id} url={url:?} transition={transition_type:?} thread={:?}",
+                    std::thread::current().id()
+                );
+            }
         }
 
         fn on_load_end(
@@ -217,18 +227,22 @@ wrap_load_handler! {
         ) {
             let id = browser_id(browser);
             let Some(frame) = frame else {
-                eprintln!(
-                    "[cef-lifecycle] event=OnLoadEnd browser_id={id} status={http_status_code} url=\"<no-frame>\" thread={:?}",
-                    std::thread::current().id()
-                );
+                if cef_diagnostics_enabled() {
+                    eprintln!(
+                        "[cef-lifecycle] event=OnLoadEnd browser_id={id} status={http_status_code} url=\"<no-frame>\" thread={:?}",
+                        std::thread::current().id()
+                    );
+                }
                 return;
             };
             let url = CefStringUtf16::from(&frame.url()).to_string();
             let is_main = frame.is_main() != 0;
-            eprintln!(
-                "[cef-lifecycle] event=OnLoadEnd browser_id={id} status={http_status_code} is_main={is_main} url={url:?} thread={:?}",
-                std::thread::current().id()
-            );
+            if cef_diagnostics_enabled() {
+                eprintln!(
+                    "[cef-lifecycle] event=OnLoadEnd browser_id={id} status={http_status_code} is_main={is_main} url={url:?} thread={:?}",
+                    std::thread::current().id()
+                );
+            }
             if is_main {
                 frame.execute_java_script(
                     Some(&CefString::from(JAVASCRIPT_PROBE)),

--- a/crates/SphereWebView/src/lib.rs
+++ b/crates/SphereWebView/src/lib.rs
@@ -1,4 +1,4 @@
-//! Native, windowed Chromium Embedded Framework views for Futureboard Studio.
+//! Chromium Embedded Framework views for Futureboard Studio.
 //!
 //! The CEF SDK is intentionally not downloaded by normal workspace builds.
 //! Run the `install_cef` example with the `installer` feature to populate the
@@ -7,8 +7,7 @@
 //!
 //! Two presentations are supported: a native CEF child window (Windows), and
 //! windowless/off-screen rendering into a host-owned framebuffer (see
-//! [`osr`]), which is what platforms without usable child-window embedding —
-//! Linux/Wayland in particular — use.
+//! [`osr`]), which Linux and macOS use.
 
 use std::path::{Path, PathBuf};
 

--- a/crates/SphereWebView/src/runtime.rs
+++ b/crates/SphereWebView/src/runtime.rs
@@ -24,6 +24,38 @@ pub enum ProcessDispatch {
     SubprocessExit(i32),
 }
 
+impl ProcessDispatch {
+    fn from_exit_code(exit_code: i32) -> Self {
+        if exit_code < 0 {
+            Self::BrowserProcess
+        } else {
+            Self::SubprocessExit(exit_code)
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ProcessIdentity {
+    executable: PathBuf,
+    process_type: Option<String>,
+    utility_sub_type: Option<String>,
+    argument_count: usize,
+}
+
+impl ProcessIdentity {
+    fn current() -> Result<Self, CefRuntimeError> {
+        let args: Vec<String> = std::env::args_os()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        Ok(Self {
+            executable: std::env::current_exe()?,
+            process_type: command_line_switch(&args, "--type").map(str::to_owned),
+            utility_sub_type: command_line_switch(&args, "--utility-sub-type").map(str::to_owned),
+            argument_count: args.len(),
+        })
+    }
+}
+
 /// Load platform runtime state and bind the CEF API version for this process.
 ///
 /// macOS does not link the Chromium framework into the executable. The
@@ -68,15 +100,29 @@ pub fn ensure_api_version() {
 /// the same executable. Keeping this at the first statement of `main` makes it
 /// unambiguous whether a helper escaped into normal application startup.
 pub fn log_process_entry() {
+    match ProcessIdentity::current() {
+        Ok(identity) => eprintln!(
+            "[cef-process] entry pid={} executable={} type={:?} utility_sub_type={:?} argument_count={}",
+            std::process::id(),
+            identity.executable.display(),
+            identity.process_type.as_deref().unwrap_or("<browser>"),
+            identity.utility_sub_type.as_deref().unwrap_or("<none>"),
+            identity.argument_count,
+        ),
+        Err(error) => eprintln!(
+            "[cef-process] entry pid={} executable=<unresolved> error={error}",
+            std::process::id()
+        ),
+    }
+}
+
+/// Whether this invocation has the CEF `--type` switch used by renderer, GPU,
+/// utility, and other helper processes.
+pub fn is_subprocess_command_line() -> bool {
     let args: Vec<String> = std::env::args_os()
         .map(|arg| arg.to_string_lossy().into_owned())
         .collect();
-    let process_type = command_line_switch(&args, "--type").unwrap_or("<browser>");
-    let utility_sub_type = command_line_switch(&args, "--utility-sub-type").unwrap_or("<none>");
-    eprintln!(
-        "[cef-process] entry pid={} command_line={args:?} type={process_type:?} utility_sub_type={utility_sub_type:?}",
-        std::process::id()
-    );
+    command_line_switch(&args, "--type").is_some()
 }
 
 fn command_line_switch<'a>(args: &'a [String], name: &str) -> Option<&'a str> {
@@ -90,8 +136,10 @@ fn command_line_switch<'a>(args: &'a [String], name: &str) -> Option<&'a str> {
 }
 
 /// Dispatch CEF subprocess command lines before starting the native UI.
-pub fn execute_subprocess(application: Option<&mut cef::App>) -> ProcessDispatch {
-    prepare_process().expect("failed to prepare the CEF process");
+pub fn execute_subprocess(
+    application: Option<&mut cef::App>,
+) -> Result<ProcessDispatch, CefRuntimeError> {
+    prepare_process()?;
     let args = cef::args::Args::new();
     let exit_code =
         cef::execute_process(Some(args.as_main_args()), application, std::ptr::null_mut());
@@ -101,11 +149,20 @@ pub fn execute_subprocess(application: Option<&mut cef::App>) -> ProcessDispatch
         std::process::id(),
         std::thread::current().id()
     );
-    if exit_code < 0 {
-        ProcessDispatch::BrowserProcess
-    } else {
-        ProcessDispatch::SubprocessExit(exit_code)
-    }
+    Ok(ProcessDispatch::from_exit_code(exit_code))
+}
+
+/// Executable CEF should launch for renderer, GPU, utility, and other helper
+/// processes.
+#[derive(Debug, Clone, Default)]
+pub enum BrowserSubprocess {
+    /// CEF re-launches the browser executable. This is represented by an empty
+    /// `browser_subprocess_path`, per CEF's API contract, and requires the
+    /// executable to call [`execute_subprocess`] before normal startup.
+    #[default]
+    CurrentExecutable,
+    /// Use a separately packaged helper executable.
+    SeparateExecutable(PathBuf),
 }
 
 /// Browser-process configuration. The runtime uses a portable, integrated
@@ -117,6 +174,10 @@ pub struct CefRuntimeConfig {
     pub locale: Option<String>,
     pub user_agent: Option<String>,
     pub remote_debugging_port: Option<u16>,
+    /// Helper-process ownership is a packaging decision. Futureboard uses the
+    /// integrated current-executable model; a separate helper must only be
+    /// selected by packaging that actually supplies one.
+    pub browser_subprocess: BrowserSubprocess,
     /// Allow [`RenderMode::Windowless`] browsers in this process. Chromium
     /// decides this once, at `cef_initialize`, so a runtime that may ever need
     /// off-screen rendering must opt in before any browser is created.
@@ -232,7 +293,33 @@ impl CefRuntime {
         application: Option<&mut cef::App>,
     ) -> Result<Self, CefRuntimeError> {
         prepare_process()?;
+        let identity = ProcessIdentity::current()?;
         let args = cef::args::Args::new();
+        let browser_subprocess_path = match &config.browser_subprocess {
+            BrowserSubprocess::CurrentExecutable => cef::CefString::default(),
+            BrowserSubprocess::SeparateExecutable(path) => {
+                cef::CefString::from(path.to_string_lossy().as_ref())
+            }
+        };
+        let resolved_subprocess = match &config.browser_subprocess {
+            BrowserSubprocess::CurrentExecutable => identity.executable.as_path(),
+            BrowserSubprocess::SeparateExecutable(path) => path.as_path(),
+        };
+        eprintln!(
+            "[cef-runtime] initialize begin executable={} process_type={:?} subprocess_model={} subprocess_path={} cache_path={} root_cache_path={} resources_path=<cef-default> locales_path=<cef-default> message_loop=manual-do-work windowless={} remote_debugging_port={} thread={:?}",
+            identity.executable.display(),
+            identity.process_type.as_deref().unwrap_or("<browser>"),
+            match &config.browser_subprocess {
+                BrowserSubprocess::CurrentExecutable => "integrated",
+                BrowserSubprocess::SeparateExecutable(_) => "separate",
+            },
+            resolved_subprocess.display(),
+            display_optional_path(config.cache_path.as_ref()),
+            display_optional_path(config.root_cache_path.as_ref()),
+            config.windowless_rendering,
+            config.remote_debugging_port.unwrap_or(0),
+            thread::current().id(),
+        );
         let settings = cef::Settings {
             no_sandbox: 1,
             multi_threaded_message_loop: 0,
@@ -240,10 +327,7 @@ impl CefRuntime {
             windowless_rendering_enabled: i32::from(config.windowless_rendering),
             cache_path: cef_path(config.cache_path.as_ref()),
             root_cache_path: cef_path(config.root_cache_path.as_ref()),
-            // Intentionally empty during CEF integration diagnosis: every CEF
-            // helper re-enters this executable and is dispatched at the first
-            // statement of `main`.
-            browser_subprocess_path: cef::CefString::default(),
+            browser_subprocess_path,
             locale: cef_string(config.locale.as_deref()),
             user_agent: cef_string(config.user_agent.as_deref()),
             remote_debugging_port: config.remote_debugging_port.unwrap_or(0) as i32,
@@ -256,8 +340,13 @@ impl CefRuntime {
             std::ptr::null_mut(),
         ) != 1
         {
+            eprintln!("[cef-runtime] initialize result=false");
             return Err(CefRuntimeError::InitializeFailed);
         }
+        eprintln!(
+            "[cef-runtime] initialize result=true owner_thread={:?}",
+            thread::current().id()
+        );
 
         Ok(Self {
             owner_thread: thread::current().id(),
@@ -302,14 +391,16 @@ impl CefRuntime {
             window_info.windowless_rendering_enabled,
             i32::from(windowless)
         );
-        eprintln!(
-            "[cef-lifecycle] event=CreateBrowserSync begin url={:?} parent={:?} bounds={:?} render_mode={:?} thread={:?}",
-            config.url,
-            parent.as_raw(),
-            config.bounds,
-            config.render_mode,
-            std::thread::current().id()
-        );
+        if crate::scheme::cef_diagnostics_enabled() {
+            eprintln!(
+                "[cef-lifecycle] event=CreateBrowserSync begin url={:?} parent={:?} bounds={:?} render_mode={:?} thread={:?}",
+                config.url,
+                parent.as_raw(),
+                config.bounds,
+                config.render_mode,
+                std::thread::current().id()
+            );
+        }
         let browser_settings = cef::BrowserSettings {
             // A transparent windowless surface would composite the timeline
             // through the editor; an opaque background also lets the host
@@ -334,12 +425,14 @@ impl CefRuntime {
             );
             return Err(CefRuntimeError::CreateBrowserFailed);
         };
-        eprintln!(
-            "[cef-lifecycle] event=CreateBrowserSync result=true browser_id={} url={:?} thread={:?}",
-            browser.identifier(),
-            config.url,
-            std::thread::current().id()
-        );
+        if crate::scheme::cef_diagnostics_enabled() {
+            eprintln!(
+                "[cef-lifecycle] event=CreateBrowserSync result=true browser_id={} url={:?} thread={:?}",
+                browser.identifier(),
+                config.url,
+                std::thread::current().id()
+            );
+        }
 
         Ok(WebView {
             browser,
@@ -383,8 +476,13 @@ impl CefRuntime {
     pub fn shutdown(mut self) -> Result<(), CefRuntimeError> {
         self.ensure_thread()?;
         if !self.shutdown {
+            eprintln!(
+                "[cef-runtime] shutdown begin owner_thread={:?}",
+                self.owner_thread
+            );
             cef::shutdown();
             self.shutdown = true;
+            eprintln!("[cef-runtime] shutdown complete");
         }
         Ok(())
     }
@@ -400,8 +498,19 @@ impl CefRuntime {
 impl Drop for CefRuntime {
     fn drop(&mut self) {
         if !self.shutdown && thread::current().id() == self.owner_thread {
+            eprintln!(
+                "[cef-runtime] shutdown begin source=drop owner_thread={:?}",
+                self.owner_thread
+            );
             cef::shutdown();
             self.shutdown = true;
+            eprintln!("[cef-runtime] shutdown complete source=drop");
+        } else if !self.shutdown {
+            eprintln!(
+                "[cef-runtime] shutdown skipped reason=wrong-thread owner_thread={:?} current_thread={:?}",
+                self.owner_thread,
+                thread::current().id()
+            );
         }
     }
 }
@@ -416,13 +525,15 @@ pub struct WebView<'runtime> {
 
 impl Drop for WebView<'_> {
     fn drop(&mut self) {
-        eprintln!(
-            "[cef-ref] object_type=cef_browser_t browser_id={} event=webview_release has_one_ref={} has_at_least_one_ref={} thread={:?}",
-            self.browser.identifier(),
-            self.browser.has_one_ref(),
-            self.browser.has_at_least_one_ref(),
-            std::thread::current().id()
-        );
+        if crate::scheme::cef_diagnostics_enabled() {
+            eprintln!(
+                "[cef-ref] object_type=cef_browser_t browser_id={} event=webview_release has_one_ref={} has_at_least_one_ref={} thread={:?}",
+                self.browser.identifier(),
+                self.browser.has_one_ref(),
+                self.browser.has_at_least_one_ref(),
+                std::thread::current().id()
+            );
+        }
     }
 }
 
@@ -578,6 +689,11 @@ fn cef_string(value: Option<&str>) -> cef::CefString {
     value.map(cef::CefString::from).unwrap_or_default()
 }
 
+fn display_optional_path(path: Option<&PathBuf>) -> String {
+    path.map(|path| path.display().to_string())
+        .unwrap_or_else(|| "<cef-default>".to_owned())
+}
+
 #[cfg(target_os = "macos")]
 fn load_macos_framework() -> Result<(), CefRuntimeError> {
     static LIBRARY: std::sync::OnceLock<Result<cef::library_loader::LibraryLoader, ()>> =
@@ -726,6 +842,37 @@ mod tests {
                 width: 1280,
                 height: 720,
             }
+        );
+    }
+
+    #[test]
+    fn parses_equals_and_separate_switch_values() {
+        let args = vec![
+            "FutureboardNative".to_owned(),
+            "--type=renderer".to_owned(),
+            "--utility-sub-type".to_owned(),
+            "network.mojom.NetworkService".to_owned(),
+        ];
+        assert_eq!(command_line_switch(&args, "--type"), Some("renderer"));
+        assert_eq!(
+            command_line_switch(&args, "--utility-sub-type"),
+            Some("network.mojom.NetworkService")
+        );
+    }
+
+    #[test]
+    fn process_dispatch_matches_cef_return_contract() {
+        assert_eq!(
+            ProcessDispatch::from_exit_code(-1),
+            ProcessDispatch::BrowserProcess
+        );
+        assert_eq!(
+            ProcessDispatch::from_exit_code(0),
+            ProcessDispatch::SubprocessExit(0)
+        );
+        assert_eq!(
+            ProcessDispatch::from_exit_code(9),
+            ProcessDispatch::SubprocessExit(9)
         );
     }
 }

--- a/crates/SphereWebView/src/scheme.rs
+++ b/crates/SphereWebView/src/scheme.rs
@@ -138,10 +138,12 @@ fn make_resource_handler(asset: Option<SchemeAsset>, request_id: u64) -> Resourc
             cef::stream_reader_create_for_data(asset.bytes.as_ptr().cast_mut(), asset.bytes.len());
         if let Some(stream) = stream {
             let (mime, _) = split_mime(asset.mime_type);
-            eprintln!(
-                "[cef-resource] request_id={request_id} handler=builtin length={} mime={mime:?} bytes_lifetime=static",
-                asset.bytes.len()
-            );
+            if cef_diagnostics_enabled() {
+                eprintln!(
+                    "[cef-resource] request_id={request_id} handler=builtin length={} mime={mime:?} bytes_lifetime=static",
+                    asset.bytes.len()
+                );
+            }
             let handler = StreamResourceHandler::new_with_stream(mime.to_string(), stream);
             if cef_diagnostics_enabled() {
                 eprintln!(
@@ -156,10 +158,12 @@ fn make_resource_handler(asset: Option<SchemeAsset>, request_id: u64) -> Resourc
         );
     }
 
-    eprintln!(
-        "[cef-resource] request_id={request_id} handler=custom length={} bytes_lifetime=static",
-        asset.map(|asset| asset.bytes.len()).unwrap_or(0)
-    );
+    if cef_diagnostics_enabled() {
+        eprintln!(
+            "[cef-resource] request_id={request_id} handler=custom length={} bytes_lifetime=static",
+            asset.map(|asset| asset.bytes.len()).unwrap_or(0)
+        );
+    }
     let handler = PluginAssetHandler::new(
         asset,
         ReadState::new(request_id),
@@ -223,12 +227,14 @@ wrap_app! {
                 Some(&CefString::from(PLUGIN_SCHEME)),
                 options as _,
             );
-            eprintln!(
-                "[plugin-scheme] event=OnRegisterCustomSchemes scheme={PLUGIN_SCHEME} options={options} registered={} pid={} thread={:?}",
-                registered != 0,
-                std::process::id(),
-                std::thread::current().id()
-            );
+            if registered == 0 || cef_diagnostics_enabled() {
+                eprintln!(
+                    "[plugin-scheme] event=OnRegisterCustomSchemes scheme={PLUGIN_SCHEME} options={options} registered={} pid={} thread={:?}",
+                    registered != 0,
+                    std::process::id(),
+                    std::thread::current().id()
+                );
+            }
         }
     }
 }
@@ -633,12 +639,12 @@ pub fn split_plugin_url(url: &str) -> Option<(String, String)> {
 
 /// Build the [`App`] that declares the plugin scheme. Pass the **same** app to
 /// both `execute_subprocess` and `CefRuntime::initialize`.
-pub fn plugin_scheme_app() -> App {
+pub fn plugin_scheme_app() -> Result<App, crate::runtime::CefRuntimeError> {
     // Constructing a `cef::App` is itself a CEF object creation, so macOS must
     // load the bundled framework and every platform must bind the API version
     // *here* — not when the app is consumed later. Skipping either step makes
     // the first generated CEF wrapper call invalid.
-    crate::runtime::prepare_process().expect("failed to prepare the CEF process");
+    crate::runtime::prepare_process()?;
     let object_id = NEXT_OBJECT_ID.fetch_add(1, Ordering::Relaxed);
     let app = PluginSchemeApp::new(ObjectLifetime::new("cef_app_t", object_id));
     if cef_diagnostics_enabled() {
@@ -647,7 +653,7 @@ pub fn plugin_scheme_app() -> App {
             app.has_one_ref()
         );
     }
-    app
+    Ok(app)
 }
 
 /// Install the handler that serves plugin assets. Call once, after

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,6 +16,7 @@ clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
+sphere-webview.workspace = true
 # Parse `cargo build --message-format=json` artifact messages to discover the
 # real executable path instead of guessing target/<profile>/FutureboardNative.
 cargo_metadata = "0.18"

--- a/xtask/src/cargo_build.rs
+++ b/xtask/src/cargo_build.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 use std::io::BufReader;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -54,7 +54,12 @@ pub struct BuildOutput {
 
 /// Build the application and its sidecars for the requested profile / target /
 /// edition, returning the actual executable paths parsed from Cargo's output.
-pub fn build(profile: &str, target: Option<&str>, edition: Edition) -> Result<BuildOutput> {
+pub fn build(
+    profile: &str,
+    target: Option<&str>,
+    edition: Edition,
+    cef_path: Option<&Path>,
+) -> Result<BuildOutput> {
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
 
     let mut command = Command::new(&cargo);
@@ -72,6 +77,12 @@ pub fn build(profile: &str, target: Option<&str>, edition: Edition) -> Result<Bu
     }
     if let Some(target) = target {
         command.args(["--target", target]);
+    }
+    if let Some(cef_path) = cef_path {
+        // Always pass an absolute, target-matched distribution. cef-dll-sys
+        // treats relative CEF_PATH values as version roots and may append its
+        // own version/platform components.
+        command.env("CEF_PATH", cef_path);
     }
 
     // Merge the edition features with the sidecar bin features into one

--- a/xtask/src/cef.rs
+++ b/xtask/src/cef.rs
@@ -14,6 +14,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use sphere_webview::{CEF_SHORT_VERSION, CefTarget};
 
 use crate::platform::dynamic_library_extension;
 use crate::staging::copy_into;
@@ -22,7 +23,6 @@ use crate::staging::copy_into;
 const RELEASE_DIR: &str = "Release";
 /// Directory (relative to `build/cef`) holding the `.pak`/`icu` resources.
 const RESOURCES_DIR: &str = "Resources";
-const PINNED_CEF_VERSION: &str = "150.0.11";
 const MAC_FRAMEWORK_DIR: &str = "Chromium Embedded Framework.framework";
 /// The one CEF subdirectory that must keep its name at the app root.
 pub const LOCALES_DIR: &str = "locales";
@@ -50,7 +50,7 @@ pub fn cef_dist_candidates(workspace_root: &Path, triple: &str) -> Vec<PathBuf> 
     };
     let cef_root = workspace_root.join("build").join("cef");
     vec![
-        cef_root.join(PINNED_CEF_VERSION).join(platform_dir),
+        cef_root.join(CEF_SHORT_VERSION).join(platform_dir),
         // Compatibility with the original installer and existing developer
         // workspaces. This can be removed after those installations migrate.
         cef_root,
@@ -68,23 +68,19 @@ pub fn locate_cef_dist(workspace_root: &Path, triple: &str) -> Option<PathBuf> {
 }
 
 fn platform_dir(triple: &str) -> Option<&'static str> {
-    match triple {
-        "x86_64-pc-windows-msvc" => Some("cef_windows_x86_64"),
-        "x86_64-unknown-linux-gnu" => Some("cef_linux_x86_64"),
-        "x86_64-apple-darwin" => Some("cef_macos_x86_64"),
-        "aarch64-apple-darwin" => Some("cef_macos_aarch64"),
-        _ => None,
-    }
+    CefTarget::from_target_triple(triple)
+        .ok()
+        .map(CefTarget::directory_name)
 }
 
 fn validate_pinned_distribution(dist: &Path) -> Result<()> {
     let version_header = dist.join("include/cef_version.h");
     let version = fs::read_to_string(&version_header)
         .with_context(|| format!("cannot read {}", version_header.display()))?;
-    let expected = format!("#define CEF_VERSION \"{PINNED_CEF_VERSION}+");
+    let expected = format!("#define CEF_VERSION \"{CEF_SHORT_VERSION}+");
     if !version.contains(&expected) {
         bail!(
-            "CEF SDK version mismatch in {}: expected {PINNED_CEF_VERSION}",
+            "CEF SDK version mismatch in {}: expected {CEF_SHORT_VERSION}",
             version_header.display()
         );
     }
@@ -92,10 +88,10 @@ fn validate_pinned_distribution(dist: &Path) -> Result<()> {
     let archive_path = dist.join("archive.json");
     let archive = fs::read_to_string(&archive_path)
         .with_context(|| format!("cannot read {}", archive_path.display()))?;
-    let expected_archive = format!("cef_binary_{PINNED_CEF_VERSION}+");
+    let expected_archive = format!("cef_binary_{CEF_SHORT_VERSION}+");
     if !archive.contains(&expected_archive) {
         bail!(
-            "CEF archive mismatch in {}: expected {PINNED_CEF_VERSION}",
+            "CEF archive mismatch in {}: expected {CEF_SHORT_VERSION}",
             archive_path.display()
         );
     }
@@ -397,7 +393,7 @@ mod tests {
         let versioned = temp
             .path()
             .join("build/cef")
-            .join(PINNED_CEF_VERSION)
+            .join(CEF_SHORT_VERSION)
             .join("cef_windows_x86_64");
         fs::create_dir_all(versioned.parent().unwrap()).unwrap();
         copy_test_distribution(&source, &versioned);

--- a/xtask/src/package.rs
+++ b/xtask/src/package.rs
@@ -71,17 +71,41 @@ pub struct PackageOptions {
 
 /// Run the full package pipeline and return the published directory.
 pub fn run(options: &PackageOptions) -> Result<PathBuf> {
-    // 1. Build and discover the real executable paths (app + runtime sidecars).
-    let build = cargo_build::build(&options.profile, options.target.as_deref(), options.edition)?;
-    let executable = &build.app_executable;
-    eprintln!("[xtask] built executable: {}", executable.display());
-
     // Resolve the effective target triple (explicit flag or detected host) for
-    // platform naming and metadata.
+    // the build environment, platform naming, and metadata.
     let target_triple = match &options.target {
         Some(target) => target.clone(),
         None => host_target().context("could not determine host target triple")?,
     };
+    let workspace = workspace_root();
+    let cef_dist = cef::locate_cef_dist(&workspace, &target_triple);
+    if options.stage_cef && cef_dist.is_none() {
+        let checked = cef::cef_dist_candidates(&workspace, &target_triple)
+            .into_iter()
+            .map(|path| format!("  - {}", path.display()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        bail!(
+            "CEF distribution not found or invalid for {target_triple}.\n\
+             Checked:\n{checked}\n\
+             Install it with `cargo run -p SphereWebView --example install_cef \
+             --features installer`, or pass --no-cef for an intentional \
+             CEF-free developer package"
+        );
+    }
+
+    // 1. Build and discover the real executable paths (app + runtime sidecars).
+    // Pass the target-matched SDK explicitly so a stale shell CEF_PATH cannot
+    // select a distribution for another operating system or architecture.
+    let build = cargo_build::build(
+        &options.profile,
+        options.target.as_deref(),
+        options.edition,
+        cef_dist.as_deref(),
+    )?;
+    let executable = &build.app_executable;
+    eprintln!("[xtask] built executable: {}", executable.display());
+
     let platform = platform_folder(&target_triple);
 
     // 2. Prepare staging (clean any stale directory first).
@@ -118,32 +142,17 @@ pub fn run(options: &PackageOptions) -> Result<PathBuf> {
     //     who intentionally need a CEF-free tree must opt out with --no-cef.
     let mut cef_staged = false;
     if options.stage_cef {
-        match cef::locate_cef_dist(&workspace_root(), &target_triple) {
-            Some(dist) => {
-                let report = cef::stage_cef(&plan.staging_dir, &dist, &target_triple)
-                    .context("failed to stage the CEF runtime")?;
-                eprintln!(
-                    "[xtask] staged CEF runtime flat: {} files + {} locales",
-                    report.runtime_files.len(),
-                    report.locale_count
-                );
-                cef_staged = true;
-            }
-            None => {
-                let checked = cef::cef_dist_candidates(&workspace_root(), &target_triple)
-                    .into_iter()
-                    .map(|path| format!("  - {}", path.display()))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                bail!(
-                    "CEF distribution not found or invalid for {target_triple}.\n\
-                     Checked:\n{checked}\n\
-                     Install it with `cargo run -p SphereWebView --example install_cef \
-                     --features installer`, or pass --no-cef for an intentional \
-                     CEF-free developer package"
-                )
-            }
-        }
+        let dist = cef_dist
+            .as_ref()
+            .expect("stage_cef preflight requires a distribution");
+        let report = cef::stage_cef(&plan.staging_dir, dist, &target_triple)
+            .context("failed to stage the CEF runtime")?;
+        eprintln!(
+            "[xtask] staged CEF runtime flat: {} files + {} locales",
+            report.runtime_files.len(),
+            report.locale_count
+        );
+        cef_staged = true;
     }
 
     // 4b. Optionally build and stage Built-in Plugin dynamic libraries.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve one `CefApp` across subprocess dispatch and browser initialization
- make integrated subprocess ownership and manual message-loop configuration explicit
- remove host-specific global build environment defaults and have packaging select an absolute target-matched CEF SDK
- centralize CEF target metadata between runtime installation and packaging
- improve high-signal CEF diagnostics while gating routine lifecycle noise
- use the platform cache directory and document runtime/build contracts

## Linux validation
- `cargo fmt --all -- --check`
- `cargo clippy`
- `cargo check`
- `cargo build`
- `cargo test -p SphereWebView --features cef-runtime` (29 passed)
- `cargo test -p xtask cef` (11 passed)
- `cargo test -p builtin_ui_embed` (15 passed)
- `cargo test -p sphere_ui_components --features builtin-plugin-editor builtin_plugin_editor` (40 passed)
- `env -u CEF_PATH cargo run -p xtask -- package --profile dev --edition community` selected and staged the Linux SDK successfully
- full `osr_editor_probe`: subprocess re-entry, browser creation, paint, bridge, mouse/wheel/keyboard input, close, and shutdown all succeeded

Existing warnings remain in vendored VST3 `ustring.cpp`, missing unbuilt `equz8` editor assets, `proc-macro-error2`, and a pre-existing large enum variant in the plugin host.

macOS runtime behavior remains intentionally unverified on Linux; this PR does not claim to fix the macOS crash.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8638f981-7617-4d6d-81a5-df4362964907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8638f981-7617-4d6d-81a5-df4362964907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

