### PR TITLE
feat(echospace): editor UI and audio bridge for the delay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,6 +2387,9 @@ version = "0.1.0"
 dependencies = [
  "biquad",
  "builtin_dsp_core",
+ "builtin_ui_embed",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -7419,6 +7422,7 @@ dependencies = [
  "cpal",
  "crossbeam-channel",
  "dirs 5.0.1",
+ "echospace",
  "embed-resource",
  "equz8",
  "libc",
@@ -7471,6 +7475,7 @@ dependencies = [
  "builtin_ui_embed",
  "crc32fast",
  "dirs 5.0.1",
+ "echospace",
  "equz8",
  "gpui",
  "image",

--- a/crates/BuiltinAudioPlugins/crates/echospace/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/crates/echospace/Cargo.toml
@@ -15,6 +15,18 @@ crate-type = ["rlib", "cdylib"]
 [dependencies]
 biquad.workspace = true
 builtin-dsp-core.workspace = true
+builtin-ui-embed.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[build-dependencies]
+# Build-time only: turns `editorui/dist` into the embedded asset table.
+#
+# Must stay pointed at the dependency-free `builtin_ui_embed`, never at the
+# `BuiltinAudioPlugins` umbrella — see rodharerist's manifest for why (a
+# build-dependency is a separate build unit and would rebuild every plugin
+# `cdylib` into the same output path).
+builtin-ui-embed = { workspace = true, features = ["generate"] }
 
 [lints]
 workspace = true

--- a/crates/BuiltinAudioPlugins/crates/echospace/build.rs
+++ b/crates/BuiltinAudioPlugins/crates/echospace/build.rs
@@ -1,0 +1,35 @@
+//! Embeds the compiled Svelte editor (`editorui/dist`) into the library.
+//!
+//! The generator enumerates `dist/` every build, so Vite's content-hashed
+//! filenames are never hard-coded. A missing or unbuilt `dist/` is not an
+//! error: an empty table is emitted and the crate still compiles, which keeps
+//! `cargo test -p echospace` working for anyone who has not run
+//! `bun run build` in `editorui/`.
+
+use std::path::PathBuf;
+
+fn main() {
+    let out_dir =
+        PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is always set for build scripts"));
+    let dist = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("editorui/dist");
+
+    let options = builtin_ui_embed::generate::GenerateOptions::from_out_dir(dist, out_dir);
+    match builtin_ui_embed::generate::generate(&options) {
+        // Success is the normal case — stay quiet rather than emitting a
+        // `cargo:warning` on every build.
+        Ok(report) if report.dist_present => {
+            println!(
+                "cargo:rustc-env=ECHOSPACE_UI_ASSET_COUNT={}",
+                report.asset_count
+            );
+        }
+        Ok(_) => {
+            // Not fatal — the DSP core is independently useful and tested.
+            println!(
+                "cargo:warning=echospace: editorui/dist not built; the plugin editor \
+                 will have no UI assets (run `bun run build` in editorui/)"
+            );
+        }
+        Err(error) => panic!("echospace: failed to embed editor UI: {error}"),
+    }
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/README.md
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/README.md
@@ -1,0 +1,71 @@
+# EchoSpace editor
+
+Embedded editor UI for the `echospace` built-in plugin. Svelte 5 + Vite,
+bundled to a single self-contained `dist/index.html` that `build.rs` embeds into
+the plugin library and the native CEF host serves at
+`mikoplugin://echospace/index.html`.
+
+This is a plugin view, not an application. It has no router, no dev server
+dependency at runtime, and no network access — a strict single-file bundle is
+the deliverable. It shares its control language with the VerbSpace editor; only
+the accent, the display, and the parameter set differ.
+
+## Commands
+
+```bash
+bun install
+bun run build      # svelte-check, then the embedded single-file bundle
+bun test           # schema/model checks (also run in the Rust-side workflow)
+bun run dev        # standalone preview; the bridge no-ops without a host
+```
+
+After `bun run build`, rebuild the crate so the new assets are embedded:
+
+```bash
+cargo build -p echospace
+```
+
+## Where authority lives
+
+Rust owns everything that decides what a value *means*:
+
+| Concern | Owner |
+| --- | --- |
+| parameter ids and wire indices | `../src/ipc.rs` (`UI_PARAM_IDS`) |
+| ranges, clamping, defaults | `../src/ipc.rs`, `../src/lib.rs` |
+| DSP, persistence, state blob | `../src/lib.rs`, `../src/ipc.rs` |
+| taper, layout, formatting | `src/params.ts` |
+
+`src/params.ts` and `src/model.ts` duplicate a few Rust constants so the UI can
+lay out a control and draw the echo display. `src/params.test.ts` and
+`src/model.test.ts` parse the real `.rs` files and compare, so a change on
+either side that is not mirrored fails the tests rather than shipping a UI that
+quietly disagrees with the DSP.
+
+## The echo display
+
+`EchoView` draws the repeat pattern the current parameters produce: each round
+trip as a bar on its channel's lane, on a decibel axis, with the feedback
+envelope behind it and the tap times marked. Three things it gets from the real
+model rather than from decoration:
+
+- **Ping-pong alternation.** The DSP swaps the two feedback paths every round
+  trip, so a line's odd passes come back on the opposite side — the bars follow
+  that, and mono collapses both lanes onto the left tap.
+- **Loop gain.** Cross-feed is normalised in the DSP so it changes *where* the
+  repeats go, not how loud the loop is. The display uses the same rule.
+- **Per-pass dulling.** Each repeat runs through the low and high cut once
+  more, so successive bars are pulled toward grey by the magnitude those
+  2-pole sections actually have at a reference tone.
+
+It is a model computed from parameters, labelled as such in the UI, not
+measured audio; no analyser feed exists for this plugin.
+
+## Bridge
+
+`src/bridge.ts` speaks the shared built-in editor protocol: the host pushes
+`futureboard.selectInstance` with the authoritative state, the page answers
+`futureboard.instanceReady`, and gestures go back as `futureboard.setParams`
+batched per animation frame and tagged with the binding they were made against.
+Stale batches are dropped by the host, so an edit made against a torn-down
+instance can never land on its replacement.

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/bun.lock
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/bun.lock
@@ -1,0 +1,235 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "echospace-editor",
+      "dependencies": {
+        "svelte": "^5.51.0",
+      },
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^6.2.1",
+        "@tsconfig/svelte": "^5.0.5",
+        "@types/bun": "^1.3.14",
+        "@types/node": "^24",
+        "svelte-check": "^4.4.2",
+        "typescript": "^5.9.3",
+        "vite": "^7.1.14",
+        "vite-plugin-singlefile": "^2.3.3",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.3", "", { "os": "android", "cpu": "arm" }, "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.3", "", { "os": "android", "cpu": "arm64" }, "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.3", "", { "os": "linux", "cpu": "arm" }, "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.3", "", { "os": "linux", "cpu": "arm" }, "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.3", "", { "os": "linux", "cpu": "x64" }, "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.3", "", { "os": "linux", "cpu": "x64" }, "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.3", "", { "os": "none", "cpu": "arm64" }, "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.3", "", { "os": "win32", "cpu": "x64" }, "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.3", "", { "os": "win32", "cpu": "x64" }, "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.11", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw=="],
+
+    "@sveltejs/load-config": ["@sveltejs/load-config@0.2.1", "", {}, "sha512-5m3B2cbqQ4TbwW6Xkh66Ntw6dD7gNc77cCxABTTesWcq9jxIzMgTk97pZx5vEtvQx8iokgi7GIphqZe+PGwcZA=="],
+
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@6.2.4", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0", "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.1" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA=="],
+
+    "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@5.0.2", "", { "dependencies": { "obug": "^2.1.0" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0", "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig=="],
+
+    "@tsconfig/svelte": ["@tsconfig/svelte@5.0.8", "", {}, "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "devalue": ["devalue@5.8.2", "", {}, "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "esrap": ["esrap@2.3.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "rollup": ["rollup@4.62.3", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.3", "@rollup/rollup-android-arm64": "4.62.3", "@rollup/rollup-darwin-arm64": "4.62.3", "@rollup/rollup-darwin-x64": "4.62.3", "@rollup/rollup-freebsd-arm64": "4.62.3", "@rollup/rollup-freebsd-x64": "4.62.3", "@rollup/rollup-linux-arm-gnueabihf": "4.62.3", "@rollup/rollup-linux-arm-musleabihf": "4.62.3", "@rollup/rollup-linux-arm64-gnu": "4.62.3", "@rollup/rollup-linux-arm64-musl": "4.62.3", "@rollup/rollup-linux-loong64-gnu": "4.62.3", "@rollup/rollup-linux-loong64-musl": "4.62.3", "@rollup/rollup-linux-ppc64-gnu": "4.62.3", "@rollup/rollup-linux-ppc64-musl": "4.62.3", "@rollup/rollup-linux-riscv64-gnu": "4.62.3", "@rollup/rollup-linux-riscv64-musl": "4.62.3", "@rollup/rollup-linux-s390x-gnu": "4.62.3", "@rollup/rollup-linux-x64-gnu": "4.62.3", "@rollup/rollup-linux-x64-musl": "4.62.3", "@rollup/rollup-openbsd-x64": "4.62.3", "@rollup/rollup-openharmony-arm64": "4.62.3", "@rollup/rollup-win32-arm64-msvc": "4.62.3", "@rollup/rollup-win32-ia32-msvc": "4.62.3", "@rollup/rollup-win32-x64-gnu": "4.62.3", "@rollup/rollup-win32-x64-msvc": "4.62.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q=="],
+
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "svelte": ["svelte@5.56.8", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg=="],
+
+    "svelte-check": ["svelte-check@4.7.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.1", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+
+    "vite-plugin-singlefile": ["vite-plugin-singlefile@2.3.3", "", { "dependencies": { "micromatch": "^4.0.8" }, "peerDependencies": { "rollup": "^4.59.0", "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["rollup"] }, "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg=="],
+
+    "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+  }
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/index.html
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EchoSpace</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/package.json
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "echospace-editor",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "svelte-check --tsconfig ./tsconfig.json && vite build",
+    "build:fast": "vite build",
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "preview": "vite preview",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "svelte": "^5.51.0"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^6.2.1",
+    "@tsconfig/svelte": "^5.0.5",
+    "@types/bun": "^1.3.14",
+    "@types/node": "^24",
+    "svelte-check": "^4.4.2",
+    "typescript": "^5.9.3",
+    "vite": "^7.1.14",
+    "vite-plugin-singlefile": "^2.3.3"
+  }
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/App.svelte
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/App.svelte
@@ -1,0 +1,426 @@
+<script lang="ts">
+  import { connectBridge, postParam, type EchoParams } from './bridge'
+  import {
+    DEFAULT_PARAMS,
+    FACTORY_PRESETS,
+    matchingPresetIndex,
+    postAllParams,
+  } from './presets'
+  import { PARAMS, modeToWire, type Mode, type ParamId } from './params'
+  import EchoView from './lib/EchoView.svelte'
+  import Knob from './lib/Knob.svelte'
+  import ModeSelect from './lib/ModeSelect.svelte'
+  import PresetControl from './lib/PresetControl.svelte'
+  import Toggle from './lib/Toggle.svelte'
+  import logo from './assets/logo.svg'
+
+  /**
+   * Local view of the parameters. Rust is the authority: this starts at the
+   * schema defaults, is replaced wholesale by `selectInstance`, and is only
+   * moved locally to keep a drag responsive — every change is posted in the
+   * same tick, and the host's value wins on the next selection.
+   */
+  let params = $state<EchoParams>({ ...DEFAULT_PARAMS })
+
+  let connected = $state(false)
+  let preset = $state<number | null>(0)
+
+  $effect(() =>
+    connectBridge(
+      (next) => {
+        params = next
+        preset = matchingPresetIndex(next)
+      },
+      (isConnected) => {
+        connected = isConnected
+      },
+    ),
+  )
+
+  function set(id: ParamId, value: number) {
+    params[id] = value
+    postParam(id, value)
+    preset = null
+  }
+
+  function setMode(mode: Mode) {
+    params.mode = mode
+    postParam('mode', modeToWire(mode))
+    preset = null
+  }
+
+  function setFlag(id: 'power' | 'freeze', value: boolean) {
+    params[id] = value
+    postParam(id, value ? 1 : 0)
+    if (id === 'freeze') preset = null
+  }
+
+  function loadPreset(index: number) {
+    const wrapped =
+      ((index % FACTORY_PRESETS.length) + FACTORY_PRESETS.length) %
+      FACTORY_PRESETS.length
+    const next = { ...FACTORY_PRESETS[wrapped]!.params }
+    params = next
+    preset = wrapped
+    postAllParams(next)
+  }
+
+  // Mono sums the input and reads both rings from the left tap, so the right
+  // time and the cross amount have nothing to act on. Disabled rather than
+  // hidden: the control still shows the value the DSP will use again on the
+  // next mode change.
+  const monoCollapsed = $derived(params.mode === 'mono')
+</script>
+
+<div class="app">
+  <header class="chrome">
+    <div class="bar">
+      <div class="identity">
+        <img class="mark" src={logo} alt="" aria-hidden="true" />
+        <div class="names">
+          <div class="name">EchoSpace</div>
+          <div class="sub">stereo delay</div>
+        </div>
+        <div
+          class="link"
+          class:connected
+          title={connected ? 'Linked to DSP' : 'Preview'}
+        ></div>
+      </div>
+
+      <PresetControl
+        {preset}
+        names={FACTORY_PRESETS.map((entry) => entry.name)}
+        onchange={loadPreset}
+        onprevious={() => loadPreset((preset ?? 0) - 1)}
+        onnext={() => loadPreset((preset ?? -1) + 1)}
+      />
+
+      <div class="bar-right">
+        <Toggle
+          label="Freeze"
+          tone="warn"
+          value={params.freeze}
+          onchange={(v) => setFlag('freeze', v)}
+        />
+        <Toggle
+          label="Power"
+          value={params.power}
+          onchange={(v) => setFlag('power', v)}
+        />
+      </div>
+    </div>
+
+    <div class="mode-row">
+      <ModeSelect value={params.mode} onchange={setMode} />
+    </div>
+  </header>
+
+  <div class="body">
+    <div class="stage" class:bypassed={!params.power}>
+      <EchoView {params} />
+    </div>
+
+    <div class="rack">
+      <section class="group" aria-label="Time">
+        <div class="group-title">Time</div>
+        <div class="group-knobs">
+          <Knob
+            spec={PARAMS.timeMsL}
+            value={params.timeMsL}
+            onchange={(v) => set('timeMsL', v)}
+          />
+          <Knob
+            spec={PARAMS.timeMsR}
+            value={params.timeMsR}
+            onchange={(v) => set('timeMsR', v)}
+            disabled={monoCollapsed}
+          />
+        </div>
+      </section>
+
+      <section class="group" aria-label="Feedback">
+        <div class="group-title">Feedback</div>
+        <div class="group-knobs">
+          <Knob
+            spec={PARAMS.feedback}
+            value={params.feedback}
+            onchange={(v) => set('feedback', v)}
+            alert={params.freeze}
+            disabled={params.freeze}
+          />
+          <Knob
+            spec={PARAMS.crossFeedback}
+            value={params.crossFeedback}
+            onchange={(v) => set('crossFeedback', v)}
+            disabled={monoCollapsed}
+          />
+        </div>
+      </section>
+
+      <section class="group" aria-label="Tone">
+        <div class="group-title">Tone</div>
+        <div class="group-knobs">
+          <Knob
+            spec={PARAMS.lowCutHz}
+            value={params.lowCutHz}
+            onchange={(v) => set('lowCutHz', v)}
+          />
+          <Knob
+            spec={PARAMS.highCutHz}
+            value={params.highCutHz}
+            onchange={(v) => set('highCutHz', v)}
+          />
+          <Knob
+            spec={PARAMS.saturation}
+            value={params.saturation}
+            onchange={(v) => set('saturation', v)}
+          />
+        </div>
+      </section>
+
+      <section class="group output" aria-label="Output">
+        <div class="group-title">Output</div>
+        <div class="group-knobs">
+          <Knob
+            spec={PARAMS.mix}
+            value={params.mix}
+            onchange={(v) => set('mix', v)}
+            size="clamp(3.9rem, 6.5vw, 5.1rem)"
+          />
+          <Knob
+            spec={PARAMS.outputDb}
+            value={params.outputDb}
+            onchange={(v) => set('outputDb', v)}
+          />
+        </div>
+      </section>
+    </div>
+  </div>
+</div>
+
+<style>
+  .app {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    height: 100%;
+    min-height: 0;
+    background: var(--panel);
+  }
+
+  .chrome {
+    display: grid;
+    grid-template-rows: var(--header-height) auto;
+    border-bottom: 1px solid var(--border);
+    background: linear-gradient(180deg, #13201f 0%, var(--panel) 100%);
+  }
+
+  .bar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: center;
+    gap: var(--space-2) var(--space-3);
+    min-width: 0;
+    padding: 0 var(--space-3) 0 var(--space-4);
+  }
+
+  .identity {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+
+  .mark {
+    display: block;
+    flex: none;
+    width: 2.1rem;
+    height: auto;
+    opacity: 0.95;
+  }
+
+  .names {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+
+  .name {
+    color: var(--text);
+    font-size: 0.92rem;
+    font-weight: 650;
+    letter-spacing: 0.01em;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .sub {
+    color: var(--text-faint);
+    font-size: 0.6rem;
+    font-weight: 600;
+    letter-spacing: 0.09em;
+    line-height: 1;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .link {
+    flex: none;
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: 50%;
+    background: var(--track);
+    border: 1px solid var(--border-strong);
+  }
+
+  .link.connected {
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .bar-right {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-2);
+    min-width: 0;
+  }
+
+  .mode-row {
+    display: flex;
+    justify-content: center;
+    min-width: 0;
+    padding: 0 var(--space-3) var(--space-2);
+  }
+
+  .body {
+    display: grid;
+    grid-template-rows: minmax(8rem, 1fr) auto;
+    gap: var(--space-3);
+    min-height: 0;
+    padding: var(--space-3);
+  }
+
+  .stage {
+    display: flex;
+    min-height: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--stage-bottom);
+    overflow: hidden;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  }
+
+  .stage.bypassed {
+    opacity: 0.38;
+  }
+
+  .rack {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--raised);
+    overflow: hidden;
+  }
+
+  .group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    min-width: 0;
+    padding: var(--space-3) var(--space-2) var(--space-3);
+  }
+
+  .group + .group {
+    border-left: 1px solid var(--border);
+  }
+
+  .group-title {
+    padding: 0 var(--space-1);
+    color: var(--text-faint);
+    font-size: 0.65rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .group-knobs {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(3.85rem, 1fr));
+    justify-items: center;
+    align-items: start;
+    gap: var(--space-2) var(--space-1);
+    min-width: 0;
+  }
+
+  .output {
+    background: color-mix(in srgb, var(--accent) 6%, var(--raised));
+  }
+
+  @media (max-width: 980px) {
+    .rack {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    .group:nth-child(3),
+    .group:nth-child(4) {
+      border-top: 1px solid var(--border);
+    }
+
+    .group:nth-child(3) {
+      border-left: 0;
+    }
+  }
+
+  @media (max-width: 760px) {
+    .bar {
+      grid-template-columns: minmax(0, auto) minmax(0, 1fr) auto;
+      padding-inline: var(--space-2);
+    }
+
+    .mode-row {
+      padding-inline: var(--space-2);
+    }
+
+    .body {
+      gap: var(--space-2);
+      padding: var(--space-2);
+    }
+
+    .group {
+      padding: var(--space-2);
+    }
+  }
+
+  @media (max-width: 640px) {
+    .rack {
+      grid-template-columns: 1fr;
+    }
+
+    .group + .group {
+      border-left: 0;
+      border-top: 1px solid var(--border);
+    }
+
+    .group:nth-child(3) {
+      border-left: 0;
+    }
+  }
+
+  @media (max-height: 560px) {
+    .body {
+      gap: var(--space-2);
+      padding: var(--space-2);
+    }
+
+    .mode-row {
+      padding-bottom: var(--space-1);
+    }
+
+    .group {
+      padding-block: var(--space-2);
+    }
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/app.css
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/app.css
@@ -1,0 +1,118 @@
+/*
+ * EchoSpace editor palette.
+ *
+ * Same surface hierarchy and control language as VerbSpace (graphite planes,
+ * soft borders, amber reserved for the held/override state), with a teal accent
+ * that belongs to this delay rather than the Studio cyan or VerbSpace's violet.
+ *
+ * The knob shading is driven from tokens rather than literals so the accent is
+ * the only thing that has to change between the two plugins.
+ */
+
+:root {
+  --base: #080d0d;
+  --panel: #0e1516;
+  --raised: #131c1d;
+  --stage-top: #101a1a;
+  --stage-bottom: #080f10;
+  --knob-face: #172122;
+  --knob-face-hi: #22302f;
+
+  --border: rgba(255, 255, 255, 0.06);
+  --border-strong: rgba(255, 255, 255, 0.12);
+  --track: #222e2e;
+  --grid: #1c2727;
+
+  --text: #e6f0ee;
+  --text-muted: #91a4a1;
+  --text-faint: #62726f;
+
+  --accent: #2fd6a6;
+  --accent-bright: #62f2c8;
+  --accent-dim: rgba(47, 214, 166, 0.34);
+  --accent-fill: rgba(47, 214, 166, 0.14);
+  --accent-text: #a6f8de;
+
+  /* The right channel's lane in the echo display. Distinct enough from the
+     accent to read as a second channel, not as a state change. */
+  --accent-alt: #4aa8ff;
+  --accent-alt-bright: #7cc4ff;
+
+  --overlay-scrim: rgba(8, 13, 13, 0.78);
+
+  --warn: #f0a83c;
+  --warn-dim: rgba(240, 168, 60, 0.4);
+
+  /* Knob shading — see lib/Knob.svelte. */
+  --knob-ring-hi: #2e4342;
+  --knob-ring-lo: #101817;
+  --knob-body-hi: #243433;
+  --knob-body-mid: #16201f;
+  --knob-body-lo: #080e0e;
+  --knob-cap-hi: #365351;
+  --knob-cap-mid: #1f2d2c;
+  --knob-cap-lo: #121b1a;
+  --knob-cap-edge: #070c0c;
+  --knob-pointer: #eaf6f3;
+
+  --header-height: 3rem;
+  --radius: 0.75rem;
+  --radius-sm: 0.45rem;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --knob-size: clamp(3.55rem, 5.2vw, 4.85rem);
+
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  min-width: 560px;
+  height: 100%;
+  min-height: 480px;
+  margin: 0;
+  overflow: hidden;
+}
+
+body {
+  background: var(--base);
+  color: var(--text);
+  font-family:
+    'Inter Variable', Inter, 'Segoe UI Variable', 'Segoe UI', system-ui,
+    sans-serif;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-synthesis: none;
+  line-height: 1.2;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  user-select: none;
+  cursor: default;
+}
+
+button,
+input {
+  margin: 0;
+  font: inherit;
+}
+
+button {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+}
+
+button:focus-visible,
+[role='slider']:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/assets/logo.svg
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/assets/logo.svg
@@ -1,0 +1,9 @@
+<svg width="34" height="30" viewBox="0 0 34 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Source tap plus three decaying repeats: the plugin's mark, reading as a
+       delay line. Colours are baked because an <img> cannot see page CSS. -->
+  <rect x="1" y="4" width="3" height="22" rx="1.5" fill="#E6F0EE" />
+  <rect x="9" y="8" width="3" height="14" rx="1.5" fill="#2FD6A6" />
+  <rect x="17" y="11" width="3" height="8" rx="1.5" fill="#2FD6A6" opacity="0.62" />
+  <rect x="25" y="13" width="3" height="4" rx="1.5" fill="#2FD6A6" opacity="0.32" />
+  <circle cx="32" cy="15" r="1.4" fill="#2FD6A6" opacity="0.18" />
+</svg>

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/bridge.ts
@@ -1,0 +1,188 @@
+/**
+ * Native bridge for the EchoSpace editor.
+ *
+ * Same wire contract every built-in editor speaks: the host posts
+ * `futureboard.selectInstance` with the authoritative state, the page answers
+ * `futureboard.instanceReady`, and every gesture travels back as a batched
+ * `futureboard.setParams` tagged with the binding it was made against. The
+ * host drops a batch whose `bindingGeneration` is stale, so an edit made
+ * against a torn-down instance can never land on its replacement.
+ */
+
+import { MODES, type Mode } from './params'
+
+export const BRIDGE_PROTOCOL_VERSION = 1
+export const PLUGIN_ID = 'echospace'
+
+/** The state blob `echospace::ipc::EchospaceState` serializes. */
+export type EchoParams = {
+  power: boolean
+  mode: Mode
+  timeMsL: number
+  timeMsR: number
+  feedback: number
+  crossFeedback: number
+  lowCutHz: number
+  highCutHz: number
+  saturation: number
+  mix: number
+  outputDb: number
+  freeze: boolean
+}
+
+type Binding = {
+  pluginId: string
+  instanceId: string
+  bindingGeneration: number
+}
+
+type SelectInstanceMessage = {
+  type: 'futureboard.selectInstance'
+  protocolVersion: number
+  pluginId: string
+  instanceId: string
+  bindingGeneration: number
+  stateRevision: number
+  state: unknown
+}
+
+type InstanceRemovedMessage = {
+  type: 'futureboard.instanceRemoved'
+  protocolVersion: number
+  instanceId: string
+}
+
+let binding: Binding | null = null
+const pending = new Map<string, number>()
+let scheduled = false
+
+function post(body: unknown) {
+  if (window.location.protocol !== 'mikoplugin:') return
+  try {
+    void fetch('__bridge', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }).catch(() => {})
+  } catch {
+    // A standalone design preview intentionally has no native endpoint.
+  }
+}
+
+/**
+ * Coalesce a frame's worth of edits into one batch. A knob drag emits on every
+ * pointer move; the map keeps the *last* value per id, so the committed value
+ * is always sent even though the intermediate ones are not.
+ */
+function flush() {
+  scheduled = false
+  if (!binding || pending.size === 0) {
+    pending.clear()
+    return
+  }
+  const params = Array.from(pending, ([id, value]) => ({ id, value }))
+  pending.clear()
+  post({
+    type: 'futureboard.setParams',
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    ...binding,
+    params,
+  })
+}
+
+export function postParam(id: string, value: number) {
+  pending.set(id, value)
+  if (scheduled) return
+  scheduled = true
+  requestAnimationFrame(flush)
+}
+
+const NUMERIC_KEYS = [
+  'timeMsL',
+  'timeMsR',
+  'feedback',
+  'crossFeedback',
+  'lowCutHz',
+  'highCutHz',
+  'saturation',
+  'mix',
+  'outputDb',
+] as const
+
+/**
+ * Accept a host state blob only when every field is present and of the right
+ * type. A partial blob is rejected whole rather than merged: a half-applied
+ * state would show values the DSP does not have.
+ */
+function parseParams(state: unknown): EchoParams | null {
+  if (!state || typeof state !== 'object') return null
+  const candidate =
+    'params' in state ? (state as { params?: unknown }).params : state
+  if (!candidate || typeof candidate !== 'object') return null
+  const params = candidate as Record<string, unknown>
+
+  if (typeof params.power !== 'boolean' || typeof params.freeze !== 'boolean') {
+    return null
+  }
+  if (!MODES.includes(params.mode as Mode)) return null
+  for (const key of NUMERIC_KEYS) {
+    const value = params[key]
+    if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  }
+  return params as unknown as EchoParams
+}
+
+export function connectBridge(
+  onParams: (params: EchoParams) => void,
+  onConnection: (connected: boolean) => void,
+) {
+  post({
+    type: 'futureboard.bridgeReady',
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    bridgeVersion: BRIDGE_PROTOCOL_VERSION,
+    pluginId: PLUGIN_ID,
+  })
+
+  const listener = (event: MessageEvent) => {
+    const message = event.data as
+      | SelectInstanceMessage
+      | InstanceRemovedMessage
+      | undefined
+    if (!message || typeof message !== 'object') return
+
+    if (message.type === 'futureboard.selectInstance') {
+      binding = {
+        pluginId: message.pluginId,
+        instanceId: message.instanceId,
+        bindingGeneration: message.bindingGeneration,
+      }
+      // Edits queued against the previous binding are abandoned, not
+      // re-tagged: they were made against different state.
+      pending.clear()
+      const params = parseParams(message.state)
+      if (params) onParams(params)
+      onConnection(true)
+      post({
+        type: 'futureboard.instanceReady',
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        pluginId: message.pluginId,
+        instanceId: message.instanceId,
+        bindingGeneration: message.bindingGeneration,
+        stateRevision: message.stateRevision,
+      })
+    } else if (
+      message.type === 'futureboard.instanceRemoved' &&
+      binding?.instanceId === message.instanceId
+    ) {
+      binding = null
+      pending.clear()
+      onConnection(false)
+    }
+  }
+
+  window.addEventListener('message', listener)
+  return () => {
+    window.removeEventListener('message', listener)
+    binding = null
+    pending.clear()
+  }
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/EchoView.svelte
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/EchoView.svelte
@@ -1,0 +1,392 @@
+<script lang="ts">
+  import type { EchoParams } from '../bridge'
+  import { echoModel, envelopeAt, filterMagnitude, tapTimes } from '../model'
+
+  type Props = { params: EchoParams }
+  const { params }: Props = $props()
+
+  let canvas: HTMLCanvasElement | undefined = $state()
+  let host: HTMLDivElement | undefined = $state()
+  let cssWidth = $state(0)
+  let cssHeight = $state(0)
+
+  /** Longest window the axis will show, so a 4 s delay does not squash the
+   *  first repeat into the left edge. */
+  const MAX_WINDOW_SEC = 6
+
+  /** Reference tone the per-pass filter dulling is measured at. Sits inside the
+   *  high cut's usual range so the colour actually tracks it, but low enough
+   *  that a dark setting does not put every repeat past the floor at once. */
+  const TONE_REF_HZ = 3000
+
+  /** Ceiling on how far a repeat's colour is pulled toward grey. Fully grey
+   *  would lose which channel the repeat is on, which is the display's whole
+   *  point under ping-pong. */
+  const MAX_DULL = 0.6
+
+  /** Bottom of the amplitude axis, in decibels. Matches the -60 the repeat
+   *  model stops at. */
+  const FLOOR_DB = -60
+
+  const model = $derived(echoModel(params))
+  const times = $derived(tapTimes(params))
+
+  /** Repeats below this are drawn but do not get to widen the time axis — at a
+   *  modest feedback the last few are 50 dB down and would leave most of the
+   *  plot empty. */
+  const WINDOW_FLOOR_DB = -40
+
+  const windowSec = $derived.by(() => {
+    const floor = 10 ** (WINDOW_FLOOR_DB / 20)
+    const audible = model.taps.filter((tap) => tap.amplitude >= floor)
+    const last = audible.length > 0 ? audible[audible.length - 1]!.time : 0
+    return Math.min(MAX_WINDOW_SEC, Math.max(0.25, last * 1.15))
+  })
+
+  function cssVar(name: string, fallback: string): string {
+    if (!host) return fallback
+    const value = getComputedStyle(host).getPropertyValue(name).trim()
+    return value || fallback
+  }
+
+  /** `#rrggbb` + alpha -> `rgba(...)`, so one palette drives both the DOM and
+   *  the canvas instead of the canvas carrying a second set of literals. */
+  function alpha(hex: string, a: number): string {
+    const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim())
+    if (!match?.[1]) return hex
+    const int = parseInt(match[1], 16)
+    return `rgba(${(int >> 16) & 255}, ${(int >> 8) & 255}, ${int & 255}, ${a})`
+  }
+
+  /** Blend two `#rrggbb` colours, `t` = 0 keeps `from`. */
+  function blend(from: string, to: string, t: number, a: number): string {
+    const parse = (hex: string) => {
+      const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim())
+      return match?.[1] ? parseInt(match[1], 16) : null
+    }
+    const f = parse(from)
+    const g = parse(to)
+    if (f === null || g === null) return alpha(from, a)
+    const mix = (shift: number) => {
+      const a0 = (f >> shift) & 255
+      const b0 = (g >> shift) & 255
+      return Math.round(a0 + (b0 - a0) * Math.min(Math.max(t, 0), 1))
+    }
+    return `rgba(${mix(16)}, ${mix(8)}, ${mix(0)}, ${a})`
+  }
+
+  function draw() {
+    if (!canvas || cssWidth <= 0 || cssHeight <= 0) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = Math.round(cssWidth * dpr)
+    canvas.height = Math.round(cssHeight * dpr)
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, cssWidth, cssHeight)
+
+    const accent = cssVar('--accent', '#2fd6a6')
+    const accentBright = cssVar('--accent-bright', '#62f2c8')
+    const alt = cssVar('--accent-alt', '#4aa8ff')
+    const altBright = cssVar('--accent-alt-bright', '#7cc4ff')
+    const warn = cssVar('--warn', '#f0a83c')
+    const grid = cssVar('--grid', '#1c2727')
+    const faint = cssVar('--text-faint', '#62726f')
+    const dull = cssVar('--text-faint', '#62726f')
+
+    const padL = 30
+    const padR = 14
+    const padT = 16
+    const padB = 20
+    const w = Math.max(cssWidth - padL - padR, 1)
+    const h = Math.max(cssHeight - padT - padB, 1)
+    const mid = padT + h / 2
+    // Each lane gets half the height, less a small gap at the centre line.
+    const lane = h / 2 - 5
+
+    const x = (t: number) => padL + (t / windowSec) * w
+
+    // Bar height is decibels, not raw amplitude. On a linear scale everything
+    // past the second repeat collapses into a stub at the centre line, even
+    // though a -30 dB repeat is plainly audible.
+    const height = (amplitude: number) => {
+      if (amplitude <= 0) return 0
+      const db = 20 * Math.log10(amplitude)
+      if (db <= FLOOR_DB) return 0
+      return lane * (1 - db / FLOOR_DB)
+    }
+
+    ctx.font =
+      '9px ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace'
+    ctx.lineWidth = 1
+
+    // ---- time grid -------------------------------------------------------
+    const tickSec =
+      windowSec <= 0.5 ? 0.1 : windowSec <= 1.5 ? 0.25 : windowSec <= 4 ? 0.5 : 1
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'top'
+    for (let t = tickSec; t < windowSec; t += tickSec) {
+      const gx = Math.round(x(t)) + 0.5
+      ctx.strokeStyle = grid
+      ctx.beginPath()
+      ctx.moveTo(gx, padT)
+      ctx.lineTo(gx, padT + h)
+      ctx.stroke()
+      ctx.fillStyle = faint
+      ctx.fillText(
+        tickSec < 1 ? `${Math.round(t * 1000)}ms` : `${t.toFixed(0)}s`,
+        gx,
+        padT + h + 5,
+      )
+    }
+
+    // ---- amplitude grid --------------------------------------------------
+    ctx.textAlign = 'right'
+    ctx.textBaseline = 'middle'
+    for (const db of [-12, -24, -36, -48]) {
+      const off = height(10 ** (db / 20))
+      for (const sign of [-1, 1]) {
+        const gy = Math.round(mid + sign * off) + 0.5
+        ctx.strokeStyle = grid
+        ctx.beginPath()
+        ctx.moveTo(padL, gy)
+        ctx.lineTo(padL + w, gy)
+        ctx.stroke()
+      }
+      // Labelled on the upper lane only — the lower one mirrors it exactly.
+      ctx.fillStyle = faint
+      ctx.fillText(`${db}`, padL - 6, mid - off)
+    }
+
+    // ---- lane labels + centre line --------------------------------------
+    ctx.strokeStyle = alpha(faint, 0.22)
+    ctx.beginPath()
+    ctx.moveTo(padL, Math.round(mid) + 0.5)
+    ctx.lineTo(padL + w, Math.round(mid) + 0.5)
+    ctx.stroke()
+
+    ctx.textAlign = 'left'
+    ctx.textBaseline = 'middle'
+    ctx.fillStyle = alpha(faint, 0.9)
+    ctx.fillText('L', padL + 12, padT + 5)
+    ctx.fillText('R', padL + 12, padT + h - 5)
+
+    // ---- dry signal ------------------------------------------------------
+    // Drawn at unity on both lanes so the repeats have a reference to read
+    // against; it is the input, not a repeat.
+    const dryX = Math.round(x(0)) + 0.5
+    ctx.strokeStyle = alpha(faint, 0.85)
+    ctx.lineWidth = 2
+    ctx.beginPath()
+    ctx.moveTo(dryX, mid - lane)
+    ctx.lineTo(dryX, mid + lane)
+    ctx.stroke()
+
+    // ---- feedback envelopes ---------------------------------------------
+    const floor = 10 ** (-60 / 20)
+    const envelope = (step: number, sign: number) => {
+      const path = new Path2D()
+      const steps = Math.max(Math.round(w), 2)
+      let started = false
+      for (let i = 0; i <= steps; i++) {
+        const t = (i / steps) * windowSec
+        const a = envelopeAt(t, step, model.gain)
+        if (a < floor) break
+        const py = mid + sign * height(Math.min(a, 1))
+        if (started) path.lineTo(x(t), py)
+        else {
+          path.moveTo(x(t), py)
+          started = true
+        }
+      }
+      return path
+    }
+
+    const tailColor = params.freeze ? warn : accent
+    ctx.setLineDash([3, 3])
+    ctx.lineWidth = 1
+    ctx.strokeStyle = alpha(tailColor, 0.4)
+    ctx.stroke(envelope(times.left, -1))
+    ctx.stroke(envelope(times.right, 1))
+    ctx.setLineDash([])
+
+    // ---- repeats ---------------------------------------------------------
+    // Each pass runs through the feedback filters once more, so successive
+    // repeats are drawn duller by exactly the magnitude those filters have at
+    // the reference tone.
+    const perPass = filterMagnitude(params, TONE_REF_HZ)
+    for (const tap of model.taps) {
+      if (tap.time > windowSec) continue
+      const sign = tap.lane === 'left' ? -1 : 1
+      const base = tap.lane === 'left' ? accentBright : altBright
+      const color = params.freeze ? warn : base
+      const tone = perPass ** tap.pass
+      const dulled = Math.min(1 - tone, MAX_DULL)
+      const gx = Math.round(x(tap.time)) + 0.5
+      const bar = height(Math.min(tap.amplitude, 1))
+
+      // Opacity floors well above zero: a -40 dB repeat is quiet, not absent,
+      // and an almost-invisible bar reads as the delay having stopped.
+      ctx.strokeStyle = blend(color, dull, dulled, 0.5 + tap.amplitude * 0.45)
+      ctx.lineWidth = 2.5
+      ctx.beginPath()
+      ctx.moveTo(gx, mid)
+      ctx.lineTo(gx, mid + sign * bar)
+      ctx.stroke()
+
+      // Cap the bar so a short repeat still reads as a discrete event.
+      ctx.fillStyle = blend(color, dull, dulled, 0.7 + tap.amplitude * 0.3)
+      ctx.fillRect(gx - 2, mid + sign * bar - (sign < 0 ? 0 : 2), 4, 2)
+    }
+
+    // ---- tap-time markers ------------------------------------------------
+    // Drawn full height rather than in "their" lane: a tap time marks a moment,
+    // and under ping-pong the line's own first repeat comes back on the
+    // opposite side — a half-height marker would point at the wrong one.
+    for (const [step, color] of [
+      [times.left, accent],
+      [times.right, alt],
+    ] as const) {
+      if (step > windowSec) continue
+      const gx = Math.round(x(step)) + 0.5
+      ctx.strokeStyle = alpha(color, 0.4)
+      ctx.setLineDash([1, 3])
+      ctx.beginPath()
+      ctx.moveTo(gx, padT)
+      ctx.lineTo(gx, padT + h)
+      ctx.stroke()
+      ctx.setLineDash([])
+    }
+  }
+
+  $effect(() => {
+    // Touch every input so the redraw re-runs when any of them changes.
+    void params
+    void windowSec
+    void cssWidth
+    void cssHeight
+    draw()
+  })
+
+  $effect(() => {
+    if (!host) return
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0]?.contentRect
+      if (!rect) return
+      cssWidth = rect.width
+      cssHeight = rect.height
+    })
+    observer.observe(host)
+    return () => observer.disconnect()
+  })
+
+  function ms(value: number): string {
+    return value >= 1 ? `${value.toFixed(2)}s` : `${Math.round(value * 1000)}ms`
+  }
+</script>
+
+<div class="view" bind:this={host} class:frozen={params.freeze}>
+  <canvas bind:this={canvas} style="width: {cssWidth}px; height: {cssHeight}px"
+  ></canvas>
+  <div class="overlay">
+    <div class="caption">
+      <span class="title">Echo model</span>
+      <span class="note">computed from parameters · repeats over time</span>
+    </div>
+    <div class="legend">
+      <div class="item">
+        <span class="key">L</span>
+        <span class="val">{ms(times.left)}</span>
+      </div>
+      <div class="item">
+        <span class="key">R</span>
+        <span class="val">{ms(times.right)}</span>
+      </div>
+      <div class="item">
+        <span class="key">Repeats</span>
+        <span class="val">{params.freeze ? '∞' : model.passes}</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .view {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    background: linear-gradient(180deg, var(--stage-top), var(--stage-bottom));
+    overflow: hidden;
+  }
+
+  .view.frozen {
+    box-shadow: inset 0 0 0 1px var(--warn-dim);
+  }
+
+  canvas {
+    display: block;
+  }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .caption {
+    position: absolute;
+    left: 2rem;
+    bottom: 1.4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 0.2rem 0.4rem;
+    border-radius: var(--radius-sm);
+    background: var(--overlay-scrim);
+  }
+
+  .title {
+    color: var(--text-muted);
+    font-size: 0.6rem;
+    font-weight: 650;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .note {
+    color: var(--text-faint);
+    font-size: 0.6rem;
+  }
+
+  .legend {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.6rem;
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.2rem 0.45rem;
+    border-radius: var(--radius-sm);
+    background: var(--overlay-scrim);
+  }
+
+  .item {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 1px;
+  }
+
+  .key {
+    color: var(--text-faint);
+    font-size: 0.55rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .val {
+    color: var(--text);
+    font-size: 0.72rem;
+    font-weight: 600;
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/Knob.svelte
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/Knob.svelte
@@ -1,0 +1,474 @@
+<script lang="ts">
+  import {
+    clamp,
+    format,
+    fromNorm,
+    toNorm,
+    unitFor,
+    type ParamSpec,
+  } from '../params'
+
+  type Props = {
+    spec: ParamSpec
+    value: number
+    onchange: (value: number) => void
+    /** Optional CSS size override, e.g. `5.5rem`. Defaults to `--knob-size`. */
+    size?: string
+    alert?: boolean
+    disabled?: boolean
+  }
+
+  const {
+    spec,
+    value,
+    onchange,
+    size,
+    alert = false,
+    disabled = false,
+  }: Props = $props()
+
+  const norm = $derived(toNorm(spec, value))
+  const uid = `k${Math.random().toString(36).slice(2, 9)}`
+
+  let dragging = $state(false)
+  let editing = $state(false)
+  let draft = $state('')
+  let inputEl: HTMLInputElement | undefined = $state()
+  let dragStartY = 0
+  let dragStartNorm = 0
+
+  $effect(() => {
+    if (editing) {
+      inputEl?.focus()
+      inputEl?.select()
+    }
+  })
+
+  const TRAVEL_PX = 230
+
+  function commit(nextNorm: number) {
+    if (disabled) return
+    onchange(fromNorm(spec, clamp(nextNorm, 0, 1)))
+  }
+
+  function onPointerDown(event: PointerEvent) {
+    if (disabled || editing || event.button !== 0) return
+    dragging = true
+    dragStartY = event.clientY
+    dragStartNorm = norm
+    ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
+    event.preventDefault()
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    if (!dragging) return
+    const travel = event.shiftKey ? TRAVEL_PX * 5 : TRAVEL_PX
+    commit(dragStartNorm + (dragStartY - event.clientY) / travel)
+  }
+
+  function onPointerUp(event: PointerEvent) {
+    if (!dragging) return
+    dragging = false
+    ;(event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId)
+  }
+
+  function onWheel(event: WheelEvent) {
+    if (disabled) return
+    event.preventDefault()
+    const step = event.shiftKey ? spec.step / 5 : spec.step
+    onchange(
+      clamp(value + (event.deltaY < 0 ? step : -step), spec.min, spec.max),
+    )
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    if (disabled) return
+    const step = event.shiftKey ? spec.step / 5 : spec.step
+    switch (event.key) {
+      case 'ArrowUp':
+      case 'ArrowRight':
+        onchange(clamp(value + step, spec.min, spec.max))
+        break
+      case 'ArrowDown':
+      case 'ArrowLeft':
+        onchange(clamp(value - step, spec.min, spec.max))
+        break
+      case 'PageUp':
+        commit(norm + 0.1)
+        break
+      case 'PageDown':
+        commit(norm - 0.1)
+        break
+      case 'Home':
+        onchange(spec.default)
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+  }
+
+  function startEdit() {
+    if (disabled) return
+    draft = String(Number(value.toFixed(Math.max(spec.digits, 2))))
+    editing = true
+  }
+
+  function commitEdit() {
+    const parsed = Number(draft.replace(/[^\d.+-]/g, ''))
+    if (Number.isFinite(parsed)) {
+      onchange(clamp(parsed, spec.min, spec.max))
+    }
+    editing = false
+  }
+
+  const START_DEG = -225
+  const SWEEP_DEG = 270
+  const R = 41
+
+  function polar(deg: number, radius: number) {
+    const rad = (deg * Math.PI) / 180
+    return { x: 50 + Math.cos(rad) * radius, y: 50 + Math.sin(rad) * radius }
+  }
+
+  function arc(fromNormValue: number, toNormValue: number, radius: number) {
+    const a0 = START_DEG + SWEEP_DEG * fromNormValue
+    const a1 = START_DEG + SWEEP_DEG * toNormValue
+    const p0 = polar(a0, radius)
+    const p1 = polar(a1, radius)
+    const large = Math.abs(a1 - a0) > 180 ? 1 : 0
+    const sweep = a1 >= a0 ? 1 : 0
+    return `M ${p0.x.toFixed(2)} ${p0.y.toFixed(2)} A ${radius} ${radius} 0 ${large} ${sweep} ${p1.x.toFixed(2)} ${p1.y.toFixed(2)}`
+  }
+
+  const originNorm = $derived(
+    spec.origin === undefined ? 0 : toNorm(spec, spec.origin),
+  )
+  const defaultNorm = $derived(toNorm(spec, spec.default))
+  const pointer = $derived(polar(START_DEG + SWEEP_DEG * norm, R - 7))
+  const inner = $derived(polar(START_DEG + SWEEP_DEG * norm, R - 24))
+  const tip = $derived(polar(START_DEG + SWEEP_DEG * norm, R - 10))
+  const defaultTick = $derived(polar(START_DEG + SWEEP_DEG * defaultNorm, 47))
+  const defaultTickOuter = $derived(
+    polar(START_DEG + SWEEP_DEG * defaultNorm, 51),
+  )
+
+  const ticks = [0, 0.25, 0.5, 0.75, 1].map((t) => {
+    const deg = START_DEG + SWEEP_DEG * t
+    return { a: polar(deg, 46.5), b: polar(deg, 49.5) }
+  })
+</script>
+
+<div
+  class="knob"
+  class:disabled
+  style={size ? `--knob-size: ${size}` : undefined}
+>
+  <div class="label">{spec.label}</div>
+  <div
+    class="dial"
+    class:dragging
+    class:alert
+    role="slider"
+    tabindex={disabled ? -1 : 0}
+    aria-label={spec.label}
+    aria-valuemin={spec.min}
+    aria-valuemax={spec.max}
+    aria-valuenow={value}
+    aria-valuetext="{format(spec, value)} {unitFor(spec, value)}"
+    aria-disabled={disabled}
+    title="{spec.label} — drag vertically, Shift for fine, double-click to reset"
+    onpointerdown={onPointerDown}
+    onpointermove={onPointerMove}
+    onpointerup={onPointerUp}
+    onpointercancel={onPointerUp}
+    onwheel={onWheel}
+    onkeydown={onKeyDown}
+    ondblclick={() => !disabled && onchange(spec.default)}
+  >
+    <svg viewBox="0 0 100 100" aria-hidden="true">
+      <defs>
+        <linearGradient id="{uid}-ring" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stop-color="var(--knob-ring-hi)" />
+          <stop offset="1" stop-color="var(--knob-ring-lo)" />
+        </linearGradient>
+        <linearGradient id="{uid}-body" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stop-color="var(--knob-body-hi)" />
+          <stop offset=".45" stop-color="var(--knob-body-mid)" />
+          <stop offset="1" stop-color="var(--knob-body-lo)" />
+        </linearGradient>
+        <radialGradient id="{uid}-cap" cx=".32" cy=".24" r=".78">
+          <stop offset="0" stop-color="var(--knob-cap-hi)" />
+          <stop offset=".28" stop-color="var(--knob-cap-mid)" />
+          <stop offset=".7" stop-color="var(--knob-cap-lo)" />
+          <stop offset="1" stop-color="var(--knob-cap-edge)" />
+        </radialGradient>
+        <radialGradient id="{uid}-glow" cx=".5" cy=".5" r=".5">
+          <stop offset="0" stop-color="var(--accent)" stop-opacity=".35" />
+          <stop offset="1" stop-color="var(--accent)" stop-opacity="0" />
+        </radialGradient>
+        <filter id="{uid}-shadow" x="-35%" y="-35%" width="170%" height="180%">
+          <feDropShadow
+            dx="0"
+            dy="3.5"
+            stdDeviation="3.2"
+            flood-color="#000"
+            flood-opacity=".55"
+          />
+        </filter>
+      </defs>
+
+      {#each ticks as tick}
+        <line class="tick" x1={tick.a.x} y1={tick.a.y} x2={tick.b.x} y2={tick.b.y} />
+      {/each}
+
+      <path class="track" d={arc(0, 1, R)} />
+      {#if Math.abs(norm - originNorm) > 0.001}
+        <path class="fill" d={arc(originNorm, norm, R)} />
+      {/if}
+      <line
+        class="default"
+        x1={defaultTick.x}
+        y1={defaultTick.y}
+        x2={defaultTickOuter.x}
+        y2={defaultTickOuter.y}
+      />
+
+      <circle class="ring" cx="50" cy="50" r="35.5" fill="url(#{uid}-ring)" />
+      <circle
+        class="body"
+        cx="50"
+        cy="50"
+        r="32.5"
+        fill="url(#{uid}-body)"
+        filter="url(#{uid}-shadow)"
+      />
+      <circle class="cap" cx="50" cy="50" r="27.5" fill="url(#{uid}-cap)" />
+      <circle class="rim" cx="50" cy="50" r="27.5" />
+      <path class="highlight" d="M30 39 A 22 22 0 0 1 67 31" />
+      {#if dragging}
+        <circle cx="50" cy="50" r="36" fill="url(#{uid}-glow)" />
+      {/if}
+      <line
+        class="pointer"
+        x1={inner.x}
+        y1={inner.y}
+        x2={pointer.x}
+        y2={pointer.y}
+      />
+      <circle class="tip" cx={tip.x} cy={tip.y} r="2.1" />
+    </svg>
+  </div>
+
+  {#if editing}
+    <input
+      class="input"
+      bind:this={inputEl}
+      bind:value={draft}
+      aria-label="{spec.label} value"
+      onblur={commitEdit}
+      onkeydown={(event) => {
+        if (event.key === 'Enter') commitEdit()
+        if (event.key === 'Escape') editing = false
+      }}
+    />
+  {:else}
+    <button
+      type="button"
+      class="readout"
+      {disabled}
+      title="Click to type a value"
+      onclick={startEdit}
+    >
+      <span class="value">{format(spec, value)}</span>
+      <span class="unit">{unitFor(spec, value)}</span>
+    </button>
+  {/if}
+</div>
+
+<style>
+  .knob {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.3rem;
+    width: 100%;
+    max-width: 5.4rem;
+    min-width: 0;
+  }
+
+  .label {
+    max-width: 100%;
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .dial {
+    width: var(--knob-size);
+    height: var(--knob-size);
+    cursor: ns-resize;
+    touch-action: none;
+    outline: none;
+    transition: transform 120ms ease;
+  }
+
+  .dial:hover {
+    transform: scale(1.025);
+  }
+
+  .dial.dragging {
+    transform: scale(1.035);
+  }
+
+  .knob.disabled .dial {
+    cursor: default;
+    opacity: 0.36;
+    transform: none;
+  }
+
+  svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+  }
+
+  .tick {
+    stroke: rgba(255, 255, 255, 0.14);
+    stroke-width: 1.25;
+    stroke-linecap: round;
+  }
+
+  .track {
+    fill: none;
+    stroke: rgba(255, 255, 255, 0.08);
+    stroke-width: 3.75;
+    stroke-linecap: round;
+  }
+
+  .fill {
+    fill: none;
+    stroke: var(--accent);
+    stroke-width: 3.75;
+    stroke-linecap: round;
+    filter: drop-shadow(
+      0 0 2.5px color-mix(in srgb, var(--accent) 60%, transparent)
+    );
+  }
+
+  .default {
+    stroke: rgba(255, 255, 255, 0.28);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+  }
+
+  .ring {
+    stroke: rgba(255, 255, 255, 0.06);
+    stroke-width: 0.75;
+  }
+
+  .body {
+    stroke: rgba(255, 255, 255, 0.1);
+    stroke-width: 1;
+  }
+
+  .cap {
+    stroke: rgba(255, 255, 255, 0.035);
+    stroke-width: 1;
+  }
+
+  .rim {
+    fill: none;
+    stroke: color-mix(in srgb, var(--accent) 14%, transparent);
+    stroke-width: 1.1;
+  }
+
+  .highlight {
+    fill: none;
+    stroke: rgba(255, 255, 255, 0.2);
+    stroke-width: 1.35;
+    stroke-linecap: round;
+  }
+
+  .pointer {
+    stroke: var(--knob-pointer);
+    stroke-width: 2.4;
+    stroke-linecap: round;
+  }
+
+  .tip {
+    fill: var(--accent-bright);
+    stroke: #fff;
+    stroke-width: 0.6;
+  }
+
+  .dial.dragging .fill,
+  .dial:hover .fill {
+    stroke: var(--accent-bright);
+  }
+
+  .dial.dragging .body {
+    stroke: color-mix(in srgb, var(--accent) 50%, transparent);
+  }
+
+  .dial.dragging .rim {
+    stroke: color-mix(in srgb, var(--accent) 45%, transparent);
+  }
+
+  .dial.alert .fill {
+    stroke: var(--warn);
+    filter: none;
+  }
+
+  .dial.alert .tip {
+    fill: var(--warn);
+  }
+
+  .readout {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 0.18rem;
+    min-width: 4rem;
+    min-height: 1.3rem;
+    padding: 0.12rem 0.3rem;
+    border-radius: var(--radius-sm);
+    cursor: text;
+  }
+
+  .readout:hover {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .value {
+    color: var(--text);
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+
+  .unit {
+    color: var(--text-faint);
+    font-size: 0.62rem;
+  }
+
+  .input {
+    width: 4.2rem;
+    min-height: 1.3rem;
+    padding: 0.12rem 0.3rem;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    outline: none;
+    background: var(--base);
+    color: var(--text);
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-align: center;
+    user-select: text;
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/ModeSelect.svelte
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/ModeSelect.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import { MODES, MODE_LABELS, type Mode } from '../params'
+
+  type Props = {
+    value: Mode
+    onchange: (mode: Mode) => void
+    disabled?: boolean
+  }
+
+  const { value, onchange, disabled = false }: Props = $props()
+</script>
+
+<div class="modes" class:disabled role="radiogroup" aria-label="Reverb mode">
+  {#each MODES as mode (mode)}
+    <button
+      type="button"
+      role="radio"
+      aria-checked={mode === value}
+      class:active={mode === value}
+      {disabled}
+      onclick={() => onchange(mode)}
+    >
+      {MODE_LABELS[mode]}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .modes {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 2px;
+    width: min(100%, 24rem);
+    padding: 3px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--base);
+  }
+
+  button {
+    appearance: none;
+    border: none;
+    min-width: 0;
+    min-height: 1.75rem;
+    padding: 0.3rem 0.35rem;
+    font: inherit;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    background: transparent;
+    border-radius: calc(var(--radius-sm) - 1px);
+    cursor: pointer;
+    text-transform: capitalize;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  button:hover:not(.active):not(:disabled) {
+    color: var(--text);
+    background: var(--raised);
+  }
+
+  button.active {
+    color: var(--accent-text);
+    background: var(--accent-fill);
+  }
+
+  button:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--accent-dim);
+  }
+
+  .modes.disabled button {
+    cursor: default;
+    opacity: 0.45;
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/PresetControl.svelte
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/PresetControl.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  type Props = {
+    preset: number | null
+    names: string[]
+    onchange: (index: number) => void
+    onprevious: () => void
+    onnext: () => void
+  }
+
+  const { preset, names, onchange, onprevious, onnext }: Props = $props()
+</script>
+
+<div class="preset">
+  <button type="button" class="step" aria-label="Previous preset" onclick={onprevious}>
+    ‹
+  </button>
+  <label class="select">
+    <span>{preset === null ? 'Custom' : names[preset]}</span>
+    <select
+      aria-label="Preset"
+      value={preset ?? 'custom'}
+      onchange={(event) => {
+        const value = (event.currentTarget as HTMLSelectElement).value
+        if (value !== 'custom') onchange(Number(value))
+      }}
+    >
+      {#if preset === null}
+        <option value="custom">Custom</option>
+      {/if}
+      {#each names as name, index (name)}
+        <option value={index}>{name}</option>
+      {/each}
+    </select>
+  </label>
+  <button type="button" class="step" aria-label="Next preset" onclick={onnext}>
+    ›
+  </button>
+</div>
+
+<style>
+  .preset {
+    display: grid;
+    grid-template-columns: 1.6rem minmax(0, 10.5rem) 1.6rem;
+    align-items: stretch;
+    width: min(100%, 14rem);
+    height: 2rem;
+    overflow: hidden;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    background: rgba(12, 11, 16, 0.72);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.03),
+      0 4px 12px rgba(0, 0, 0, 0.2);
+  }
+
+  .step {
+    color: var(--text-muted);
+    font-size: 1rem;
+    cursor: pointer;
+  }
+
+  .step:hover {
+    color: var(--text);
+    background: var(--raised);
+  }
+
+  .select {
+    position: relative;
+    display: grid;
+    place-items: center;
+    min-width: 0;
+    border-inline: 1px solid var(--border);
+  }
+
+  .select > span {
+    overflow: hidden;
+    width: 100%;
+    padding: 0 var(--space-2);
+    color: var(--text);
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .select select {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    border: 0;
+    opacity: 0;
+    cursor: pointer;
+    background: var(--raised);
+    color: var(--text);
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/Toggle.svelte
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/Toggle.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  type Props = {
+    label: string
+    value: boolean
+    onchange: (value: boolean) => void
+    /** `warn` marks a hold/override state; `accent` marks ordinary engagement. */
+    tone?: 'accent' | 'warn'
+    disabled?: boolean
+  }
+
+  const {
+    label,
+    value,
+    onchange,
+    tone = 'accent',
+    disabled = false,
+  }: Props = $props()
+</script>
+
+<button
+  type="button"
+  class="toggle {tone}"
+  class:active={value}
+  role="switch"
+  aria-checked={value}
+  aria-label={label}
+  {disabled}
+  onclick={() => onchange(!value)}
+>
+  <span class="dot"></span>
+  <span class="text">{label}</span>
+</button>
+
+<style>
+  .toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    min-height: 1.85rem;
+    padding: 0.35rem 0.85rem 0.35rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--raised);
+    color: var(--text-muted);
+    font: inherit;
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .toggle:hover:not(:disabled) {
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+
+  .toggle:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--accent-dim);
+  }
+
+  .toggle:disabled {
+    cursor: default;
+    opacity: 0.45;
+  }
+
+  .dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: var(--track);
+    border: 1px solid var(--border-strong);
+  }
+
+  .toggle.active {
+    color: var(--text);
+    border-color: var(--accent-dim);
+  }
+
+  .toggle.accent.active .dot {
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .toggle.warn.active {
+    border-color: var(--warn-dim);
+    color: var(--warn);
+  }
+
+  .toggle.warn.active .dot {
+    background: var(--warn);
+    border-color: var(--warn);
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/main.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/main.ts
@@ -1,0 +1,9 @@
+import { mount } from 'svelte'
+
+import './app.css'
+import App from './App.svelte'
+
+const root = document.getElementById('root')
+if (!root) throw new Error('#root is missing from index.html')
+
+export default mount(App, { target: root })

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/model.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/model.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { EchoParams } from './bridge'
+import {
+  MAX_FEEDBACK,
+  echoModel,
+  envelopeAt,
+  filterMagnitude,
+  laneFor,
+  loopGain,
+  tapTimes,
+} from './model'
+import { DEFAULT_PARAMS } from './presets'
+import { LIB_RS, rustScalar } from './rust'
+
+const defaults: EchoParams = { ...DEFAULT_PARAMS }
+
+describe('the display model mirrors the Rust delay line', () => {
+  test('the feedback ceiling matches echospace::MAX_FEEDBACK', () => {
+    expect(MAX_FEEDBACK).toBe(rustScalar(LIB_RS, 'MAX_FEEDBACK'))
+  })
+
+  /**
+   * The Rust normalises the two feedback paths by the cross amount so the loop
+   * gain stays `feedback`. If that ever reverts, this display would keep
+   * drawing a decaying tail while the real line ran away.
+   */
+  test('cross-feed does not change the loop gain', () => {
+    const none = loopGain({ ...defaults, crossFeedback: 0 })
+    const full = loopGain({ ...defaults, crossFeedback: 100 })
+    expect(none).toBeCloseTo(defaults.feedback / 100, 9)
+    expect(full).toBeCloseTo(none, 9)
+  })
+
+  test('freeze pins the loop at the ceiling', () => {
+    expect(loopGain({ ...defaults, freeze: true })).toBe(MAX_FEEDBACK)
+  })
+})
+
+describe('tap layout', () => {
+  test('mono collapses both lanes onto the left time', () => {
+    const params = { ...defaults, mode: 'mono' as const, timeMsR: 900 }
+    const times = tapTimes(params)
+    expect(times.left).toBeCloseTo(params.timeMsL / 1000, 9)
+    expect(times.right).toBe(times.left)
+  })
+
+  test('stereo keeps each line on its own time and side', () => {
+    const times = tapTimes({ ...defaults, mode: 'stereo' })
+    expect(times.left).toBeCloseTo(defaults.timeMsL / 1000, 9)
+    expect(times.right).toBeCloseTo(defaults.timeMsR / 1000, 9)
+    expect(laneFor('stereo', 1, 'left')).toBe('left')
+    expect(laneFor('stereo', 2, 'right')).toBe('right')
+  })
+
+  /** Ping-pong swaps the feedback paths every round trip, so a line's odd
+   *  passes come back on the opposite side. */
+  test('ping-pong alternates sides on odd passes', () => {
+    expect(laneFor('pingpong', 1, 'left')).toBe('right')
+    expect(laneFor('pingpong', 2, 'left')).toBe('left')
+    expect(laneFor('pingpong', 3, 'right')).toBe('left')
+    expect(laneFor('pingpong', 4, 'right')).toBe('right')
+  })
+
+  test('repeats land on integer multiples of the tap time and decay', () => {
+    const params = { ...defaults, mode: 'stereo' as const, feedback: 50 }
+    const { taps } = echoModel(params)
+    const left = taps.filter((tap) => tap.lane === 'left')
+    expect(left.length).toBeGreaterThan(2)
+    for (const tap of left) {
+      expect(tap.time).toBeCloseTo((params.timeMsL / 1000) * tap.pass, 9)
+      expect(tap.amplitude).toBeCloseTo(0.5 ** tap.pass, 9)
+    }
+  })
+
+  test('taps are ordered in time', () => {
+    const { taps } = echoModel(defaults)
+    for (let i = 1; i < taps.length; i++) {
+      expect(taps[i]!.time).toBeGreaterThanOrEqual(taps[i - 1]!.time)
+    }
+  })
+
+  test('zero feedback produces exactly one repeat per lane', () => {
+    const { taps } = echoModel({ ...defaults, mode: 'stereo', feedback: 0 })
+    expect(taps).toHaveLength(0)
+    const barely = echoModel({ ...defaults, mode: 'stereo', feedback: 1 })
+    expect(barely.taps.length).toBeGreaterThan(0)
+  })
+
+  /** Freeze never decays, so the list has to be bounded by the pass cap rather
+   *  than by the amplitude floor. */
+  test('freeze produces a bounded tap list', () => {
+    const { taps, passes } = echoModel({ ...defaults, freeze: true }, -60, 32)
+    expect(passes).toBe(32)
+    expect(taps).toHaveLength(64)
+    expect(taps.every((tap) => tap.amplitude > 0.9)).toBe(true)
+  })
+})
+
+describe('feedback-path tone', () => {
+  test('the reference tone passes when the filters are wide open', () => {
+    const wide = filterMagnitude(
+      { ...defaults, lowCutHz: 20, highCutHz: 20000 },
+      6000,
+    )
+    expect(wide).toBeGreaterThan(0.9)
+  })
+
+  test('closing the high cut dulls the reference tone', () => {
+    let previous = 1
+    for (const highCutHz of [20000, 12000, 6000, 3000, 1000]) {
+      const magnitude = filterMagnitude({ ...defaults, highCutHz }, 6000)
+      expect(magnitude).toBeLessThan(previous)
+      expect(magnitude).toBeGreaterThanOrEqual(0)
+      previous = magnitude
+    }
+  })
+
+  test('at the corner a 2-pole section is down 3 dB', () => {
+    const magnitude = filterMagnitude(
+      { ...defaults, lowCutHz: 20, highCutHz: 6000 },
+      6000,
+    )
+    expect(20 * Math.log10(magnitude)).toBeCloseTo(-3.01, 1)
+  })
+})
+
+describe('envelope', () => {
+  test('one tap time back is exactly one round-trip of gain', () => {
+    expect(envelopeAt(0.375, 0.375, 0.5)).toBeCloseTo(0.5, 9)
+    expect(envelopeAt(0.75, 0.375, 0.5)).toBeCloseTo(0.25, 9)
+  })
+
+  test('degenerate inputs do not produce NaN', () => {
+    expect(envelopeAt(0, 0.375, 0.5)).toBe(1)
+    expect(envelopeAt(1, 0, 0.5)).toBe(1)
+    expect(envelopeAt(1, 0.375, 0)).toBe(0)
+  })
+})

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/model.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/model.ts
@@ -1,0 +1,128 @@
+/**
+ * Analytic model of the repeat pattern the DSP produces, used to draw the echo
+ * display.
+ *
+ * Every constant here mirrors `src/lib.rs`; the display is a *derived picture
+ * of the current parameters*, not measured audio. Nothing in this file feeds
+ * the DSP — if a number drifts from Rust the display is wrong, which is why
+ * `model.test.ts` pins the constants against the Rust source.
+ */
+
+import type { Mode } from './params'
+import type { EchoParams } from './bridge'
+
+/** `echospace::MAX_FEEDBACK`. */
+export const MAX_FEEDBACK = 0.9995
+
+/** Which channel a repeat lands in. */
+export type Lane = 'left' | 'right'
+
+export type Tap = {
+  /** Arrival time in seconds after the dry signal. */
+  time: number
+  /** Linear amplitude relative to the dry signal. */
+  amplitude: number
+  /** Round-trip number; 1 is the first repeat. */
+  pass: number
+  lane: Lane
+}
+
+/**
+ * Round-trip gain, matching `process_stereo`.
+ *
+ * The two feedback paths are normalised by the cross amount so the loop gain
+ * stays `feedback` however much of it is routed across — mirroring the Rust,
+ * where summing them at full strength reached 1.96 and the line ran away.
+ */
+export function loopGain(params: EchoParams): number {
+  if (params.freeze) return MAX_FEEDBACK
+  return Math.min(params.feedback / 100, MAX_FEEDBACK)
+}
+
+/**
+ * Per-pass magnitude of the feedback path's filters at `hz`.
+ *
+ * The low and high cut are 2-pole Butterworth sections (`Q = 0.707`), so each
+ * has a magnitude of `1 / sqrt(1 + (f/fc)^4)` in its stopband direction. The
+ * display uses this to dull each successive repeat by the amount the real
+ * filters dull it.
+ */
+export function filterMagnitude(params: EchoParams, hz: number): number {
+  const lowRatio = hz / Math.max(params.lowCutHz, 1)
+  const highPass = lowRatio ** 2 / Math.sqrt(1 + lowRatio ** 4)
+  const lowPass = 1 / Math.sqrt(1 + (hz / Math.max(params.highCutHz, 1)) ** 4)
+  return highPass * lowPass
+}
+
+/** Delay time per channel in seconds, after the mode's routing. */
+export function tapTimes(params: EchoParams): { left: number; right: number } {
+  const left = params.timeMsL / 1000
+  const right = params.timeMsR / 1000
+  // Mono collapses both lines onto the left time — the DSP sums the input to
+  // mono and both rings read the same tap.
+  if (params.mode === 'mono') return { left, right: left }
+  return { left, right }
+}
+
+/**
+ * Which lane pass `pass` lands in.
+ *
+ * Ping-pong swaps the two feedback paths every round trip, so odd passes come
+ * back on the opposite side. Stereo and mono keep each line on its own side.
+ */
+export function laneFor(mode: Mode, pass: number, lane: Lane): Lane {
+  if (mode !== 'pingpong') return lane
+  const flipped: Lane = lane === 'left' ? 'right' : 'left'
+  return pass % 2 === 1 ? flipped : lane
+}
+
+export type EchoModel = {
+  taps: Tap[]
+  /** Time of the last audible repeat, in seconds. */
+  lastTime: number
+  /** Round-trip gain in use. */
+  gain: number
+  /** Number of repeats before the tail falls under `floor`. */
+  passes: number
+}
+
+/**
+ * The repeat pattern down to `floorDb`.
+ *
+ * Capped at `maxPasses` so a near-unity feedback (or freeze, which never
+ * decays) produces a bounded list instead of running until the float
+ * underflows.
+ */
+export function echoModel(
+  params: EchoParams,
+  floorDb = -60,
+  maxPasses = 64,
+): EchoModel {
+  const gain = loopGain(params)
+  const times = tapTimes(params)
+  const floor = 10 ** (floorDb / 20)
+  const taps: Tap[] = []
+  let lastTime = 0
+
+  for (const lane of ['left', 'right'] as const) {
+    const step = times[lane]
+    for (let pass = 1; pass <= maxPasses; pass++) {
+      const amplitude = gain ** pass
+      if (amplitude < floor) break
+      const time = step * pass
+      taps.push({ time, amplitude, pass, lane: laneFor(params.mode, pass, lane) })
+      lastTime = Math.max(lastTime, time)
+    }
+  }
+
+  taps.sort((a, b) => a.time - b.time)
+  const passes = taps.reduce((most, tap) => Math.max(most, tap.pass), 0)
+  return { taps, lastTime, gain, passes }
+}
+
+/** Amplitude of the feedback envelope at `t` seconds, for one lane's spacing. */
+export function envelopeAt(t: number, step: number, gain: number): number {
+  if (t <= 0 || step <= 0) return 1
+  if (gain <= 0) return 0
+  return gain ** (t / step)
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/params.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/params.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  MODES,
+  MODE_LABELS,
+  PARAMS,
+  format,
+  fromNorm,
+  modeFromWire,
+  modeToWire,
+  toNorm,
+  unitFor,
+  type ParamId,
+} from './params'
+import { IPC_RS, rustModeOrder, rustRanges, rustStringArray } from './rust'
+
+const rustIds = rustStringArray(IPC_RS, 'UI_PARAM_IDS')
+const rustRangeTable = rustRanges('RANGES')
+
+describe('the schema mirrors echospace::ipc', () => {
+  test('every editor param id exists in the Rust wire table', () => {
+    for (const id of Object.keys(PARAMS) as ParamId[]) {
+      expect(rustIds).toContain(id)
+    }
+  })
+
+  test('ranges match the Rust ranges exactly', () => {
+    for (const id of Object.keys(PARAMS) as ParamId[]) {
+      const spec = PARAMS[id]
+      const index = rustIds.indexOf(id)
+      const range = rustRangeTable[index]
+      expect(range, `no Rust range for ${id}`).toBeDefined()
+      expect([id, spec.min, spec.max]).toEqual([id, range![0], range![1]])
+      expect(spec.default).toBeGreaterThanOrEqual(spec.min)
+      expect(spec.default).toBeLessThanOrEqual(spec.max)
+    }
+  })
+
+  /**
+   * `power`, `mode` and `freeze` are not knobs, so they are absent from
+   * `PARAMS` on purpose — but nothing else may be.
+   */
+  test('only the non-continuous params are missing from the knob table', () => {
+    const missing = rustIds.filter((id) => !(id in PARAMS))
+    expect(missing.sort()).toEqual(['freeze', 'mode', 'power'])
+  })
+
+  test('mode order is the wire contract', () => {
+    expect(MODES.map(String)).toEqual(rustModeOrder())
+    for (const [index, mode] of MODES.entries()) {
+      expect(modeToWire(mode)).toBe(index)
+      expect(modeFromWire(index)).toBe(mode)
+      expect(MODE_LABELS[mode]).toBeTruthy()
+    }
+  })
+
+  test('an unknown mode wire value falls back to ping-pong, as Rust does', () => {
+    expect(modeFromWire(99)).toBe('pingpong')
+    expect(modeFromWire(-1)).toBe('pingpong')
+  })
+})
+
+describe('control tapers', () => {
+  test('every taper round-trips across its whole range', () => {
+    for (const id of Object.keys(PARAMS) as ParamId[]) {
+      const spec = PARAMS[id]
+      for (const t of [0, 0.13, 0.5, 0.87, 1]) {
+        const value = fromNorm(spec, t)
+        expect(value).toBeGreaterThanOrEqual(spec.min - 1e-6)
+        expect(value).toBeLessThanOrEqual(spec.max + 1e-6)
+        expect(toNorm(spec, value)).toBeCloseTo(t, 5)
+      }
+    }
+  })
+
+  test('out-of-range travel clamps instead of extrapolating', () => {
+    const spec = PARAMS.timeMsL
+    expect(fromNorm(spec, -3)).toBe(spec.min)
+    expect(fromNorm(spec, 4)).toBe(spec.max)
+    expect(toNorm(spec, -100)).toBe(0)
+    expect(toNorm(spec, 1e9)).toBe(1)
+  })
+
+  /** Exponential tapers must put the midpoint at the geometric mean — that is
+   *  the whole reason a delay time does not use a linear dial. */
+  test('time and frequency tapers are geometric', () => {
+    for (const spec of [PARAMS.timeMsL, PARAMS.highCutHz, PARAMS.lowCutHz]) {
+      expect(fromNorm(spec, 0.5)).toBeCloseTo(Math.sqrt(spec.min * spec.max), 3)
+    }
+  })
+})
+
+describe('readouts', () => {
+  test('delay times flip to seconds and frequencies to kHz', () => {
+    expect(format(PARAMS.timeMsL, 375)).toBe('375')
+    expect(unitFor(PARAMS.timeMsL, 375)).toBe('ms')
+    expect(format(PARAMS.timeMsL, 1500)).toBe('1.50')
+    expect(unitFor(PARAMS.timeMsL, 1500)).toBe('s')
+    expect(format(PARAMS.highCutHz, 9000)).toBe('9.00k')
+    expect(format(PARAMS.lowCutHz, 180)).toBe('180')
+  })
+
+  test('gains carry a sign', () => {
+    expect(format(PARAMS.outputDb, 3)).toBe('+3.0')
+    expect(format(PARAMS.outputDb, -6)).toBe('-6.0')
+  })
+
+  test('a value outside the range is displayed clamped, never as NaN', () => {
+    expect(format(PARAMS.mix, 1e9)).toBe('100')
+    expect(format(PARAMS.mix, -50)).toBe('0')
+  })
+})

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/params.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/params.ts
@@ -1,0 +1,168 @@
+/**
+ * Editor-side mirror of EchoSpace's parameter contract.
+ *
+ * Rust owns the authority: `src/ipc.rs` defines the ids and their ranges, and
+ * clamps every incoming value again. This table exists so the UI can lay out a
+ * control, choose a taper, and format a readout — never to decide what a value
+ * means. `params.test.ts` pins the ids and ranges against the Rust source.
+ */
+
+export type ParamId =
+  | 'timeMsL'
+  | 'timeMsR'
+  | 'feedback'
+  | 'crossFeedback'
+  | 'lowCutHz'
+  | 'highCutHz'
+  | 'saturation'
+  | 'mix'
+  | 'outputDb'
+
+/**
+ * How the 0..1 control travel maps onto the value range.
+ *
+ * - `lin` — uniform.
+ * - `exp` — constant ratio per unit travel; the only sane choice for a
+ *   frequency or a delay time, where the useful resolution is at the bottom.
+ * - a number — `value = min + (max - min) * t ** exponent`, for ranges that
+ *   want more resolution low down without being fully logarithmic.
+ */
+type Taper = 'lin' | 'exp' | number
+
+export type ParamSpec = {
+  id: ParamId
+  label: string
+  min: number
+  max: number
+  default: number
+  unit: string
+  taper: Taper
+  /** Readout precision in decimal places. */
+  digits: number
+  /** Arrow-key / wheel step, in value units. */
+  step: number
+  /**
+   * Value the dial fills *out from*. Defaults to `min`. Set it for controls
+   * with a real neutral point, so "no change" reads as an empty dial rather
+   * than a half-full one.
+   */
+  origin?: number
+}
+
+const spec = (
+  id: ParamId,
+  label: string,
+  min: number,
+  max: number,
+  def: number,
+  unit: string,
+  taper: Taper,
+  digits: number,
+  step: number,
+  origin?: number,
+): ParamSpec => ({
+  id,
+  label,
+  min,
+  max,
+  default: def,
+  unit,
+  taper,
+  digits,
+  step,
+  origin,
+})
+
+export const PARAMS: Record<ParamId, ParamSpec> = {
+  // Musical delay times live in the low hundreds of ms; an exponential taper
+  // keeps eighth-note territory off the very bottom of the travel.
+  timeMsL: spec('timeMsL', 'Time L', 1, 4000, 375, 'ms', 'exp', 0, 1),
+  timeMsR: spec('timeMsR', 'Time R', 1, 4000, 563, 'ms', 'exp', 0, 1),
+  feedback: spec('feedback', 'Feedback', 0, 98, 34, '%', 'lin', 0, 1),
+  crossFeedback: spec('crossFeedback', 'Cross', 0, 100, 65, '%', 'lin', 0, 1),
+  lowCutHz: spec('lowCutHz', 'Low Cut', 20, 2000, 180, 'Hz', 'exp', 0, 1),
+  highCutHz: spec('highCutHz', 'High Cut', 1000, 20000, 9000, 'Hz', 'exp', 0, 10),
+  saturation: spec('saturation', 'Saturation', 0, 100, 8, '%', 'lin', 0, 1),
+  mix: spec('mix', 'Mix', 0, 100, 20, '%', 'lin', 0, 1),
+  outputDb: spec('outputDb', 'Output', -24, 12, 0, 'dB', 'lin', 1, 0.5, 0),
+}
+
+export const MODES = ['stereo', 'pingpong', 'mono'] as const
+export type Mode = (typeof MODES)[number]
+
+export const MODE_LABELS: Record<Mode, string> = {
+  stereo: 'Stereo',
+  pingpong: 'Ping-Pong',
+  mono: 'Mono',
+}
+
+/** Wire value for `mode`; the index in [`MODES`] is the contract. */
+export function modeToWire(mode: Mode): number {
+  const index = MODES.indexOf(mode)
+  return index < 0 ? MODES.indexOf('pingpong') : index
+}
+
+export function modeFromWire(value: number): Mode {
+  return MODES[Math.round(value)] ?? 'pingpong'
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return value < min ? min : value > max ? max : value
+}
+
+/** Value -> 0..1 control travel. */
+export function toNorm(spec: ParamSpec, value: number): number {
+  const v = clamp(value, spec.min, spec.max)
+  if (spec.taper === 'exp') {
+    const lo = Math.log(Math.max(spec.min, 1e-6))
+    return (Math.log(Math.max(v, 1e-6)) - lo) / (Math.log(spec.max) - lo)
+  }
+  const t = (v - spec.min) / (spec.max - spec.min)
+  return spec.taper === 'lin' ? t : Math.pow(t, 1 / spec.taper)
+}
+
+/**
+ * 0..1 control travel -> value.
+ *
+ * The endpoints return `min`/`max` exactly rather than evaluating the taper:
+ * `exp(log(4000))` lands a few ulps *short* of 4000, so a knob at full travel
+ * would report 3999.9999999999995 ms and never quite reach its own maximum.
+ * The interior result is clamped too, so no taper can overshoot the range.
+ */
+export function fromNorm(spec: ParamSpec, norm: number): number {
+  const t = clamp(norm, 0, 1)
+  if (t <= 0) return spec.min
+  if (t >= 1) return spec.max
+  if (spec.taper === 'exp') {
+    const lo = Math.log(Math.max(spec.min, 1e-6))
+    return clamp(
+      Math.exp(lo + t * (Math.log(spec.max) - lo)),
+      spec.min,
+      spec.max,
+    )
+  }
+  const shaped = spec.taper === 'lin' ? t : Math.pow(t, spec.taper)
+  return clamp(spec.min + shaped * (spec.max - spec.min), spec.min, spec.max)
+}
+
+/** Readout text. Frequencies and delay times switch to a larger unit where the
+ * four-digit form stops scanning quickly. */
+export function format(spec: ParamSpec, value: number): string {
+  const v = clamp(value, spec.min, spec.max)
+  if (spec.unit === 'Hz' && v >= 1000) {
+    return `${(v / 1000).toFixed(v >= 10000 ? 1 : 2)}k`
+  }
+  if (spec.unit === 'ms' && v >= 1000) {
+    return `${(v / 1000).toFixed(2)}`
+  }
+  if (spec.unit === 'dB' && v > 0) {
+    return `+${v.toFixed(spec.digits)}`
+  }
+  return v.toFixed(spec.digits)
+}
+
+/** Unit shown next to the readout — delay times flip to seconds past 1000 ms. */
+export function unitFor(spec: ParamSpec, value: number): string {
+  if (spec.unit === 'ms' && clamp(value, spec.min, spec.max) >= 1000) return 's'
+  return spec.unit
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/presets.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/presets.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  DEFAULT_PARAMS,
+  FACTORY_PRESETS,
+  matchingPresetIndex,
+  paramsMatch,
+} from './presets'
+import { PARAMS } from './params'
+
+describe('factory presets', () => {
+  test('Default mirrors the schema defaults', () => {
+    expect(FACTORY_PRESETS[0]?.name).toBe('Default')
+    expect(paramsMatch(FACTORY_PRESETS[0]!.params, DEFAULT_PARAMS)).toBe(true)
+    for (const id of Object.keys(PARAMS) as (keyof typeof PARAMS)[]) {
+      expect(DEFAULT_PARAMS[id]).toBe(PARAMS[id].default)
+    }
+  })
+
+  test('every preset stays inside the schema ranges', () => {
+    for (const entry of FACTORY_PRESETS) {
+      for (const id of Object.keys(PARAMS) as (keyof typeof PARAMS)[]) {
+        const spec = PARAMS[id]
+        const value = entry.params[id]
+        expect(value).toBeGreaterThanOrEqual(spec.min)
+        expect(value).toBeLessThanOrEqual(spec.max)
+      }
+      expect(entry.params.power).toBe(true)
+      expect(entry.params.freeze).toBe(false)
+    }
+  })
+
+  test('matchingPresetIndex recognizes Default and rejects edits', () => {
+    expect(matchingPresetIndex(DEFAULT_PARAMS)).toBe(0)
+    expect(
+      matchingPresetIndex({ ...DEFAULT_PARAMS, mix: DEFAULT_PARAMS.mix + 1 }),
+    ).toBeNull()
+  })
+})

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/presets.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/presets.ts
@@ -1,0 +1,159 @@
+/**
+ * Factory presets for EchoSpace.
+ *
+ * These are editor-side starting points that push real parameter values through
+ * the existing bridge. Rust still clamps and owns DSP state — presets never
+ * invent controls or bypass the wire contract.
+ */
+
+import { postParam, type EchoParams } from './bridge'
+import { PARAMS, modeToWire, type ParamId } from './params'
+
+export const DEFAULT_PARAMS: EchoParams = {
+  power: true,
+  mode: 'pingpong',
+  timeMsL: PARAMS.timeMsL.default,
+  timeMsR: PARAMS.timeMsR.default,
+  feedback: PARAMS.feedback.default,
+  crossFeedback: PARAMS.crossFeedback.default,
+  lowCutHz: PARAMS.lowCutHz.default,
+  highCutHz: PARAMS.highCutHz.default,
+  saturation: PARAMS.saturation.default,
+  mix: PARAMS.mix.default,
+  outputDb: PARAMS.outputDb.default,
+  freeze: false,
+}
+
+export type FactoryPreset = {
+  name: string
+  params: EchoParams
+}
+
+function preset(name: string, patch: Partial<EchoParams>): FactoryPreset {
+  return {
+    name,
+    params: { ...DEFAULT_PARAMS, ...patch, power: true, freeze: false },
+  }
+}
+
+export const FACTORY_PRESETS: FactoryPreset[] = [
+  preset('Default', {}),
+  preset('Slapback', {
+    mode: 'mono',
+    timeMsL: 96,
+    timeMsR: 96,
+    feedback: 8,
+    crossFeedback: 0,
+    lowCutHz: 220,
+    highCutHz: 7000,
+    saturation: 18,
+    mix: 24,
+  }),
+  preset('Quarter Ping', {
+    mode: 'pingpong',
+    timeMsL: 500,
+    timeMsR: 500,
+    feedback: 38,
+    crossFeedback: 80,
+    lowCutHz: 160,
+    highCutHz: 10000,
+    saturation: 6,
+    mix: 26,
+  }),
+  preset('Dotted Eighth', {
+    mode: 'pingpong',
+    timeMsL: 375,
+    timeMsR: 250,
+    feedback: 32,
+    crossFeedback: 70,
+    lowCutHz: 200,
+    highCutHz: 11000,
+    saturation: 4,
+    mix: 22,
+  }),
+  preset('Tape Echo', {
+    mode: 'stereo',
+    timeMsL: 320,
+    timeMsR: 340,
+    feedback: 52,
+    crossFeedback: 25,
+    lowCutHz: 260,
+    highCutHz: 4200,
+    saturation: 62,
+    mix: 30,
+    outputDb: -1.5,
+  }),
+  preset('Dub Space', {
+    mode: 'pingpong',
+    timeMsL: 620,
+    timeMsR: 930,
+    feedback: 74,
+    crossFeedback: 95,
+    lowCutHz: 320,
+    highCutHz: 3200,
+    saturation: 48,
+    mix: 38,
+  }),
+  preset('Wide Doubler', {
+    mode: 'stereo',
+    timeMsL: 28,
+    timeMsR: 41,
+    feedback: 0,
+    crossFeedback: 0,
+    lowCutHz: 140,
+    highCutHz: 14000,
+    saturation: 0,
+    mix: 42,
+  }),
+  preset('Ambient Wash', {
+    mode: 'pingpong',
+    timeMsL: 1200,
+    timeMsR: 1800,
+    feedback: 82,
+    crossFeedback: 88,
+    lowCutHz: 240,
+    highCutHz: 5200,
+    saturation: 22,
+    mix: 45,
+    outputDb: -2,
+  }),
+]
+
+const NUMERIC_IDS = Object.keys(PARAMS) as ParamId[]
+
+export function paramsMatch(left: EchoParams, right: EchoParams) {
+  if (
+    left.power !== right.power ||
+    left.freeze !== right.freeze ||
+    left.mode !== right.mode
+  ) {
+    return false
+  }
+  // Delay times and cut frequencies travel through an exponential taper, so
+  // compare them proportionally; a 0.05 absolute window would call 1200 ms and
+  // 1800 ms a match on nothing but rounding.
+  return NUMERIC_IDS.every((id) => {
+    const tolerance =
+      PARAMS[id].taper === 'exp'
+        ? Math.max(Math.abs(right[id]) * 0.002, 0.05)
+        : 0.05
+    return Math.abs(left[id] - right[id]) < tolerance
+  })
+}
+
+export function matchingPresetIndex(params: EchoParams) {
+  const index = FACTORY_PRESETS.findIndex((entry) =>
+    paramsMatch(params, entry.params),
+  )
+  return index >= 0 ? index : null
+}
+
+/** Whole-state push; the bridge coalesces into one `setParams` per frame. */
+export function postAllParams(params: EchoParams) {
+  postParam('power', params.power ? 1 : 0)
+  postParam('mode', modeToWire(params.mode))
+  for (const id of NUMERIC_IDS) {
+    postParam(id, params[id])
+  }
+  postParam('freeze', params.freeze ? 1 : 0)
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/rust.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/rust.ts
@@ -1,0 +1,77 @@
+/**
+ * Test-only readers for the Rust source of truth.
+ *
+ * The editor duplicates a handful of Rust constants — parameter ids, ranges,
+ * and the tank geometry the decay display draws. Duplication is unavoidable
+ * (the editor is a separate bundle), so the tests parse the real `.rs` files
+ * and compare, which turns a silent drift into a failing check.
+ *
+ * Not imported by the app; kept out of the bundle by having no runtime caller.
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const read = (relative: string) =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8')
+
+export const LIB_RS = read('../../src/lib.rs')
+export const IPC_RS = read('../../src/ipc.rs')
+
+/** Rust float literals allow `_` separators; JS `Number` does not. */
+function num(literal: string): number {
+  return Number(literal.replace(/_/g, ''))
+}
+
+/** The body of `<name>: <type> = [ ... ];`. */
+function arrayBody(source: string, name: string): string {
+  const match = new RegExp(
+    `(?:pub )?const ${name}\\s*:[^=]+=\\s*\\[([\\s\\S]*?)\\];`,
+  ).exec(source)
+  if (!match?.[1]) throw new Error(`${name} not found in Rust source`)
+  return match[1]
+}
+
+/** `pub const NAME: f32 = 500.0;` */
+export function rustScalar(source: string, name: string): number {
+  const match = new RegExp(
+    `(?:pub )?const ${name}\\s*:\\s*f32\\s*=\\s*([0-9_.]+)\\s*;`,
+  ).exec(source)
+  if (!match?.[1]) throw new Error(`${name} not found in Rust source`)
+  return num(match[1])
+}
+
+export function rustFloatArray(source: string, name: string): number[] {
+  return arrayBody(source, name)
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map(num)
+}
+
+/** `UI_PARAM_IDS` — the quoted strings, in order. */
+export function rustStringArray(source: string, name: string): string[] {
+  return Array.from(arrayBody(source, name).matchAll(/"([^"]*)"/g), (m) => m[1]!)
+}
+
+/**
+ * `RANGES` — `(min, max), // comment` tuples, in order. Identifiers are
+ * resolved against `lib.rs` scalars so `MAX_PREDELAY_MS` reads as 500.
+ */
+export function rustRanges(name: string): [number, number][] {
+  const resolve = (token: string) =>
+    /^[-0-9]/.test(token) ? num(token) : rustScalar(LIB_RS, token)
+  return Array.from(
+    arrayBody(IPC_RS, name).matchAll(/\(\s*([^,\s]+)\s*,\s*([^)\s]+)\s*\)/g),
+    (m) => [resolve(m[1]!), resolve(m[2]!)] as [number, number],
+  )
+}
+
+/** Variant order of `enum DelayMode`, which is the `to_wire` contract. */
+export function rustModeOrder(): string[] {
+  const match = /pub enum DelayMode \{([\s\S]*?)\n\}/.exec(LIB_RS)
+  if (!match?.[1]) throw new Error('enum DelayMode not found')
+  return Array.from(match[1].matchAll(/^\s{4}(\w+),/gm), (m) =>
+    m[1]!.toLowerCase(),
+  )
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/svelte.config.js
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+export default {
+  preprocess: vitePreprocess(),
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/tsconfig.json
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "types": ["bun", "svelte", "vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "vite.config.ts"]
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/vite.config.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { viteSingleFile } from 'vite-plugin-singlefile'
+import { fileURLToPath } from 'node:url'
+
+// The editor is embedded into the plugin library as a single, fully
+// self-contained `index.html` (JS/CSS inlined). It is served to CEF through the
+// `mikoplugin://echospace/index.html` custom scheme, so there must be no
+// sibling asset requests and no network fetch at runtime.
+export default defineConfig({
+  // Pin the root to this config's own URL: the checkout may be reached through
+  // more than one path, and a relative root makes Vite emit index.html as an
+  // absolute asset reference the custom scheme cannot resolve.
+  root: fileURLToPath(new URL('.', import.meta.url)),
+  plugins: [svelte(), viteSingleFile()],
+  build: {
+    target: 'chrome120',
+    assetsInlineLimit: Infinity,
+    cssCodeSplit: false,
+  },
+})

--- a/crates/BuiltinAudioPlugins/crates/echospace/src/ipc.rs
+++ b/crates/BuiltinAudioPlugins/crates/echospace/src/ipc.rs
@@ -1,0 +1,264 @@
+//! Stable editor/DSP parameter wire contract for EchoSpace.
+//!
+//! String ids live at the UI/control boundary only. The native host resolves
+//! them to compact indices before publishing edits to an audio-side bounded
+//! queue; [`Dsp::apply_wire_param`](crate::Dsp::apply_wire_param) consumes the
+//! numeric form without allocation, serialization, locking, or string lookup.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{DelayMode, MAX_DELAY_MS, Params, clamp, default_params};
+
+pub const PROTOCOL_VERSION: u32 = 1;
+pub const STATE_VERSION: u32 = 1;
+
+pub const POWER_INDEX: u32 = 0;
+pub const MODE_INDEX: u32 = 1;
+pub const TIME_L_INDEX: u32 = 2;
+pub const TIME_R_INDEX: u32 = 3;
+pub const FEEDBACK_INDEX: u32 = 4;
+pub const CROSS_INDEX: u32 = 5;
+pub const LOW_CUT_INDEX: u32 = 6;
+pub const HIGH_CUT_INDEX: u32 = 7;
+pub const SATURATION_INDEX: u32 = 8;
+pub const MIX_INDEX: u32 = 9;
+pub const OUTPUT_INDEX: u32 = 10;
+pub const FREEZE_INDEX: u32 = 11;
+
+pub const PARAM_COUNT: usize = 12;
+
+/// Wire index *is* the position in this table; the editor and the host both
+/// resolve through it, so the order is part of the persisted contract. Append
+/// only.
+pub const UI_PARAM_IDS: [&str; PARAM_COUNT] = [
+    "power",
+    "mode",
+    "timeMsL",
+    "timeMsR",
+    "feedback",
+    "crossFeedback",
+    "lowCutHz",
+    "highCutHz",
+    "saturation",
+    "mix",
+    "outputDb",
+    "freeze",
+];
+
+/// Inclusive `(min, max)` for every continuous parameter, indexed by wire
+/// index. Booleans and the mode enum carry `(0, 0)` and are handled by their
+/// own arms in [`apply_wire_param`]. Single source of truth for clamping, so
+/// [`sanitize_params`] and the wire path cannot drift apart.
+const RANGES: [(f32, f32); PARAM_COUNT] = [
+    (0.0, 0.0),          // power
+    (0.0, 0.0),          // mode
+    (1.0, MAX_DELAY_MS), // timeMsL
+    (1.0, MAX_DELAY_MS), // timeMsR
+    (0.0, 98.0),         // feedback
+    (0.0, 100.0),        // crossFeedback
+    (20.0, 2_000.0),     // lowCutHz
+    (1_000.0, 20_000.0), // highCutHz
+    (0.0, 100.0),        // saturation
+    (0.0, 100.0),        // mix
+    (-24.0, 12.0),       // outputDb
+    (0.0, 0.0),          // freeze
+];
+
+#[inline]
+fn clamp_wire(index: u32, value: f32) -> f32 {
+    let (min, max) = RANGES[index as usize];
+    clamp(value, min, max)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EchospaceState {
+    pub version: u32,
+    pub params: Params,
+}
+
+impl EchospaceState {
+    pub fn new(params: Params) -> Self {
+        Self {
+            version: STATE_VERSION,
+            params,
+        }
+    }
+
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+}
+
+impl Default for EchospaceState {
+    fn default() -> Self {
+        Self::new(default_params())
+    }
+}
+
+pub fn ui_param_index(id: &str) -> Option<u32> {
+    UI_PARAM_IDS
+        .iter()
+        .position(|candidate| *candidate == id)
+        .map(|index| index as u32)
+}
+
+pub fn ui_param_id(index: u32) -> Option<&'static str> {
+    UI_PARAM_IDS.get(index as usize).copied()
+}
+
+/// Clamp a whole `Params` into range. Used after deserializing a project blob,
+/// which may predate a range change or have been edited by hand.
+pub fn sanitize_params(params: &mut Params) {
+    params.time_ms_l = clamp_wire(TIME_L_INDEX, params.time_ms_l);
+    params.time_ms_r = clamp_wire(TIME_R_INDEX, params.time_ms_r);
+    params.feedback = clamp_wire(FEEDBACK_INDEX, params.feedback);
+    params.cross_feedback = clamp_wire(CROSS_INDEX, params.cross_feedback);
+    params.low_cut_hz = clamp_wire(LOW_CUT_INDEX, params.low_cut_hz);
+    params.high_cut_hz = clamp_wire(HIGH_CUT_INDEX, params.high_cut_hz);
+    params.saturation = clamp_wire(SATURATION_INDEX, params.saturation);
+    params.mix = clamp_wire(MIX_INDEX, params.mix);
+    params.output_db = clamp_wire(OUTPUT_INDEX, params.output_db);
+}
+
+/// Apply one compact UI/control update. Allocation-free and total: invalid
+/// indices are rejected, non-finite values are rejected, and every continuous
+/// value is clamped to its declared range.
+pub fn apply_wire_param(params: &mut Params, index: u32, value: f32) -> bool {
+    if !value.is_finite() || index as usize >= PARAM_COUNT {
+        return false;
+    }
+    match index {
+        POWER_INDEX => params.power = value >= 0.5,
+        MODE_INDEX => params.mode = DelayMode::from_wire(value),
+        FREEZE_INDEX => params.freeze = value >= 0.5,
+        TIME_L_INDEX => params.time_ms_l = clamp_wire(index, value),
+        TIME_R_INDEX => params.time_ms_r = clamp_wire(index, value),
+        FEEDBACK_INDEX => params.feedback = clamp_wire(index, value),
+        CROSS_INDEX => params.cross_feedback = clamp_wire(index, value),
+        LOW_CUT_INDEX => params.low_cut_hz = clamp_wire(index, value),
+        HIGH_CUT_INDEX => params.high_cut_hz = clamp_wire(index, value),
+        SATURATION_INDEX => params.saturation = clamp_wire(index, value),
+        MIX_INDEX => params.mix = clamp_wire(index, value),
+        OUTPUT_INDEX => params.output_db = clamp_wire(index, value),
+        _ => return false,
+    }
+    true
+}
+
+/// Resolve a string id off the realtime path and apply it to a state mirror.
+pub fn apply_ui_param(params: &mut Params, id: &str, value: f32) -> bool {
+    let Some(index) = ui_param_index(id) else {
+        return false;
+    };
+    apply_wire_param(params, index, value)
+}
+
+/// Every parameter as `(id, raw value)`, in wire order. Drives project replay
+/// and the descriptor-vs-defaults check.
+pub fn ui_values(params: &Params) -> Vec<(&'static str, f32)> {
+    vec![
+        ("power", f32::from(params.power)),
+        ("mode", params.mode.to_wire()),
+        ("timeMsL", params.time_ms_l),
+        ("timeMsR", params.time_ms_r),
+        ("feedback", params.feedback),
+        ("crossFeedback", params.cross_feedback),
+        ("lowCutHz", params.low_cut_hz),
+        ("highCutHz", params.high_cut_hz),
+        ("saturation", params.saturation),
+        ("mix", params.mix),
+        ("outputDb", params.output_db),
+        ("freeze", f32::from(params.freeze)),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_round_trip_to_wire_indices() {
+        assert_eq!(UI_PARAM_IDS.len(), PARAM_COUNT);
+        for (index, id) in UI_PARAM_IDS.iter().enumerate() {
+            assert_eq!(ui_param_index(id), Some(index as u32));
+            assert_eq!(ui_param_id(index as u32), Some(*id));
+        }
+    }
+
+    /// `ui_values` is what project replay pushes back through the wire, so a
+    /// missing or misordered entry would silently drop a parameter on reload.
+    #[test]
+    fn ui_values_covers_every_id_in_wire_order() {
+        let values = ui_values(&default_params());
+        assert_eq!(values.len(), PARAM_COUNT);
+        for (index, (id, _)) in values.iter().enumerate() {
+            assert_eq!(*id, UI_PARAM_IDS[index]);
+        }
+    }
+
+    #[test]
+    fn state_round_trips() {
+        let mut params = default_params();
+        assert!(apply_ui_param(&mut params, "timeMsL", 250.0));
+        assert!(apply_ui_param(
+            &mut params,
+            "mode",
+            DelayMode::Mono.to_wire()
+        ));
+        let json = EchospaceState::new(params).to_json().unwrap();
+        let decoded = EchospaceState::from_json(&json).unwrap();
+        assert_eq!(decoded.params.time_ms_l, 250.0);
+        assert_eq!(decoded.params.mode, DelayMode::Mono);
+        assert_eq!(decoded.version, STATE_VERSION);
+    }
+
+    #[test]
+    fn out_of_range_values_are_clamped_not_rejected() {
+        let mut params = default_params();
+        assert!(apply_ui_param(&mut params, "timeMsL", 99_000.0));
+        assert_eq!(params.time_ms_l, MAX_DELAY_MS);
+        // The feedback ceiling is below 100 % on purpose — the delay line is a
+        // feedback loop and unity would never decay.
+        assert!(apply_ui_param(&mut params, "feedback", 100.0));
+        assert_eq!(params.feedback, 98.0);
+    }
+
+    #[test]
+    fn invalid_and_non_finite_updates_are_rejected() {
+        let mut params = default_params();
+        assert!(!apply_wire_param(&mut params, u32::MAX, 1.0));
+        assert!(!apply_wire_param(&mut params, PARAM_COUNT as u32, 1.0));
+        assert!(!apply_wire_param(&mut params, TIME_L_INDEX, f32::NAN));
+        assert!(!apply_wire_param(&mut params, TIME_L_INDEX, f32::INFINITY));
+        assert!(!apply_ui_param(&mut params, "notAParam", 1.0));
+    }
+
+    /// A blob written by an older build (or edited by hand) must not reach the
+    /// DSP with values the coefficient math cannot survive.
+    #[test]
+    fn sanitize_pulls_a_hand_edited_blob_back_into_range() {
+        let mut params = default_params();
+        params.time_ms_l = -20.0;
+        params.feedback = 400.0;
+        params.high_cut_hz = 96_000.0;
+        params.output_db = 60.0;
+        sanitize_params(&mut params);
+        assert_eq!(params.time_ms_l, 1.0);
+        assert_eq!(params.feedback, 98.0);
+        assert_eq!(params.high_cut_hz, 20_000.0);
+        assert_eq!(params.output_db, 12.0);
+    }
+
+    #[test]
+    fn mode_wire_values_round_trip() {
+        for mode in [DelayMode::Stereo, DelayMode::PingPong, DelayMode::Mono] {
+            assert_eq!(DelayMode::from_wire(mode.to_wire()), mode);
+            assert_eq!(DelayMode::parse(mode.as_str()), Some(mode));
+        }
+    }
+}

--- a/crates/BuiltinAudioPlugins/crates/echospace/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/echospace/src/lib.rs
@@ -8,19 +8,71 @@ use builtin_dsp_core::{
     ParamDescriptor, PluginCategory, PluginDescriptor, StereoEffect, clamp, db_to_linear,
     make_eq_biquad, mix,
 };
+use serde::{Deserialize, Serialize};
+
+pub mod ipc;
+pub mod ui;
+
+/// Editor-facing parameter id table, re-exported at the crate root so the host
+/// resolves ids the same way for every built-in (`<plugin>::ui_param_index`).
+pub use ipc::{UI_PARAM_IDS, ui_param_id, ui_param_index};
 
 pub const PLUGIN_ID: &str = "futureboard.echospace";
-const MAX_DELAY_MS: f32 = 4_000.0;
-const MAX_DELAY_SAMPLES: usize = 192_000; // 4s @ 48k; clamped per sample-rate
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Longest delay either line can be set to. The rings are sized for this at the
+/// current sample rate, so a time edit only moves a read offset.
+pub const MAX_DELAY_MS: f32 = 4_000.0;
+
+/// Feedback ceiling. The delay line is a feedback loop: at exactly 1.0 it never
+/// decays, and with the cross-feed sum below it can only be held short of unity
+/// by the saturator — which the user is allowed to turn off.
+const MAX_FEEDBACK: f32 = 0.9995;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum DelayMode {
     Stereo,
     PingPong,
     Mono,
 }
 
-#[derive(Debug, Clone)]
+impl DelayMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Stereo => "stereo",
+            Self::PingPong => "pingpong",
+            Self::Mono => "mono",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "stereo" => Some(Self::Stereo),
+            "pingpong" | "ping-pong" => Some(Self::PingPong),
+            "mono" => Some(Self::Mono),
+            _ => None,
+        }
+    }
+
+    pub const fn to_wire(self) -> f32 {
+        match self {
+            Self::Stereo => 0.0,
+            Self::PingPong => 1.0,
+            Self::Mono => 2.0,
+        }
+    }
+
+    pub fn from_wire(value: f32) -> Self {
+        match value.round() as i32 {
+            0 => Self::Stereo,
+            2 => Self::Mono,
+            _ => Self::PingPong,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Params {
     pub power: bool,
     pub mode: DelayMode,
@@ -70,6 +122,14 @@ pub fn descriptor() -> PluginDescriptor {
                 unit: "bool",
             },
             ParamDescriptor {
+                id: "mode",
+                name: "Mode",
+                default_value: 1.0,
+                min: 0.0,
+                max: 2.0,
+                unit: "enum",
+            },
+            ParamDescriptor {
                 id: "timeMsL",
                 name: "Time L",
                 default_value: 375.0,
@@ -94,12 +154,60 @@ pub fn descriptor() -> PluginDescriptor {
                 unit: "%",
             },
             ParamDescriptor {
+                id: "crossFeedback",
+                name: "Cross",
+                default_value: 65.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+            ParamDescriptor {
+                id: "lowCutHz",
+                name: "Low Cut",
+                default_value: 180.0,
+                min: 20.0,
+                max: 2_000.0,
+                unit: "Hz",
+            },
+            ParamDescriptor {
+                id: "highCutHz",
+                name: "High Cut",
+                default_value: 9_000.0,
+                min: 1_000.0,
+                max: 20_000.0,
+                unit: "Hz",
+            },
+            ParamDescriptor {
+                id: "saturation",
+                name: "Saturation",
+                default_value: 8.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+            ParamDescriptor {
                 id: "mix",
                 name: "Mix",
                 default_value: 20.0,
                 min: 0.0,
                 max: 100.0,
                 unit: "%",
+            },
+            ParamDescriptor {
+                id: "outputDb",
+                name: "Output",
+                default_value: 0.0,
+                min: -24.0,
+                max: 12.0,
+                unit: "dB",
+            },
+            ParamDescriptor {
+                id: "freeze",
+                name: "Freeze",
+                default_value: 0.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
             },
         ],
     }
@@ -157,9 +265,18 @@ pub struct Dsp {
 }
 
 impl Dsp {
+    /// Ring length for the longest reachable delay at `sample_rate`.
+    ///
+    /// Derived from the rate rather than a fixed sample count: a constant sized
+    /// for 48 kHz silently caps `timeMs` at 2 s once the engine runs at 96 kHz,
+    /// so the editor would offer 4 s that the DSP could not deliver.
+    fn ring_capacity(sample_rate: f32) -> usize {
+        ((sample_rate * MAX_DELAY_MS * 0.001).ceil() as usize).max(2) + 2
+    }
+
     pub fn new(sample_rate: f32) -> Self {
         let sr = sample_rate.max(1.0);
-        let capacity = ((sr * MAX_DELAY_MS * 0.001) as usize).clamp(1, MAX_DELAY_SAMPLES);
+        let capacity = Self::ring_capacity(sr);
         let mut dsp = Self {
             sample_rate: sr,
             params: default_params(),
@@ -182,28 +299,60 @@ impl Dsp {
     }
 
     pub fn set_params(&mut self, params: Params) {
-        self.params = Params {
-            power: params.power,
-            mode: params.mode,
-            time_ms_l: clamp(params.time_ms_l, 1.0, MAX_DELAY_MS),
-            time_ms_r: clamp(params.time_ms_r, 1.0, MAX_DELAY_MS),
-            feedback: clamp(params.feedback, 0.0, 98.0),
-            cross_feedback: clamp(params.cross_feedback, 0.0, 100.0),
-            low_cut_hz: clamp(params.low_cut_hz, 20.0, 2_000.0),
-            high_cut_hz: clamp(params.high_cut_hz, 1_000.0, 20_000.0),
-            saturation: clamp(params.saturation, 0.0, 100.0),
-            mix: clamp(params.mix, 0.0, 100.0),
-            output_db: clamp(params.output_db, -24.0, 12.0),
-            freeze: params.freeze,
-        };
+        self.params = params;
+        ipc::sanitize_params(&mut self.params);
         self.apply_params();
     }
 
-    fn apply_params(&mut self) {
-        self.delay_samples_l = ((self.params.time_ms_l * 0.001 * self.sample_rate) as usize).max(1);
-        self.delay_samples_r = ((self.params.time_ms_r * 0.001 * self.sample_rate) as usize).max(1);
-        self.output_gain = db_to_linear(self.params.output_db);
+    /// Apply a compact wire update already resolved by the UI/control thread.
+    ///
+    /// The audio path never parses JSON or looks up string parameter ids. Every
+    /// arm below only recomputes derived scalars or biquad coefficients, so this
+    /// stays allocation-free and safe to call from the producer thread between
+    /// blocks.
+    pub fn apply_wire_param(&mut self, wire_index: u32, value: f32) -> bool {
+        if !ipc::apply_wire_param(&mut self.params, wire_index, value) {
+            return false;
+        }
+        match wire_index {
+            ipc::LOW_CUT_INDEX | ipc::HIGH_CUT_INDEX => self.rebuild_filters(),
+            ipc::TIME_L_INDEX | ipc::TIME_R_INDEX | ipc::OUTPUT_INDEX => self.apply_scalars(),
+            // Feedback, cross, saturation, mix, mode and the two flags are read
+            // straight off `params` in `process_stereo`; nothing to recompute.
+            _ => {}
+        }
+        true
+    }
 
+    /// Resolve a string id off the realtime path (project restore, tests).
+    pub fn apply_ui_param(&mut self, id: &str, value: f32) -> bool {
+        match ipc::ui_param_index(id) {
+            Some(index) => self.apply_wire_param(index, value),
+            None => false,
+        }
+    }
+
+    /// EchoSpace introduces no lookahead: the delay time is a musical
+    /// parameter, not a processing latency the graph should compensate for.
+    pub fn latency_samples(&self) -> usize {
+        0
+    }
+
+    fn apply_params(&mut self) {
+        self.apply_scalars();
+        self.rebuild_filters();
+    }
+
+    fn apply_scalars(&mut self) {
+        let max_delay = self.delay_l.buffer.len().saturating_sub(2).max(1);
+        self.delay_samples_l =
+            ((self.params.time_ms_l * 0.001 * self.sample_rate) as usize).clamp(1, max_delay);
+        self.delay_samples_r =
+            ((self.params.time_ms_r * 0.001 * self.sample_rate) as usize).clamp(1, max_delay);
+        self.output_gain = db_to_linear(self.params.output_db);
+    }
+
+    fn rebuild_filters(&mut self) {
         let hpf = make_eq_biquad(
             "highpass",
             self.params.low_cut_hz,
@@ -270,7 +419,10 @@ impl StereoEffect for Dsp {
 
     fn set_sample_rate(&mut self, sample_rate: f32) {
         let sr = sample_rate.max(1.0);
-        let capacity = ((sr * MAX_DELAY_MS * 0.001) as usize).clamp(1, MAX_DELAY_SAMPLES);
+        if (sr - self.sample_rate).abs() < f32::EPSILON {
+            return;
+        }
+        let capacity = Self::ring_capacity(sr);
         self.sample_rate = sr;
         self.delay_l = DelayLine::new(capacity);
         self.delay_r = DelayLine::new(capacity);
@@ -286,12 +438,17 @@ impl StereoEffect for Dsp {
         let delayed_r = self.delay_r.read(self.delay_samples_r);
 
         let fb = if self.params.freeze {
-            1.0
+            MAX_FEEDBACK
         } else {
             self.params.feedback / 100.0
         };
         let xfb = self.params.cross_feedback / 100.0;
         let sat = self.params.saturation / 100.0;
+        // Normalising by the cross amount keeps the round-trip gain at `fb`
+        // however much of it is routed across. Summing the two paths at full
+        // strength reaches 1.96 at the maximum settings, and with saturation at
+        // 0 — which the user is free to do — nothing else bounds the line.
+        let fb_norm = fb / (1.0 + xfb);
 
         let (in_l, in_r) = match self.params.mode {
             DelayMode::Mono => {
@@ -301,8 +458,8 @@ impl StereoEffect for Dsp {
             DelayMode::Stereo | DelayMode::PingPong => (left, right),
         };
 
-        let mut fb_l = delayed_l * fb + delayed_r * xfb * fb;
-        let mut fb_r = delayed_r * fb + delayed_l * xfb * fb;
+        let mut fb_l = (delayed_l + delayed_r * xfb) * fb_norm;
+        let mut fb_r = (delayed_r + delayed_l * xfb) * fb_norm;
         if self.params.mode == DelayMode::PingPong {
             // Swap cross paths for classic ping-pong bounce.
             std::mem::swap(&mut fb_l, &mut fb_r);
@@ -333,6 +490,51 @@ mod tests {
     use super::*;
 
     #[test]
+    fn descriptor_ids_are_unique_and_match_defaults() {
+        let d = descriptor();
+        assert_eq!(d.id, PLUGIN_ID);
+        assert_eq!(d.category, PluginCategory::Effect);
+
+        let mut ids: Vec<_> = d.params.iter().map(|p| p.id).collect();
+        let count = ids.len();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(count, ids.len(), "duplicate parameter id in descriptor");
+
+        let defaults = ipc::ui_values(&default_params());
+        for param in d.params {
+            let (_, actual) = defaults
+                .iter()
+                .find(|(id, _)| *id == param.id)
+                .copied()
+                .unwrap_or_else(|| panic!("`{}` is missing from ui_values", param.id));
+            assert!(
+                (param.default_value - actual).abs() < 1.0e-6,
+                "`{}`: descriptor says {}, default_params() says {actual}",
+                param.id,
+                param.default_value,
+            );
+            assert!(
+                param.default_value >= param.min && param.default_value <= param.max,
+                "`{}`: default {} is outside {}..{}",
+                param.id,
+                param.default_value,
+                param.min,
+                param.max,
+            );
+        }
+    }
+
+    #[test]
+    fn bypass_when_power_off() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.power = false;
+        dsp.set_params(params);
+        assert_eq!(dsp.process_stereo(0.25, -0.25), (0.25, -0.25));
+    }
+
+    #[test]
     fn delay_produces_echo() {
         let mut dsp = Dsp::new(48_000.0);
         let mut params = default_params();
@@ -351,5 +553,182 @@ mod tests {
             heard = heard.max(l.abs());
         }
         assert!(heard > 0.1);
+    }
+
+    /// The echo must land at the requested time, not at whatever the ring
+    /// happens to be long enough for. Sizing the buffer with a fixed sample
+    /// count silently capped this at 2 s once the engine ran at 96 kHz.
+    #[test]
+    fn the_longest_delay_is_reachable_at_every_rate() {
+        for &sr in &[44_100.0f32, 48_000.0, 96_000.0, 192_000.0] {
+            let mut dsp = Dsp::new(sr);
+            let mut params = default_params();
+            params.time_ms_l = MAX_DELAY_MS;
+            params.time_ms_r = MAX_DELAY_MS;
+            params.feedback = 0.0;
+            params.mix = 100.0;
+            params.mode = DelayMode::Stereo;
+            dsp.set_params(params);
+
+            let expected = (MAX_DELAY_MS * 0.001 * sr) as usize;
+            let _ = dsp.process_stereo(1.0, 1.0);
+
+            // Nothing before the tap...
+            let mut early = 0.0f32;
+            for _ in 0..(expected - 16) {
+                let (l, _) = dsp.process_stereo(0.0, 0.0);
+                early = early.max(l.abs());
+            }
+            assert!(early < 1.0e-4, "echo arrived early at {sr} Hz: {early}");
+
+            // ...and the impulse right at it.
+            let mut heard = 0.0f32;
+            for _ in 0..32 {
+                let (l, _) = dsp.process_stereo(0.0, 0.0);
+                heard = heard.max(l.abs());
+            }
+            assert!(heard > 0.5, "no echo at {sr} Hz after {expected} samples");
+        }
+    }
+
+    /// Feedback and cross-feed used to be summed at full strength, so the
+    /// round-trip gain reached 1.96 at the maximum settings. The saturator hid
+    /// it until saturation was turned off, and then the line grew without
+    /// bound.
+    #[test]
+    fn maximum_cross_feedback_stays_bounded_without_saturation() {
+        for mode in [DelayMode::Stereo, DelayMode::PingPong, DelayMode::Mono] {
+            let mut dsp = Dsp::new(48_000.0);
+            let mut params = default_params();
+            params.mode = mode;
+            params.time_ms_l = 120.0;
+            params.time_ms_r = 180.0;
+            params.feedback = 98.0;
+            params.cross_feedback = 100.0;
+            params.saturation = 0.0;
+            params.mix = 100.0;
+            dsp.set_params(params);
+
+            let mut peak = 0.0f32;
+            for n in 0..(48_000 * 20) {
+                let x = if n < 4_800 {
+                    (n as f32 * 0.02).sin() * 0.7
+                } else {
+                    0.0
+                };
+                let (l, r) = dsp.process_stereo(x, x);
+                assert!(l.is_finite() && r.is_finite(), "{mode:?} diverged at {n}");
+                peak = peak.max(l.abs()).max(r.abs());
+            }
+            assert!(peak < 8.0, "{mode:?} ran away: peak {peak}");
+        }
+    }
+
+    /// Cross-feed changes where the repeats go, not how loud the loop is.
+    #[test]
+    fn cross_feedback_does_not_change_the_loop_gain() {
+        let tail_peak = |cross: f32| {
+            let mut dsp = Dsp::new(48_000.0);
+            let mut params = default_params();
+            params.mode = DelayMode::Stereo;
+            params.time_ms_l = 100.0;
+            params.time_ms_r = 100.0;
+            params.feedback = 90.0;
+            params.cross_feedback = cross;
+            params.saturation = 0.0;
+            params.mix = 100.0;
+            dsp.set_params(params);
+
+            let _ = dsp.process_stereo(1.0, 1.0);
+            let mut peak = 0.0f32;
+            for _ in 0..(48_000 * 3) {
+                let (l, r) = dsp.process_stereo(0.0, 0.0);
+                peak = peak.max(l.abs()).max(r.abs());
+            }
+            peak
+        };
+        let none = tail_peak(0.0);
+        let full = tail_peak(100.0);
+        assert!(none > 0.1 && full > 0.1, "no tail to compare");
+        assert!(
+            (none - full).abs() < none * 0.25,
+            "loop gain moved with cross-feed: {none} vs {full}"
+        );
+    }
+
+    #[test]
+    fn freeze_holds_the_repeats_after_the_input_stops() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.mix = 100.0;
+        params.time_ms_l = 250.0;
+        params.time_ms_r = 250.0;
+        params.feedback = 40.0;
+        dsp.set_params(params);
+
+        for n in 0..24_000 {
+            let x = (n as f32 * 0.03).sin() * 0.5;
+            let _ = dsp.process_stereo(x, x);
+        }
+        assert!(dsp.apply_ui_param("freeze", 1.0));
+
+        let mut early = 0.0f32;
+        for _ in 0..12_000 {
+            let (l, r) = dsp.process_stereo(0.0, 0.0);
+            early = early.max(l.abs()).max(r.abs());
+        }
+        let mut late = 0.0f32;
+        for _ in 0..(48_000 * 4) {
+            let (l, r) = dsp.process_stereo(0.0, 0.0);
+            late = late.max(l.abs()).max(r.abs());
+        }
+        assert!(early > 1.0e-4, "nothing in the line to freeze");
+        assert!(
+            late > early * 0.25,
+            "freeze decayed away: early {early}, late {late}"
+        );
+    }
+
+    #[test]
+    fn reset_clears_the_repeats() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.mix = 100.0;
+        dsp.set_params(params);
+        for _ in 0..4_800 {
+            let _ = dsp.process_stereo(0.5, -0.5);
+        }
+        dsp.reset();
+        let (l, r) = dsp.process_stereo(0.0, 0.0);
+        assert!(l.abs() < 1.0e-6 && r.abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn sample_rate_change_keeps_taps_inside_the_new_rings() {
+        let mut dsp = Dsp::new(192_000.0);
+        let mut params = default_params();
+        params.time_ms_l = MAX_DELAY_MS;
+        params.time_ms_r = MAX_DELAY_MS;
+        params.mix = 100.0;
+        dsp.set_params(params);
+        dsp.set_sample_rate(44_100.0);
+
+        let capacity = dsp.delay_l.buffer.len();
+        assert!(dsp.delay_samples_l < capacity);
+        assert!(dsp.delay_samples_r < capacity);
+        for _ in 0..4_410 {
+            let (l, r) = dsp.process_stereo(0.3, -0.3);
+            assert!(l.is_finite() && r.is_finite());
+        }
+    }
+
+    #[test]
+    fn wire_update_changes_only_authoritative_params() {
+        let mut dsp = Dsp::new(48_000.0);
+        assert!(dsp.apply_wire_param(ipc::TIME_L_INDEX, 500.0));
+        assert_eq!(dsp.params().time_ms_l, 500.0);
+        assert_eq!(dsp.delay_samples_l, 24_000);
+        assert!(!dsp.apply_wire_param(u32::MAX, 0.0));
+        assert!(!dsp.apply_wire_param(ipc::TIME_L_INDEX, f32::NAN));
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/echospace/src/ui.rs
+++ b/crates/BuiltinAudioPlugins/crates/echospace/src/ui.rs
@@ -1,0 +1,107 @@
+//! Embedded editor UI for EchoSpace.
+//!
+//! The asset table is produced at build time by `build.rs` from `editorui/dist`
+//! and lives in the library's read-only data segment. The CEF host serves it
+//! through the `mikoplugin://echospace/...` scheme; see [`builtin_ui_embed`]
+//! for the lookup and URL rules.
+
+use builtin_ui_embed::{EmbeddedPluginUi, EmbeddedUiAsset, EmbeddedUiAssetTable};
+
+// Emits `static EMBEDDED_UI_ASSETS: &[::builtin_ui_embed::EmbeddedUiAsset]`,
+// sorted by path so the table can be binary-searched.
+include!(concat!(env!("OUT_DIR"), "/embedded_ui_assets.rs"));
+
+/// The URL origin (`mikoplugin://<origin>/...`) this plugin's assets are served
+/// under. Must match the `stem` in `SpherePluginHost`'s built-in catalog.
+pub const UI_ORIGIN: &str = "echospace";
+
+/// Marker type carrying the embedded editor assets.
+pub struct EchospaceUi;
+
+impl EchospaceUi {
+    /// The embedded asset table. Empty when `editorui/dist` was not built.
+    pub fn table() -> EmbeddedUiAssetTable {
+        EmbeddedUiAssetTable::new(EMBEDDED_UI_ASSETS)
+    }
+
+    /// Whether a UI was actually embedded at build time. The host uses this to
+    /// report a clear error instead of opening a blank editor window.
+    pub fn is_embedded() -> bool {
+        !EMBEDDED_UI_ASSETS.is_empty()
+    }
+}
+
+impl EmbeddedPluginUi for EchospaceUi {
+    fn get_ui_asset(path: &str) -> Option<EmbeddedUiAsset> {
+        Self::table().get(path).copied()
+    }
+
+    fn resolve_ui_asset(path: &str) -> Option<EmbeddedUiAsset> {
+        Self::table().resolve(path).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The table is only populated when `editorui/dist` exists, so every
+    /// assertion about real content is conditional. What must hold
+    /// unconditionally is that lookups never panic and never escape the table.
+    #[test]
+    fn lookups_are_total_and_never_panic() {
+        for path in [
+            "",
+            "/",
+            "/index.html",
+            "/../secret",
+            "/assets/%zz",
+            "\\windows\\path",
+            "/a/b/c/d/e",
+        ] {
+            let _ = EchospaceUi::get_ui_asset(path);
+            let _ = EchospaceUi::resolve_ui_asset(path);
+        }
+    }
+
+    #[test]
+    fn traversal_is_rejected_even_when_a_table_is_present() {
+        assert!(EchospaceUi::get_ui_asset("/../../etc/passwd").is_none());
+        assert!(EchospaceUi::resolve_ui_asset("/../../etc/passwd").is_none());
+    }
+
+    #[test]
+    fn a_built_dist_serves_index_html_and_round_trips_every_entry() {
+        if !EchospaceUi::is_embedded() {
+            // dist/ not built in this checkout — nothing to assert.
+            return;
+        }
+        let index = EchospaceUi::get_ui_asset("/index.html")
+            .expect("an embedded table always contains /index.html");
+        assert!(!index.is_empty());
+        assert!(index.mime_type.starts_with("text/html"));
+
+        // Root and bare-slash requests must reach the SPA shell.
+        assert_eq!(
+            EchospaceUi::resolve_ui_asset("/").map(|a| a.path),
+            Some("/index.html")
+        );
+        assert_eq!(
+            EchospaceUi::resolve_ui_asset("").map(|a| a.path),
+            Some("/index.html")
+        );
+
+        // The generator's sort order is what makes the binary search valid.
+        let table = EchospaceUi::table();
+        for asset in EMBEDDED_UI_ASSETS {
+            assert_eq!(
+                table
+                    .get(asset.path)
+                    .map(|found: &EmbeddedUiAsset| found.path),
+                Some(asset.path),
+                "asset {} is not retrievable — table is not sorted by path",
+                asset.path
+            );
+        }
+    }
+}

--- a/crates/SpherePluginHost/Cargo.toml
+++ b/crates/SpherePluginHost/Cargo.toml
@@ -37,6 +37,7 @@ builtin-dsp-core.workspace = true
 equz8.workspace = true
 rodharerist.workspace = true
 verbspace.workspace = true
+echospace.workspace = true
 # Analyser FFT for the bridged-insert spectrum (src/spectrum.rs). Already a
 # workspace dependency via rodharerist / SphereAudioProcessor — no new tree.
 rustfft.workspace = true

--- a/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
+++ b/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
@@ -245,6 +245,7 @@ enum BuiltinDsp {
     Rodhareist(rodharerist::Dsp),
     Equz8(equz8::Dsp),
     Verbspace(verbspace::Dsp),
+    Echospace(echospace::Dsp),
 }
 
 /// A built-in processor is created on the IPC thread and then owned exclusively
@@ -288,6 +289,7 @@ impl BuiltinHostProcessor {
             "rodharerist" => Some(Self::rodhareist(sample_rate, state_json)),
             "equz8" => Some(Self::equz8(sample_rate, state_json)),
             "verbspace" => Some(Self::verbspace(sample_rate, state_json)),
+            "echospace" => Some(Self::echospace(sample_rate, state_json)),
             _ => None,
         }
     }
@@ -351,6 +353,34 @@ impl BuiltinHostProcessor {
         }
     }
 
+    fn echospace(sample_rate: u32, state_json: Option<&str>) -> Self {
+        let sr = sample_rate.max(1) as f32;
+        let mut dsp = echospace::Dsp::new(sr);
+        // Same pre-publish window as above: the IPC thread still owns the DSP.
+        if let Some(json) = state_json {
+            match echospace::ipc::EchospaceState::from_json(json) {
+                Ok(state) => {
+                    dsp.set_params(state.params);
+                    eprintln!(
+                        "[plugin-host-builtin] restored state version={}",
+                        state.version
+                    );
+                }
+                Err(error) => {
+                    eprintln!("[plugin-host-builtin] state blob rejected, using defaults: {error}");
+                }
+            }
+        }
+        Self {
+            dsp: UnsafeCell::new(BuiltinDsp::Echospace(dsp)),
+            spectrum: UnsafeCell::new(SpectrumAnalyzer::new(sr)),
+            // A delay has no capture or cabinet stage to hand off into.
+            nam_loader: None,
+            ir_loader: None,
+            sample_rate: sr,
+        }
+    }
+
     fn verbspace(sample_rate: u32, state_json: Option<&str>) -> Self {
         let sr = sample_rate.max(1) as f32;
         let mut dsp = verbspace::Dsp::new(sr);
@@ -405,6 +435,13 @@ impl BuiltinHostProcessor {
                     interleaved[i * 2 + 1] = r;
                 }
             }
+            BuiltinDsp::Echospace(dsp) => {
+                for i in 0..frames {
+                    let (l, r) = dsp.process_stereo(in_l[i], in_r[i]);
+                    interleaved[i * 2] = l;
+                    interleaved[i * 2 + 1] = r;
+                }
+            }
         }
     }
 
@@ -441,7 +478,7 @@ impl BuiltinHostProcessor {
                     out_clip: f.out_clip,
                 })
             }
-            BuiltinDsp::Equz8(_) | BuiltinDsp::Verbspace(_) => None,
+            BuiltinDsp::Equz8(_) | BuiltinDsp::Verbspace(_) | BuiltinDsp::Echospace(_) => None,
         }
     }
 
@@ -456,6 +493,7 @@ impl BuiltinHostProcessor {
             BuiltinDsp::Rodhareist(dsp) => dsp.latency_samples(),
             BuiltinDsp::Equz8(_) => 0,
             BuiltinDsp::Verbspace(dsp) => dsp.latency_samples(),
+            BuiltinDsp::Echospace(dsp) => dsp.latency_samples(),
         }
     }
 
@@ -477,6 +515,9 @@ impl BuiltinHostProcessor {
                 let _ = dsp.apply_wire_param(param_id, value);
             }
             BuiltinDsp::Verbspace(dsp) => {
+                let _ = dsp.apply_wire_param(param_id, value);
+            }
+            BuiltinDsp::Echospace(dsp) => {
                 let _ = dsp.apply_wire_param(param_id, value);
             }
         }
@@ -690,6 +731,84 @@ mod builtin_processor_tests {
 
         // A corrupt blob falls back to defaults instead of panicking.
         let fallback = BuiltinHostProcessor::verbspace(48_000, Some("not json"));
+        fallback.process_block(&in_l, &in_r, &mut output, 32);
+        assert!(output.iter().all(|sample| sample.is_finite()));
+    }
+
+    /// Like the reverb, a delay's output outlives its input: the check that
+    /// matters is that repeats keep arriving across block boundaries, which a
+    /// per-block DSP rebuild would silence after the first one.
+    #[test]
+    fn echospace_repeats_survive_block_boundaries() {
+        let processor = BuiltinHostProcessor::echospace(48_000, None);
+        let mix = echospace::ui_param_index("mix").expect("mix in wire table");
+        let time_l = echospace::ui_param_index("timeMsL").expect("timeMsL in wire table");
+        let time_r = echospace::ui_param_index("timeMsR").expect("timeMsR in wire table");
+        processor.apply_param(mix, 100.0);
+        // Longer than one 64-frame block, so the echo can only be heard if the
+        // ring survives between calls.
+        processor.apply_param(time_l, 40.0);
+        processor.apply_param(time_r, 40.0);
+
+        let in_l = [0.3f32; 64];
+        let in_r = [-0.3f32; 64];
+        let mut output = [0.0f32; 128];
+        for _ in 0..16 {
+            processor.process_block(&in_l, &in_r, &mut output, 64);
+        }
+        assert!(output.iter().all(|sample| sample.is_finite()));
+
+        let silence = [0.0f32; 64];
+        let mut tail = 0.0f32;
+        for _ in 0..16 {
+            processor.process_block(&silence, &silence, &mut output, 64);
+            tail = output.iter().fold(tail, |peak, s| peak.max(s.abs()));
+        }
+        assert!(tail > 1.0e-4, "no repeats after the input stopped: {tail}");
+
+        // Power off is a pure bypass — the clearest observable param effect.
+        let power = echospace::ui_param_index("power").expect("power in wire table");
+        processor.apply_param(power, 0.0);
+        processor.process_block(&in_l, &in_r, &mut output, 64);
+        for i in 0..64 {
+            assert_eq!(output[i * 2], in_l[i], "power-off must bypass");
+            assert_eq!(output[i * 2 + 1], in_r[i], "power-off must bypass");
+        }
+
+        // Out-of-range indices are silent no-ops, not panics.
+        processor.apply_param(u32::MAX, 1.0);
+        processor.apply_param(echospace::UI_PARAM_IDS.len() as u32, 1.0);
+        processor.process_block(&in_l, &in_r, &mut output, 64);
+        assert!(output.iter().all(|sample| sample.is_finite()));
+    }
+
+    #[test]
+    fn echospace_restores_state_and_reports_no_latency_or_meters() {
+        let mut params = echospace::default_params();
+        params.power = false;
+        let json = echospace::ipc::EchospaceState::new(params)
+            .to_json()
+            .expect("state serializes");
+
+        let restored = BuiltinHostProcessor::echospace(48_000, Some(&json));
+        let in_l = [0.25f32; 32];
+        let in_r = [-0.5f32; 32];
+        let mut output = [0.0f32; 64];
+        restored.process_block(&in_l, &in_r, &mut output, 32);
+        for i in 0..32 {
+            assert_eq!(output[i * 2], in_l[i], "restored power-off must bypass");
+            assert_eq!(output[i * 2 + 1], in_r[i], "restored power-off must bypass");
+        }
+
+        // The delay time is a musical parameter, not lookahead, and the delay
+        // measures nothing — the meter frame is absent rather than zeroed.
+        assert_eq!(restored.latency_samples(), 0);
+        assert!(restored.meter_frame().is_none());
+        assert!(restored.nam_loader.is_none());
+        assert!(restored.ir_loader.is_none());
+
+        // A corrupt blob falls back to defaults instead of panicking.
+        let fallback = BuiltinHostProcessor::echospace(48_000, Some("not json"));
         fallback.process_block(&in_l, &in_r, &mut output, 32);
         assert!(output.iter().all(|sample| sample.is_finite()));
     }

--- a/crates/SpherePluginHost/src/builtin.rs
+++ b/crates/SpherePluginHost/src/builtin.rs
@@ -71,7 +71,7 @@ const CATALOG: &[BuiltinEntry] = &[
         name: "EchoSpace",
         category: "Delay",
         kind: PluginKind::Effect,
-        has_editor: false,
+        has_editor: true,
     },
     BuiltinEntry {
         stem: "verbspace",
@@ -156,7 +156,7 @@ pub fn is_builtin_ref(id: &str) -> bool {
 /// Must stay in sync with `BuiltinHostProcessor::new` in the host binary — the
 /// two are covered by [`tests::bridge_supported_builtins_are_catalogued`] here
 /// and by the host's own construction test.
-pub const AUDIO_BRIDGE_STEMS: &[&str] = &["rodharerist", "equz8", "verbspace"];
+pub const AUDIO_BRIDGE_STEMS: &[&str] = &["rodharerist", "equz8", "verbspace", "echospace"];
 
 /// Whether this built-in currently has an out-of-process audio DSP runtime.
 pub fn builtin_audio_bridge_supported(id: &str) -> bool {
@@ -270,6 +270,10 @@ mod tests {
             builtin_editor_url(&builtin_id("verbspace")).as_deref(),
             Some("mikoplugin://verbspace/index.html")
         );
+        assert_eq!(
+            builtin_editor_url(&builtin_id("echospace")).as_deref(),
+            Some("mikoplugin://echospace/index.html")
+        );
         assert!(builtin_editor_url(&builtin_id("compresser")).is_none());
         assert!(builtin_editor_url("vst3:whatever").is_none());
     }
@@ -288,6 +292,8 @@ mod tests {
         assert!(builtin_audio_bridge_supported("builtin:equz8"));
         assert!(builtin_audio_bridge_supported("verbspace"));
         assert!(builtin_audio_bridge_supported("builtin:verbspace"));
+        assert!(builtin_audio_bridge_supported("echospace"));
+        assert!(builtin_audio_bridge_supported("builtin:echospace"));
         // Catalogued, but the host has no DSP for it — must keep its old path.
         assert!(!builtin_audio_bridge_supported("compresser"));
         assert!(!builtin_audio_bridge_supported("vst3:whatever"));
@@ -312,6 +318,7 @@ mod tests {
         assert_eq!(builtin_display_name("equz8"), Some("EQ-Z8"));
         assert_eq!(builtin_display_name("rodharerist"), Some("Rodhareist"));
         assert_eq!(builtin_display_name("builtin:verbspace"), Some("VerbSpace"));
+        assert_eq!(builtin_display_name("echospace"), Some("EchoSpace"));
         assert_eq!(builtin_display_name("vst3:whatever"), None);
     }
 

--- a/crates/SphereUIComponents/Cargo.toml
+++ b/crates/SphereUIComponents/Cargo.toml
@@ -28,6 +28,7 @@ builtin-plugin-editor = [
     "dep:rodharerist",
     "dep:equz8",
     "dep:verbspace",
+    "dep:echospace",
     "dep:builtin-ui-embed",
 ]
 
@@ -60,6 +61,7 @@ sphere-webview = { workspace = true, optional = true, features = ["cef-runtime"]
 rodharerist = { workspace = true, optional = true }
 equz8 = { workspace = true, optional = true }
 verbspace = { workspace = true, optional = true }
+echospace = { workspace = true, optional = true }
 builtin-ui-embed = { workspace = true, optional = true }
 # Reusable native graphics/text/window backend (DirectWrite, DWM, GDI paint).
 sphere-graphic-engine.workspace = true

--- a/crates/SphereUIComponents/src/components/builtin_plugin_editor.rs
+++ b/crates/SphereUIComponents/src/components/builtin_plugin_editor.rs
@@ -74,6 +74,7 @@ pub fn builtin_param_index(plugin_id: &str, param_id: &str) -> Option<u32> {
         rodharerist::ui::UI_ORIGIN => rodharerist::ui_param_index(param_id),
         equz8::ui::UI_ORIGIN => equz8::ui_param_index(param_id),
         verbspace::ui::UI_ORIGIN => verbspace::ui_param_index(param_id),
+        echospace::ui::UI_ORIGIN => echospace::ui_param_index(param_id),
         _ => None,
     }
 }
@@ -111,6 +112,7 @@ mod state_mirror {
         Rodhareist(Box<rodharerist::Params>),
         Equz8(Box<equz8::Params>),
         Verbspace(Box<verbspace::Params>),
+        Echospace(Box<echospace::Params>),
     }
 
     impl BuiltinParams {
@@ -119,6 +121,7 @@ mod state_mirror {
                 Self::Rodhareist(_) => rodharerist::ui::UI_ORIGIN,
                 Self::Equz8(_) => equz8::ui::UI_ORIGIN,
                 Self::Verbspace(_) => verbspace::ui::UI_ORIGIN,
+                Self::Echospace(_) => echospace::ui::UI_ORIGIN,
             }
         }
 
@@ -131,6 +134,9 @@ mod state_mirror {
                 equz8::ui::UI_ORIGIN => Some(Self::Equz8(Box::new(equz8::default_params()))),
                 verbspace::ui::UI_ORIGIN => {
                     Some(Self::Verbspace(Box::new(verbspace::default_params())))
+                }
+                echospace::ui::UI_ORIGIN => {
+                    Some(Self::Echospace(Box::new(echospace::default_params())))
                 }
                 _ => None,
             }
@@ -169,6 +175,7 @@ mod state_mirror {
             rodharerist::ui::UI_ORIGIN => rodharerist::ui_param_id(wire_index).is_some(),
             equz8::ui::UI_ORIGIN => equz8::ui_param_id(wire_index).is_some(),
             verbspace::ui::UI_ORIGIN => verbspace::ui_param_id(wire_index).is_some(),
+            echospace::ui::UI_ORIGIN => echospace::ui_param_id(wire_index).is_some(),
             _ => false,
         };
         if !known {
@@ -188,6 +195,9 @@ mod state_mirror {
             }
             Some(BuiltinParams::Verbspace(params)) => {
                 let _ = verbspace::ipc::apply_wire_param(params, wire_index, value);
+            }
+            Some(BuiltinParams::Echospace(params)) => {
+                let _ = echospace::ipc::apply_wire_param(params, wire_index, value);
             }
             None => {}
         }
@@ -212,6 +222,9 @@ mod state_mirror {
             verbspace::ui::UI_ORIGIN => verbspace::ipc::VerbspaceState::from_json(text)
                 .ok()
                 .map(|state| BuiltinParams::Verbspace(Box::new(state.params))),
+            echospace::ui::UI_ORIGIN => echospace::ipc::EchospaceState::from_json(text)
+                .ok()
+                .map(|state| BuiltinParams::Echospace(Box::new(state.params))),
             _ => None,
         };
         let Some(parsed) = parsed else {
@@ -251,6 +264,11 @@ mod state_mirror {
                     .to_json()
                     .ok()?
             }
+            BuiltinParams::Echospace(params) if origin == echospace::ui::UI_ORIGIN => {
+                echospace::ipc::EchospaceState::new((**params).clone())
+                    .to_json()
+                    .ok()?
+            }
             _ => return None,
         };
         Some(json.into_bytes())
@@ -285,6 +303,12 @@ mod state_mirror {
                 verbspace::ipc::ui_values(params)
                     .into_iter()
                     .filter_map(|(id, value)| verbspace::ui_param_index(id).map(|i| (i, value)))
+                    .collect()
+            }
+            Some(BuiltinParams::Echospace(params)) if origin == echospace::ui::UI_ORIGIN => {
+                echospace::ipc::ui_values(params)
+                    .into_iter()
+                    .filter_map(|(id, value)| echospace::ui_param_index(id).map(|i| (i, value)))
                     .collect()
             }
             _ => Vec::new(),
@@ -669,6 +693,7 @@ mod imp {
             rodharerist::ui::UI_ORIGIN => rodharerist::ui::RodhareistUi::resolve_ui_asset(path)?,
             equz8::ui::UI_ORIGIN => equz8::ui::Equz8Ui::resolve_ui_asset(path)?,
             verbspace::ui::UI_ORIGIN => verbspace::ui::VerbspaceUi::resolve_ui_asset(path)?,
+            echospace::ui::UI_ORIGIN => echospace::ui::EchospaceUi::resolve_ui_asset(path)?,
             _ => return None,
         };
         Some(SchemeAsset {
@@ -684,7 +709,10 @@ mod imp {
     fn hosts_editor(origin: &str) -> bool {
         matches!(
             origin,
-            rodharerist::ui::UI_ORIGIN | equz8::ui::UI_ORIGIN | verbspace::ui::UI_ORIGIN
+            rodharerist::ui::UI_ORIGIN
+                | equz8::ui::UI_ORIGIN
+                | verbspace::ui::UI_ORIGIN
+                | echospace::ui::UI_ORIGIN
         )
     }
 
@@ -694,6 +722,7 @@ mod imp {
             rodharerist::ui::UI_ORIGIN => rodharerist::ui::RodhareistUi::is_embedded(),
             equz8::ui::UI_ORIGIN => equz8::ui::Equz8Ui::is_embedded(),
             verbspace::ui::UI_ORIGIN => verbspace::ui::VerbspaceUi::is_embedded(),
+            echospace::ui::UI_ORIGIN => echospace::ui::EchospaceUi::is_embedded(),
             _ => false,
         }
     }
@@ -1525,6 +1554,7 @@ mod tests {
         );
         assert_eq!(origin_for_plugin_id("builtin:equz8"), Some("equz8"));
         assert_eq!(origin_for_plugin_id("builtin:verbspace"), Some("verbspace"));
+        assert_eq!(origin_for_plugin_id("builtin:echospace"), Some("echospace"));
     }
 
     /// Regression guard for the bug that left the editor unopenable in the real
@@ -1535,6 +1565,7 @@ mod tests {
         assert_eq!(origin_for_plugin_id("rodharerist"), Some("rodharerist"));
         assert_eq!(origin_for_plugin_id("equz8"), Some("equz8"));
         assert_eq!(origin_for_plugin_id("verbspace"), Some("verbspace"));
+        assert_eq!(origin_for_plugin_id("echospace"), Some("echospace"));
         assert_eq!(
             origin_for_plugin_id("rodharerist"),
             origin_for_plugin_id("builtin:rodharerist"),

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cargo:fmt": "cargo fmt --all",
     "cargo:fmt:check": "cargo fmt --all -- --check",
     "cargo:clean": "cargo clean",
-    "build:plugin-editors": "bun run --cwd crates/BuiltinAudioPlugins/crates/equz8/editor build && bun run --cwd crates/BuiltinAudioPlugins/crates/meowsyn/editor build && bun run --cwd crates/BuiltinAudioPlugins/crates/opensampler/editor build && bun run --cwd crates/BuiltinAudioPlugins/crates/rodharerist/editorui build && bun run --cwd crates/BuiltinAudioPlugins/crates/verbspace/editorui build",
+    "build:plugin-editors": "bun run --cwd crates/BuiltinAudioPlugins/crates/equz8/editor build && bun run --cwd crates/BuiltinAudioPlugins/crates/meowsyn/editor build && bun run --cwd crates/BuiltinAudioPlugins/crates/opensampler/editor build && bun run --cwd crates/BuiltinAudioPlugins/crates/rodharerist/editorui build && bun run --cwd crates/BuiltinAudioPlugins/crates/verbspace/editorui build && bun run --cwd crates/BuiltinAudioPlugins/crates/echospace/editorui build",
     "build:native": "bun run build:plugin-editors && cargo run -p xtask -- package --profile release --edition community --plugin all",
     "build:native:debug": "bun run build:plugin-editors && cargo run -p xtask -- package --profile dev --edition community --plugin all",
     "bundle:native:mac": "bash packaging/native/bundle-macos.sh",


### PR DESCRIPTION
Gives EchoSpace the same treatment VerbSpace just got: a wire contract, an embedded Svelte editor, and a route into the out-of-process audio bridge. The DSP existed but had no ipc/ui module, no editor, and was not in AUDIO_BRIDGE_STEMS, so nothing could reach it.

Two pre-existing DSP bugs surfaced once the parameters became reachable from a UI, both confirmed by reverting the fix and watching the new tests fail:

* Feedback and cross-feed were summed at full strength, so the round-trip gain reached 1.96 at the maximum settings. The saturator hid it until saturation was set to 0 — which the editor lets you do — and then the line grew without bound. Normalising by the cross amount keeps the loop gain at `feedback` however much of it is routed across, which is also what the control means.
* The ring was sized with a fixed 192 000-sample cap, so the 4 s maximum delay silently became 2 s at 96 kHz and 1 s at 192 kHz. Capacity now follows the sample rate, and the editor cannot offer a time the DSP will not deliver.

`freeze` also pinned feedback at exactly 1.0; it now uses the same below-unity ceiling as the reverb.

Editor: Svelte 5 + Vite bundled to one self-contained `index.html`, sharing VerbSpace's control language with a teal accent of its own. The display is the delay counterpart to the reverb's decay plot — each round trip drawn as a bar on its channel's lane over a decibel axis, with the feedback envelope behind it. Three things come from the real model rather than from decoration: ping-pong alternation (odd passes come back on the opposite side), loop gain (cross-feed moves repeats, it does not make them louder), and per-pass dulling (successive bars are pulled toward grey by the magnitude the low/high cut sections actually have at a reference tone). Labelled a model in the UI; there is no analyser feed for this plugin.

The knob's shading is now driven from palette tokens instead of literals, so the accent is the only thing that differs between the two editors.

Also fixes an exponential-taper endpoint: `exp(log(4000))` lands a few ulps short, so a Time knob at full travel reported 3999.9999999999995 ms and never reached its own maximum.

Validation: cargo test -p echospace (20), -p sphere-plugin-host (79), -p sphere_ui_components --features builtin-plugin-editor (569), -p xtask (48), -p verbspace (18), -p BuiltinAudioPlugins (3); cargo check --workspace; cargo fmt --all --check; bun run build + bun test in editorui (0 type errors, 29 tests). Not exercised: audio through the real engine, CEF window lifecycle, and project save/restore.