### PR TITLE
Fix inverted Ctrl/Alt + wheel zoom direction

### DIFF
--- a/crates/SphereUIComponents/src/components/piano_roll.rs
+++ b/crates/SphereUIComponents/src/components/piano_roll.rs
@@ -4544,6 +4544,11 @@ impl PianoRoll {
             gpui::ScrollDelta::Pixels(p) => (f32::from(p.x), f32::from(p.y)),
             gpui::ScrollDelta::Lines(p) => (p.x * 36.0, p.y * 36.0),
         };
+        // Wheel up is a *positive* delta on every platform. The zoom helpers
+        // multiply by the factor, so wheel up must yield a factor above 1
+        // (zoom in) — the exponent is deliberately not negated. The scroll
+        // branches below do subtract it, because panning maps wheel motion onto
+        // the content origin rather than onto a scale.
         // Alt + wheel = Zoom Y (independent of Zoom X).
         if event.modifiers.alt && !(event.modifiers.control || event.modifiers.platform) {
             let (_, view_h) = self.grid_view_size();
@@ -4551,7 +4556,7 @@ impl PianoRoll {
                 .grid_local(event.position)
                 .map(|(_, ly)| ly)
                 .unwrap_or(view_h * 0.5);
-            let factor = (1.0022_f32).powf(-dy);
+            let factor = (1.0022_f32).powf(dy);
             self.zoom_row_h_around(factor, anchor_y, cx);
             return;
         }
@@ -4563,7 +4568,7 @@ impl PianoRoll {
                 .grid_local(event.position)
                 .map(|(lx, _)| lx)
                 .unwrap_or(view_w * 0.5);
-            let factor = (1.0022_f32).powf(-dy);
+            let factor = (1.0022_f32).powf(dy);
             self.zoom_ppb_around(factor, anchor_x, cx);
             return;
         }

--- a/crates/SphereUIComponents/src/components/timeline/timeline/render.rs
+++ b/crates/SphereUIComponents/src/components/timeline/timeline/render.rs
@@ -1784,7 +1784,7 @@ impl Render for Timeline {
 
             let x: f32 = event.position.x.into();
             let anchor = (x - SIDEBAR_WIDTH - HEADER_WIDTH).max(0.0);
-            let factor = (1.0024_f32).powf(-delta.1);
+            let factor = wheel_zoom_factor(delta.1);
             this.state.zoom_by(factor, anchor);
             let (max_x, max_y) = this.max_scroll_offsets(window);
             this.state.clamp_scroll(max_x, max_y);
@@ -2328,6 +2328,23 @@ pub(crate) fn horizontal_scrollbar(
 /// the engine or marks the project dirty. Spans the affected tracks vertically
 /// and the selected beat span horizontally. Non-interactive so it does not
 /// intercept lane drags. Returns `None` when no range is active.
+/// Per-pixel zoom rate for Ctrl + wheel on the arrangement.
+const WHEEL_ZOOM_BASE: f32 = 1.0024;
+
+/// Map a wheel delta onto a multiplicative zoom factor.
+///
+/// Wheel up is a *positive* delta on every platform, and the zoom helpers
+/// multiply by this factor, so wheel up must yield a factor above 1 (zoom in).
+/// The exponent is therefore deliberately **not** negated — doing so inverted
+/// the gesture, making Ctrl + wheel up zoom out.
+///
+/// This is the opposite of the pan path, which does subtract the delta: panning
+/// maps wheel motion onto the content origin (opposite by definition), whereas
+/// zooming maps it onto a scale, where up simply means more.
+pub(crate) fn wheel_zoom_factor(delta_y: f32) -> f32 {
+    WHEEL_ZOOM_BASE.powf(delta_y)
+}
+
 /// Resolve a pen-draw gesture's `(start_beat, end_beat)` into the final
 /// `(clip_start, length_beats)` that will be committed. Both endpoints are
 /// already resolved by the shared musical snap source (or Shift-bypassed), so
@@ -2847,6 +2864,46 @@ mod midi_clip_draw_tests {
     use crate::components::timeline::timeline_state::{
         DEFAULT_MIDI_CLIP_BEATS, MIN_MIDI_CLIP_BEATS,
     };
+
+    /// Ctrl + wheel up must zoom *in*. Regression guard: the exponent was
+    /// negated, so wheel up produced a factor below 1 and zoomed out.
+    #[test]
+    fn ctrl_wheel_up_zooms_in_and_down_zooms_out() {
+        assert!(
+            wheel_zoom_factor(30.0) > 1.0,
+            "wheel up must zoom in, got {}",
+            wheel_zoom_factor(30.0)
+        );
+        assert!(
+            wheel_zoom_factor(-30.0) < 1.0,
+            "wheel down must zoom out, got {}",
+            wheel_zoom_factor(-30.0)
+        );
+        assert_eq!(wheel_zoom_factor(0.0), 1.0, "no delta must not zoom");
+    }
+
+    /// The factor has to actually move `pixels_per_second` the right way, not
+    /// merely sit on the right side of 1.0.
+    #[test]
+    fn ctrl_wheel_up_increases_pixels_per_second() {
+        let mut state = TimelineState::default();
+        let before = state.viewport.pixels_per_second;
+        state.zoom_by(wheel_zoom_factor(30.0), 0.0);
+        assert!(
+            state.viewport.pixels_per_second > before,
+            "wheel up should widen the timeline: {before} -> {}",
+            state.viewport.pixels_per_second
+        );
+
+        let mut state = TimelineState::default();
+        let before = state.viewport.pixels_per_second;
+        state.zoom_by(wheel_zoom_factor(-30.0), 0.0);
+        assert!(
+            state.viewport.pixels_per_second < before,
+            "wheel down should narrow the timeline: {before} -> {}",
+            state.viewport.pixels_per_second
+        );
+    }
 
     #[test]
     fn drag_span_supports_both_directions() {


### PR DESCRIPTION
Ctrl + wheel **up zoomed out** and wheel **down zoomed in**, on the arrangement and in the piano roll.

## Cause

Wheel up is a *positive* delta on every platform — macOS passes `scrollingDeltaY` through, Windows passes `signed_hiword` through, and both Linux backends normalize to the same convention. The zoom helpers multiply (`new_pps = old_pps * factor`), so wheel up has to produce a factor **above** 1.

All three call sites negated the exponent, producing one below 1 instead:

```rust
let factor = (1.0024_f32).powf(-delta.1);
//                             ^ scroll up (+30) -> 1.0024^-30 = 0.93 -> zoom OUT
```

| File | Gesture |
|---|---|
| `timeline/timeline/render.rs` | Ctrl + wheel, zoom X (arrangement) |
| `piano_roll.rs` | Alt + wheel, zoom Y |
| `piano_roll.rs` | Ctrl + wheel, zoom X |

## The pan paths are deliberately untouched

They *do* subtract the delta, and that is correct — panning maps wheel motion onto the content origin (opposite by definition), whereas zooming maps it onto a scale, where up simply means more.

Conflating those two is exactly what made this read as a platform/axis bug rather than a sign error. I checked the whole input path first — Wayland and X11 sign conventions, `SCROLL_LINES`, the CEF editor's `to_view_point`, and whether any axis was swapped — and all of it was correct and consistent with macOS/Windows. Both conventions are now spelled out in comments where they are used, so the next person does not "fix" the pan direction to match.

## Verification

The mapping is extracted as `wheel_zoom_factor()` so the direction is testable:

- `ctrl_wheel_up_zooms_in_and_down_zooms_out` — the factor itself
- `ctrl_wheel_up_increases_pixels_per_second` — that `pixels_per_second` actually moves the right way, not merely that the factor lands on the correct side of 1.0

Both were confirmed to **fail** against the old sign before being kept:

```
ctrl_wheel_up_zooms_in_and_down_zooms_out ... FAILED
ctrl_wheel_up_increases_pixels_per_second ... FAILED
```

```
cargo test -p sphere_ui_components --lib   ->  568 passed, 0 failed
cargo check -p futureboard_native          ->  clean
cargo fmt                                  ->  clean
```

## Not verified

Not yet exercised in a running build — the evidence above is unit-level. Worth a quick manual check of Ctrl + wheel on the arrangement and Alt + wheel in the piano roll.

Unrelated and left alone: `mixer_panel.rs` uses `scroll_x + delta`, whose direction does not match the other panels. Not touched here because it is unclear whether that is intentional.