### PR TITLE
Equz8: add band solo and fix the Q control's resolution

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/builtin_dsp_core/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/builtin_dsp_core/src/lib.rs
@@ -241,6 +241,9 @@ pub fn make_eq_coefficients(
         "lowpass" | "lp" => Type::LowPass,
         "highpass" | "hp" => Type::HighPass,
         "notch" => Type::Notch,
+        // Not an EQ band shape — used to audition one band's frequency region
+        // in isolation (see Equz8's band solo).
+        "bandpass" | "bp" => Type::BandPass,
         _ => return None,
     };
     Coefficients::<f32>::from_params(filter_type, fs.hz(), f0.hz(), q).ok()

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/App.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
+  SOLO_NONE,
   connectBridge,
   postParam,
   type Band,
@@ -64,6 +65,62 @@ function App() {
     postBandPatch(index, patch)
   }, [])
 
+  /// Audition one band's frequency region on its own, FabFilter-style.
+  ///
+  /// Soloing is exclusive and self-clearing: clicking the lit band turns it
+  /// off, and clicking another moves the audition rather than stacking. It is
+  /// deliberately kept out of `updateGlobal`/preset state — see `presets.ts`.
+  const toggleSolo = useCallback((index: number) => {
+    setParams((current) => {
+      const next = current.soloBand === index ? SOLO_NONE : index
+      postParam('soloBand', next)
+      return { ...current, soloBand: next }
+    })
+  }, [])
+
+  /// Set solo outright rather than toggling.
+  ///
+  /// The momentary right-drag audition needs this: it has to force solo on at
+  /// gesture start and put back whatever was there on release, neither of which
+  /// a toggle can express. No-ops when already on the requested band so a drag
+  /// does not post a parameter per frame.
+  const setSolo = useCallback((index: number) => {
+    setParams((current) => {
+      if (current.soloBand === index) return current
+      postParam('soloBand', index)
+      return { ...current, soloBand: index }
+    })
+  }, [])
+
+  /// Solo is an audition, not a setting: leaving the EQ silently stuck
+  /// bandpassing one band would be a nasty surprise, so it drops on Escape and
+  /// on unmount (closing the editor window) alike. The ref exists purely so the
+  /// unmount cleanup can see the latest value without resubscribing per change.
+  const soloRef = useRef(params.soloBand)
+  useEffect(() => {
+    soloRef.current = params.soloBand
+  }, [params.soloBand])
+
+  const clearSolo = useCallback(() => {
+    setParams((current) => {
+      if (current.soloBand === SOLO_NONE) return current
+      postParam('soloBand', SOLO_NONE)
+      return { ...current, soloBand: SOLO_NONE }
+    })
+  }, [])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') clearSolo()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      // The component is going away, so only the DSP-side release matters here.
+      if (soloRef.current !== SOLO_NONE) postParam('soloBand', SOLO_NONE)
+    }
+  }, [clearSolo])
+
   const updateGlobal = useCallback(
     (patch: Partial<Pick<EqParams, 'power' | 'outputDb' | 'mix'>>) => {
       setParams((current) => ({ ...current, ...patch }))
@@ -113,8 +170,11 @@ function App() {
           showBandCurves={showBandCurves}
           showSpectrum={showSpectrum}
           spectrumRef={spectrum}
+          soloBand={params.soloBand}
           onSelect={setSelected}
           onBandChange={updateBand}
+          onToggleSolo={toggleSolo}
+          onSetSolo={setSolo}
         />
 
         <div className="stage-overlay">
@@ -162,8 +222,10 @@ function App() {
         selected={selected}
         outputDb={params.outputDb}
         mix={params.mix}
+        soloed={params.soloBand === selected}
         onBandChange={(patch) => updateBand(selected, patch)}
         onGlobalChange={updateGlobal}
+        onToggleSolo={() => toggleSolo(selected)}
       />
     </main>
   )

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/Editor.scss
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/Editor.scss
@@ -438,6 +438,17 @@ select:focus-visible,
     opacity: 0.3;
   }
 
+  /// A soloed band is muting everything else, so its node keeps a permanent lit
+  /// halo rather than the hover-only one — the graph has to show *why* the EQ
+  /// suddenly sounds like a bandpass, even when the pointer is elsewhere.
+  &.is-soloed {
+    opacity: 1;
+
+    .node-halo {
+      opacity: 0.42;
+    }
+  }
+
   .node-halo {
     fill: var(--band);
     opacity: 0;
@@ -569,11 +580,52 @@ select:focus-visible,
   font-variant-numeric: tabular-nums;
 }
 
+/// Audition toggle. Sits before the enable dot and takes the `margin-left:auto`
+/// that used to push that dot to the end, so the pair stays right-aligned.
+.band-solo {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 1.35rem;
+  height: 1.35rem;
+  margin-left: auto;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 0.4rem;
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+
+  svg {
+    width: 0.85rem;
+    height: 0.85rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.7;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--text-faint);
+  }
+
+  /// Soloing mutes everything else, so it has to be unmistakable at a glance —
+  /// this is the one control in the rack that changes what you are hearing
+  /// without changing the curve.
+  &.is-on {
+    color: #0b0e13;
+    border-color: var(--band);
+    background: var(--band);
+  }
+}
+
 .band-toggle {
   flex: none;
   width: 0.65rem;
   height: 0.65rem;
-  margin-left: auto;
   border: 1px solid var(--text-faint);
   border-radius: 50%;
   cursor: pointer;

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/bridge.ts
@@ -17,11 +17,16 @@ export type Band = {
   q: number
 }
 
+/// `soloBand` value meaning "no band is soloed". Mirrors `ipc::SOLO_NONE`.
+export const SOLO_NONE = -1
+
 export type EqParams = {
   power: boolean
   outputDb: number
   mix: number
   bands: Band[]
+  /// Index of the band being auditioned in isolation, or [`SOLO_NONE`].
+  soloBand: number
 }
 
 type Binding = {
@@ -117,7 +122,17 @@ function parseParams(state: unknown): EqParams | null {
   ) {
     return null
   }
-  return params as EqParams
+  // Optional on purpose: state saved before band solo existed has no
+  // `soloBand`, and rejecting it here would make those projects fail to load
+  // rather than simply opening with solo off. Rust applies the same default.
+  const soloBand =
+    typeof params.soloBand === 'number' &&
+    Number.isInteger(params.soloBand) &&
+    params.soloBand >= 0 &&
+    params.soloBand < params.bands.length
+      ? params.soloBand
+      : SOLO_NONE
+  return { ...(params as EqParams), soloBand }
 }
 
 export function connectBridge(

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ControlRack.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ControlRack.tsx
@@ -17,6 +17,8 @@ import {
   formatQ,
   freqToProgress,
   progressToFreq,
+  progressToQ,
+  qToProgress,
 } from '../lib/eq'
 import { Knob } from './Knob'
 
@@ -26,10 +28,12 @@ export type ControlRackProps = {
   selected: number
   outputDb: number
   mix: number
+  soloed: boolean
   onBandChange: (patch: Partial<Band>) => void
   onGlobalChange: (
     patch: Partial<Pick<EqParams, 'outputDb' | 'mix'>>,
   ) => void
+  onToggleSolo: () => void
 }
 
 export function ControlRack({
@@ -38,8 +42,10 @@ export function ControlRack({
   selected,
   outputDb,
   mix,
+  soloed,
   onBandChange,
   onGlobalChange,
+  onToggleSolo,
 }: ControlRackProps) {
   const kind = filterKind(band.bandType)
   const canGain = bandHasGain(band.bandType)
@@ -56,6 +62,23 @@ export function ControlRack({
             <strong>Band {selected + 1}</strong>
             <span>{kind.label}</span>
           </div>
+          <button
+            type="button"
+            className={`band-solo${soloed ? ' is-on' : ''}`}
+            aria-pressed={soloed}
+            aria-label={`Listen to band ${selected + 1} alone`}
+            title={
+              soloed
+                ? 'Stop listening (Esc)'
+                : "Listen to this band's frequency range alone"
+            }
+            onClick={onToggleSolo}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M4 14v-2a8 8 0 0 1 16 0v2" />
+              <path d="M4 14h3v5H5a1 1 0 0 1-1-1zM20 14h-3v5h2a1 1 0 0 0 1-1z" />
+            </svg>
+          </button>
           <button
             type="button"
             className={`band-toggle${band.active ? ' is-on' : ''}`}
@@ -125,6 +148,8 @@ export function ControlRack({
           step={0.01}
           format={formatQ}
           defaultValue={defaultBand.q}
+          toProgress={qToProgress}
+          fromProgress={progressToQ}
           onChange={(q) => onBandChange({ q })}
         />
       </div>

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ResponseGraph.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ResponseGraph.tsx
@@ -18,9 +18,7 @@ import {
   GRID_GAINS,
   LABELLED_FREQUENCIES,
   MAX_FREQ,
-  MAX_Q,
   MIN_FREQ,
-  MIN_Q,
   bandCurvePath,
   bandHasGain,
   clamp,
@@ -30,6 +28,7 @@ import {
   formatQ,
   frequencyToX,
   gainToY,
+  scaleQ,
   sumCurvePath,
   sumDbAt,
   xToFrequency,
@@ -38,6 +37,17 @@ import {
 
 const READOUT_WIDTH = 148
 const READOUT_HEIGHT = 30
+
+/// One wheel notch in `deltaY` units, matching a conventional mouse detent.
+/// Trackpads and high-resolution wheels report smaller values and so produce
+/// correspondingly smaller, smooth steps.
+const WHEEL_NOTCH = 100
+
+/// Q multiplier per wheel notch. 1.15 is roughly two notches per semitone-ish
+/// step of bandwidth — brisk enough to cross the range in a short gesture, fine
+/// enough to place a value without overshooting.
+const Q_WHEEL_COARSE = 1.15
+const Q_WHEEL_FINE = 1.03
 
 type Size = { width: number; height: number }
 
@@ -50,8 +60,12 @@ export type ResponseGraphProps = {
   /// Live handle on the analyser frame — see [`SpectrumLayer`] for why this is
   /// a ref rather than a value.
   spectrumRef: RefObject<SpectrumFrame | null>
+  /// Band currently auditioned alone, or `SOLO_NONE`.
+  soloBand: number
   onSelect: (index: number) => void
   onBandChange: (index: number, patch: Partial<Band>) => void
+  onToggleSolo: (index: number) => void
+  onSetSolo: (index: number) => void
 }
 
 export function ResponseGraph({
@@ -61,11 +75,18 @@ export function ResponseGraph({
   showBandCurves,
   showSpectrum,
   spectrumRef,
+  soloBand,
   onSelect,
   onBandChange,
+  onToggleSolo,
+  onSetSolo,
 }: ResponseGraphProps) {
   const svgRef = useRef<SVGSVGElement>(null)
   const dragging = useRef<number | null>(null)
+  /// Solo state to put back when a momentary right-drag audition ends, or
+  /// `null` when the gesture in progress is not an audition. `SOLO_NONE` is a
+  /// meaningful value to restore, hence `null` rather than `-1` as the sentinel.
+  const auditionRestore = useRef<number | null>(null)
   const [size, setSize] = useState<Size>({ width: 960, height: 420 })
   const [cursor, setCursor] = useState<{ x: number; y: number } | null>(null)
   const [dragged, setDragged] = useState<number | null>(null)
@@ -133,6 +154,12 @@ export function ResponseGraph({
       const patch: Partial<Band> = {
         freq: clamp(xToFrequency(point.x, width), MIN_FREQ, MAX_FREQ),
       }
+      // The audition drag moves the band exactly like a normal drag, both axes.
+      // An earlier revision locked it to frequency on the theory that gain is
+      // inaudible while soloed and would therefore be changed blindly — but the
+      // point of the gesture is to place the band *while* listening, and half a
+      // drag is not that. The node keeps tracking the cursor, so the gain being
+      // dialled in stays visible on the curve even when it is not audible.
       if (bandHasGain(band.bandType)) {
         patch.gainDb = clamp(yToGain(point.y, height), -GAIN_RANGE, GAIN_RANGE)
       }
@@ -145,11 +172,57 @@ export function ResponseGraph({
     event.preventDefault()
     const band = bands[index]
     if (!band) return
-    const scale = event.shiftKey ? 0.02 : 0.12
-    onBandChange(index, {
-      q: clamp(band.q - Math.sign(event.deltaY) * scale, MIN_Q, MAX_Q),
-    })
+    // Ratio per notch rather than a fixed amount, so a notch is the same
+    // perceived step at Q 0.3 as at Q 8. Notches are also accumulated by
+    // magnitude instead of `Math.sign`, which threw away how far the wheel
+    // actually moved and made every gesture exactly one step regardless.
+    const notches = clamp(event.deltaY / WHEEL_NOTCH, -4, 4)
+    const perNotch = event.shiftKey ? Q_WHEEL_FINE : Q_WHEEL_COARSE
+    onBandChange(index, { q: scaleQ(band.q, Math.pow(perNotch, -notches)) })
   }
+
+  /// End any drag, releasing a momentary audition if one was running.
+  ///
+  /// Every teardown path routes through here — pointer up, cancel and the
+  /// window-level safety net below — because a missed release would leave the
+  /// EQ silently stuck bandpassing one band.
+  const endGesture = useCallback(() => {
+    dragging.current = null
+    setDragged(null)
+    if (auditionRestore.current !== null) {
+      onSetSolo(auditionRestore.current)
+      auditionRestore.current = null
+    }
+  }, [onSetSolo])
+
+  /// Drive the drag from the window rather than from the SVG's own handlers.
+  ///
+  /// The right-button gesture cannot rely on pointer capture or on the SVG
+  /// staying the event target: opening a context menu makes Blink fire
+  /// `pointercancel`, which drops capture and would strand a half-finished
+  /// drag. Window listeners see the move regardless of capture, target, or
+  /// whether the pointer wandered outside the graph, which is also what makes
+  /// a release outside the window release the audition instead of latching it.
+  useEffect(() => {
+    const onWindowMove = (event: globalThis.PointerEvent) => {
+      if (dragging.current === null) return
+      dragBand(dragging.current, event.clientX, event.clientY)
+      setCursor(null)
+    }
+    const onWindowUp = () => {
+      if (dragging.current !== null || auditionRestore.current !== null) {
+        endGesture()
+      }
+    }
+    window.addEventListener('pointermove', onWindowMove)
+    window.addEventListener('pointerup', onWindowUp)
+    window.addEventListener('blur', onWindowUp)
+    return () => {
+      window.removeEventListener('pointermove', onWindowMove)
+      window.removeEventListener('pointerup', onWindowUp)
+      window.removeEventListener('blur', onWindowUp)
+    }
+  }, [dragBand, endGesture])
 
   const cursorFreq = cursor ? xToFrequency(cursor.x, width) : null
   const zeroY = gainToY(0, height)
@@ -163,25 +236,26 @@ export function ResponseGraph({
       viewBox={`0 0 ${width} ${height}`}
       preserveAspectRatio="none"
       onPointerMove={(event: ReactPointerEvent<SVGSVGElement>) => {
-        if (dragging.current !== null) {
-          dragBand(dragging.current, event.clientX, event.clientY)
-          setCursor(null)
-          return
-        }
+        // Dragging is handled window-side (see above); this only feeds the
+        // hover readout, which is meaningless mid-drag.
+        if (dragging.current !== null) return
         setCursor(toGraphPoint(event.clientX, event.clientY))
       }}
       onPointerLeave={() => setCursor(null)}
+      // The audition gesture is driven by the right button, whose context menu
+      // would otherwise pop up over the graph mid-drag.
+      onContextMenu={(event) => event.preventDefault()}
       onPointerUp={(event) => {
-        dragging.current = null
-        setDragged(null)
+        endGesture()
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
           event.currentTarget.releasePointerCapture(event.pointerId)
         }
       }}
-      onPointerCancel={() => {
-        dragging.current = null
-        setDragged(null)
-      }}
+      // Deliberately not wired to `endGesture`: Blink fires `pointercancel`
+      // when it opens a context menu, and treating that as "gesture over"
+      // would kill the right-button drag the instant it starts. The
+      // window-level `pointerup` above is the real end of the gesture.
+      onPointerCancel={() => setCursor(null)}
     >
       <defs>
         <linearGradient id="graph-shade" x1="0" x2="1" y1="0" y2="0">
@@ -305,7 +379,7 @@ export function ResponseGraph({
         return (
           <g
             key={index}
-            className={`node${isSelected ? ' is-selected' : ''}${band.active ? '' : ' is-off'}`}
+            className={`node${isSelected ? ' is-selected' : ''}${band.active ? '' : ' is-off'}${soloBand === index ? ' is-soloed' : ''}`}
             transform={`translate(${x} ${y})`}
             style={{ '--band': BAND_COLORS[index] } as CSSProperties}
             role="slider"
@@ -317,11 +391,31 @@ export function ResponseGraph({
             aria-valuetext={`${formatFrequency(band.freq)} hertz, ${formatGain(band.gainDb)} decibel`}
             onPointerDown={(event) => {
               onSelect(index)
+              // Alt-click latches the audition on and off, for when you want to
+              // keep listening with both hands free.
+              if (event.altKey && event.button === 0) {
+                event.preventDefault()
+                onToggleSolo(index)
+                return
+              }
+              // Right-button *hold* is the momentary audition: solo engages for
+              // as long as the button is down and the band drags normally
+              // underneath it, so you can sweep the frequency and hear the
+              // range follow. Releasing restores whatever solo state was there
+              // before, which is what makes it safe to reach for mid-mix.
+              if (event.button === 2) {
+                event.preventDefault()
+                auditionRestore.current = soloBand
+                onSetSolo(index)
+              }
               dragging.current = index
               setDragged(index)
               setCursor(null)
               svgRef.current?.setPointerCapture(event.pointerId)
             }}
+            // Also suppressed on the node itself, not just the SVG: the menu
+            // must be cancelled before it can interrupt the drag it starts.
+            onContextMenu={(event) => event.preventDefault()}
             onDoubleClick={() => onBandChange(index, { gainDb: 0, q: 1 })}
             onWheel={(event) => onNodeWheel(event, index)}
             onKeyDown={(event) => {
@@ -367,6 +461,10 @@ export function ResponseGraph({
                 </text>
               </g>
             )}
+            <title>
+              {`Band ${index + 1} — drag to move, wheel for Q, ` +
+                'hold right-button to sweep and listen, Alt-click to keep listening'}
+            </title>
             <circle className="node-halo" r={isSelected ? 19 : 15} />
             <circle className="node-ring" r={isSelected ? 11 : 9} />
             <text textAnchor="middle" dominantBaseline="central">

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/lib/eq.ts
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/lib/eq.ts
@@ -148,6 +148,35 @@ export function progressToFreq(progress: number) {
   return xToFrequency(clamp(progress, 0, 1), 1)
 }
 
+/// Q is perceptually *multiplicative*: 0.5 -> 1 is the same musical step as
+/// 4 -> 8. Laying 0.1..12 out linearly therefore crams the entire useful range
+/// into the bottom fifth of the control — most of the travel is spent between
+/// 3 and 12, where a whole unit of Q is barely audible, while the region people
+/// actually work in gets almost no resolution. That is what made the control
+/// feel like it needed a long drag before anything happened.
+///
+/// A log mapping gives every octave of Q the same distance, matching how the
+/// frequency axis already behaves.
+const qScale = scaleLog().domain([MIN_Q, MAX_Q]).range([0, 1])
+
+export function qToProgress(q: number) {
+  return clamp(qScale(clamp(q, MIN_Q, MAX_Q)), 0, 1)
+}
+
+export function progressToQ(progress: number) {
+  return clamp(qScale.invert(clamp(progress, 0, 1)), MIN_Q, MAX_Q)
+}
+
+/// Scale Q by a ratio, for wheel/scroll gestures.
+///
+/// Multiplying keeps each notch the same *perceived* step anywhere in the
+/// range. The previous additive step of 0.12 meant a notch more than doubled Q
+/// at the bottom of the range while moving it by 1% at the top, so widening a
+/// narrow band took a handful of notches and narrowing a wide one took dozens.
+export function scaleQ(q: number, ratio: number) {
+  return clamp(clamp(q, MIN_Q, MAX_Q) * ratio, MIN_Q, MAX_Q)
+}
+
 /// Log ticks straight from the scale — every multiple inside each decade, so a
 /// zoomed-out grid still reads as logarithmic instead of evenly spaced.
 export const GRID_FREQUENCIES = freqScale

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/lib/presets.ts
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/lib/presets.ts
@@ -1,4 +1,4 @@
-import { postParam, type Band, type EqParams } from '../bridge'
+import { SOLO_NONE, postParam, type Band, type EqParams } from '../bridge'
 import { filterKind } from './eq'
 
 /// Mirrors `default_params()` in the Rust DSP crate. Rust stays authoritative:
@@ -17,6 +17,7 @@ export const DEFAULT_PARAMS: EqParams = {
     { active: true, bandType: 'highshelf', freq: 8000, gainDb: 1.5, q: 0.8 },
     { active: true, bandType: 'lowpass', freq: 16000, gainDb: 0, q: 0.7 },
   ],
+  soloBand: SOLO_NONE,
 }
 
 export type FactoryPreset = {
@@ -40,6 +41,9 @@ function preset(
         ...band,
         ...(bands[index] ?? {}),
       })),
+      // Solo is an audition state, never part of a preset: loading a preset
+      // while listening to one band must not leave the EQ stuck in solo.
+      soloBand: SOLO_NONE,
     },
   }
 }
@@ -140,6 +144,7 @@ export function postAllParams(params: EqParams) {
   postParam('power', params.power ? 1 : 0)
   postParam('outputDb', params.outputDb)
   postParam('mix', params.mix)
+  postParam('soloBand', params.soloBand)
   params.bands.forEach((band, index) => {
     const prefix = `band${index + 1}_`
     postParam(`${prefix}enabled`, band.active ? 1 : 0)

--- a/crates/BuiltinAudioPlugins/crates/equz8/src/ipc.rs
+++ b/crates/BuiltinAudioPlugins/crates/equz8/src/ipc.rs
@@ -24,7 +24,18 @@ pub const BAND_FREQ: u32 = 2;
 pub const BAND_GAIN: u32 = 3;
 pub const BAND_Q: u32 = 4;
 
-pub const PARAM_COUNT: usize = BAND_BASE_INDEX as usize + BAND_COUNT * BAND_STRIDE as usize;
+/// Which band is auditioned in isolation, or [`SOLO_NONE`].
+///
+/// Deliberately appended *after* the per-band block rather than inserted next
+/// to the other globals: band wire indices are derived from
+/// [`BAND_BASE_INDEX`], so inserting ahead of them would renumber every band
+/// and silently repoint in-flight edits.
+pub const SOLO_INDEX: u32 = BAND_BASE_INDEX + BAND_COUNT as u32 * BAND_STRIDE;
+
+/// `solo_band` value meaning "no band is soloed".
+pub const SOLO_NONE: i32 = -1;
+
+pub const PARAM_COUNT: usize = SOLO_INDEX as usize + 1;
 
 pub const UI_PARAM_IDS: [&str; PARAM_COUNT] = [
     "power",
@@ -70,6 +81,7 @@ pub const UI_PARAM_IDS: [&str; PARAM_COUNT] = [
     "band8_freq",
     "band8_gainDb",
     "band8_q",
+    "soloBand",
 ];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -127,10 +139,27 @@ pub fn decode_band_wire(index: u32) -> Option<(usize, u32)> {
 pub fn sanitize_params(params: &mut Params) {
     params.output_db = clamp(params.output_db, -24.0, 12.0);
     params.mix = clamp(params.mix, 0.0, 100.0);
+    if params.solo_band < 0 || params.solo_band >= BAND_COUNT as i32 {
+        params.solo_band = SOLO_NONE;
+    }
     for band in &mut params.bands {
         band.freq = clamp(band.freq, 20.0, 20_000.0);
         band.gain_db = clamp(band.gain_db, -18.0, 18.0);
         band.q = clamp(band.q, 0.1, 12.0);
+    }
+}
+
+/// Decode a wire `soloBand` value into a validated band index.
+///
+/// Anything outside `0..BAND_COUNT` clears solo rather than being rejected, so
+/// a UI can turn solo off by sending `-1` and can never wedge the DSP into
+/// auditioning a band that does not exist.
+pub fn decode_solo_band(value: f32) -> i32 {
+    let index = value.round() as i32;
+    if index < 0 || index >= BAND_COUNT as i32 {
+        SOLO_NONE
+    } else {
+        index
     }
 }
 
@@ -144,6 +173,7 @@ pub fn apply_wire_param(params: &mut Params, index: u32, value: f32) -> bool {
         POWER_INDEX => params.power = value >= 0.5,
         MIX_INDEX => params.mix = clamp(value, 0.0, 100.0),
         OUTPUT_INDEX => params.output_db = clamp(value, -24.0, 12.0),
+        SOLO_INDEX => params.solo_band = decode_solo_band(value),
         _ => {
             let Some((band_index, field)) = decode_band_wire(index) else {
                 return false;
@@ -183,6 +213,7 @@ pub fn ui_values(params: &Params) -> Vec<(&'static str, f32)> {
         values.push((UI_PARAM_IDS[base + 3], band.gain_db));
         values.push((UI_PARAM_IDS[base + 4], band.q));
     }
+    values.push(("soloBand", params.solo_band as f32));
     values
 }
 
@@ -206,6 +237,42 @@ mod tests {
         let json = Equz8State::new(params).to_json().unwrap();
         let decoded = Equz8State::from_json(&json).unwrap();
         assert_eq!(decoded.params.bands[3].gain_db, -4.5);
+    }
+
+    /// Projects saved before band solo existed have no `soloBand` field. They
+    /// must still load, with solo off rather than failing to deserialize.
+    #[test]
+    fn state_without_solo_band_still_loads() {
+        let json = Equz8State::new(default_params()).to_json().unwrap();
+        let stripped = json
+            .replace(",\"soloBand\":-1", "")
+            .replace("\"soloBand\":-1,", "");
+        assert!(
+            !stripped.contains("soloBand"),
+            "the field should be gone for this test to mean anything"
+        );
+        let decoded = Equz8State::from_json(&stripped).expect("legacy state must load");
+        assert_eq!(decoded.params.solo_band, SOLO_NONE);
+    }
+
+    /// Adding solo must not have renumbered the band block.
+    #[test]
+    fn solo_is_appended_after_the_band_block() {
+        assert_eq!(BAND_BASE_INDEX, 3, "globals still occupy 0..3");
+        assert_eq!(band_wire_index(0, BAND_ENABLED), 3);
+        assert_eq!(band_wire_index(BAND_COUNT - 1, BAND_Q), SOLO_INDEX - 1);
+        assert_eq!(ui_param_index("soloBand"), Some(SOLO_INDEX));
+    }
+
+    #[test]
+    fn solo_index_is_validated_not_trusted() {
+        let mut params = default_params();
+        assert!(apply_wire_param(&mut params, SOLO_INDEX, 3.0));
+        assert_eq!(params.solo_band, 3);
+        for bogus in [-5.0, BAND_COUNT as f32, 999.0] {
+            assert!(apply_wire_param(&mut params, SOLO_INDEX, bogus));
+            assert_eq!(params.solo_band, SOLO_NONE, "{bogus} should clear solo");
+        }
     }
 
     #[test]

--- a/crates/BuiltinAudioPlugins/crates/equz8/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/equz8/src/lib.rs
@@ -95,6 +95,16 @@ pub struct Params {
     pub output_db: f32,
     pub mix: f32,
     pub bands: [BandParams; BAND_COUNT],
+    /// Index of the band being auditioned in isolation, or [`ipc::SOLO_NONE`].
+    ///
+    /// `serde(default)` so projects saved before band solo existed still load —
+    /// they deserialize with solo off, which is the pre-existing behavior.
+    #[serde(default = "solo_none")]
+    pub solo_band: i32,
+}
+
+fn solo_none() -> i32 {
+    ipc::SOLO_NONE
 }
 
 pub fn default_params() -> Params {
@@ -160,6 +170,7 @@ pub fn default_params() -> Params {
                 q: 0.7,
             },
         ],
+        solo_band: ipc::SOLO_NONE,
     }
 }
 
@@ -205,8 +216,20 @@ pub struct Dsp {
     params: Params,
     left: [Option<DirectForm1<f32>>; BAND_COUNT],
     right: [Option<DirectForm1<f32>>; BAND_COUNT],
+    /// Audition bandpass for the soloed band, per channel. `None` when no band
+    /// is soloed — built on the control thread so the audio path only runs it.
+    solo_left: Option<DirectForm1<f32>>,
+    solo_right: Option<DirectForm1<f32>>,
     output_gain: f32,
 }
+
+/// Q used to audition band shapes that have no meaningful centre width.
+///
+/// Shelves and pass filters are broad by construction, so reusing their own Q
+/// would open an audition window either far too wide to isolate anything or so
+/// narrow it sits on a slope. A moderate fixed Q gives a consistent "what lives
+/// around this corner frequency" listen.
+const SOLO_WIDE_Q: f32 = 0.9;
 
 impl Dsp {
     pub fn new(sample_rate: f32) -> Self {
@@ -215,6 +238,8 @@ impl Dsp {
             params: default_params(),
             left: [None, None, None, None, None, None, None, None],
             right: [None, None, None, None, None, None, None, None],
+            solo_left: None,
+            solo_right: None,
             output_gain: 1.0,
         };
         dsp.rebuild();
@@ -247,9 +272,16 @@ impl Dsp {
             ipc::OUTPUT_INDEX => {
                 self.output_gain = db_to_linear(self.params.output_db);
             }
+            ipc::SOLO_INDEX => self.rebuild_solo(),
             _ => {
                 if let Some((band, _)) = ipc::decode_band_wire(wire_index) {
                     self.rebuild_band(band);
+                    // Editing the soloed band must retune what you are hearing,
+                    // otherwise the audition window stays where the band used
+                    // to be while you drag it.
+                    if self.params.solo_band == band as i32 {
+                        self.rebuild_solo();
+                    }
                 }
             }
         }
@@ -261,6 +293,24 @@ impl Dsp {
         for i in 0..BAND_COUNT {
             self.rebuild_band(i);
         }
+        self.rebuild_solo();
+    }
+
+    /// Build the audition bandpass for the soloed band, if any.
+    fn rebuild_solo(&mut self) {
+        let index = self.params.solo_band;
+        let filter = if index >= 0 && (index as usize) < BAND_COUNT {
+            let band = self.params.bands[index as usize];
+            let q = match band.band_type {
+                BandType::Bell | BandType::Notch => band.q,
+                _ => SOLO_WIDE_Q,
+            };
+            make_eq_biquad("bandpass", band.freq, 0.0, q, self.sample_rate)
+        } else {
+            None
+        };
+        self.solo_left = filter;
+        self.solo_right = filter;
     }
 
     fn rebuild_band(&mut self, index: usize) {
@@ -290,6 +340,9 @@ impl StereoEffect for Dsp {
         for filter in self.right.iter_mut().flatten() {
             filter.reset_state();
         }
+        for filter in self.solo_left.iter_mut().chain(self.solo_right.iter_mut()) {
+            filter.reset_state();
+        }
     }
 
     fn set_sample_rate(&mut self, sample_rate: f32) {
@@ -300,6 +353,18 @@ impl StereoEffect for Dsp {
     fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32) {
         if !self.params.power {
             return (left, right);
+        }
+
+        // Band solo replaces the chain rather than adding to it, and
+        // deliberately ignores Mix: auditioning a band means hearing that
+        // frequency region alone, so blending the dry signal back in would
+        // defeat the point. Output level still applies so the audition can be
+        // matched in loudness.
+        if let (Some(solo_l), Some(solo_r)) = (self.solo_left.as_mut(), self.solo_right.as_mut()) {
+            return (
+                solo_l.run(left) * self.output_gain,
+                solo_r.run(right) * self.output_gain,
+            );
         }
 
         let mut wet_l = left;
@@ -341,6 +406,121 @@ mod tests {
         let mut dsp = Dsp::new(48_000.0);
         let (l, r) = dsp.process_stereo(0.5, -0.5);
         assert!(l.is_finite() && r.is_finite());
+    }
+
+    /// Measure output level at one frequency by running a sine through the DSP.
+    fn level_at(dsp: &mut Dsp, freq_hz: f32) -> f32 {
+        dsp.reset();
+        let sr = 48_000.0f32;
+        let step = std::f32::consts::TAU * freq_hz / sr;
+        // Settle the filter state before measuring.
+        for i in 0..4_000 {
+            let _ = dsp.process_stereo((i as f32 * step).sin(), 0.0);
+        }
+        let mut peak = 0.0f32;
+        for i in 4_000..8_000 {
+            let (l, _) = dsp.process_stereo((i as f32 * step).sin(), 0.0);
+            peak = peak.max(l.abs());
+        }
+        peak
+    }
+
+    #[test]
+    fn solo_isolates_the_band_frequency_region() {
+        let mut params = default_params();
+        // A bell at 1 kHz, soloed. Everything far from it must drop away.
+        params.bands[4].band_type = BandType::Bell;
+        params.bands[4].freq = 1_000.0;
+        params.bands[4].q = 2.0;
+        params.solo_band = 4;
+
+        let mut dsp = Dsp::new(48_000.0);
+        dsp.set_params(params);
+
+        let in_band = level_at(&mut dsp, 1_000.0);
+        let below = level_at(&mut dsp, 100.0);
+        let above = level_at(&mut dsp, 10_000.0);
+
+        assert!(
+            in_band > 0.5,
+            "the soloed region must pass through, got {in_band}"
+        );
+        assert!(
+            below < in_band * 0.2,
+            "content an octave-plus below must be rejected: {below} vs {in_band}"
+        );
+        assert!(
+            above < in_band * 0.2,
+            "content well above must be rejected: {above} vs {in_band}"
+        );
+    }
+
+    #[test]
+    fn solo_ignores_mix_so_the_dry_signal_cannot_mask_it() {
+        let mut params = default_params();
+        params.bands[4].band_type = BandType::Bell;
+        params.bands[4].freq = 1_000.0;
+        params.bands[4].q = 2.0;
+        params.solo_band = 4;
+        // Fully dry would normally bypass the chain entirely.
+        params.mix = 0.0;
+
+        let mut dsp = Dsp::new(48_000.0);
+        dsp.set_params(params);
+        let below = level_at(&mut dsp, 100.0);
+        assert!(
+            below < 0.2,
+            "solo must still reject out-of-band content at mix=0, got {below}"
+        );
+    }
+
+    #[test]
+    fn clearing_solo_restores_the_full_chain() {
+        let mut params = default_params();
+        params.solo_band = 2;
+        let mut dsp = Dsp::new(48_000.0);
+        dsp.set_params(params);
+        assert!(level_at(&mut dsp, 10_000.0) < 0.2, "soloed: highs rejected");
+
+        assert!(dsp.apply_wire_param(ipc::SOLO_INDEX, ipc::SOLO_NONE as f32));
+        assert!(
+            level_at(&mut dsp, 10_000.0) > 0.5,
+            "clearing solo must let the full chain through again"
+        );
+    }
+
+    /// Dragging the soloed band has to retune what you hear, or the audition
+    /// window stays where the band used to be.
+    #[test]
+    fn editing_the_soloed_band_retunes_the_audition() {
+        let mut params = default_params();
+        params.bands[4].band_type = BandType::Bell;
+        params.bands[4].freq = 1_000.0;
+        params.bands[4].q = 2.0;
+        params.solo_band = 4;
+        let mut dsp = Dsp::new(48_000.0);
+        dsp.set_params(params);
+        assert!(
+            level_at(&mut dsp, 5_000.0) < 0.2,
+            "5 kHz starts out rejected"
+        );
+
+        assert!(dsp.apply_wire_param(ipc::band_wire_index(4, ipc::BAND_FREQ), 5_000.0));
+        assert!(
+            level_at(&mut dsp, 5_000.0) > 0.5,
+            "moving the soloed band to 5 kHz must move the audition with it"
+        );
+    }
+
+    #[test]
+    fn out_of_range_solo_index_clears_instead_of_wedging() {
+        let mut dsp = Dsp::new(48_000.0);
+        assert!(dsp.apply_wire_param(ipc::SOLO_INDEX, 99.0));
+        assert_eq!(dsp.params().solo_band, ipc::SOLO_NONE);
+        assert!(
+            level_at(&mut dsp, 10_000.0) > 0.5,
+            "no band should be soloed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two separate complaints about Equz8: adjusting a band needed far too much movement before anything changed, and there was no way to listen to a single band's range the way Pro-Q lets you.

## Q had no mapping at all

`ControlRack` passed neither `toProgress` nor `fromProgress` for Q, so the knob fell back to the default **linear** map over `0.1..12`.

Q is perceptually *multiplicative* — 0.5 → 1 is the same musical step as 4 → 8. Laid out linearly:

- the useful 0.5–3 region gets **21%** of the travel
- the remaining 79% is spent between 3 and 12, where a whole unit of Q is barely audible

Now mapped with `scaleLog`, the way the frequency axis already worked, so every octave of Q gets equal distance.

The graph's wheel gesture was worse:

```ts
q: clamp(band.q - Math.sign(event.deltaY) * 0.12, ...)
```

A flat ±0.12 per notch more than doubles Q at the bottom of the range and moves it ~1% at the top — **Q 1 → 8 took 58 notches**. `Math.sign` also discarded how far the wheel actually moved, making every gesture exactly one step no matter how hard it was flicked. It now scales by a ratio per notch (1.15, or 1.03 with Shift) and accumulates by magnitude, so trackpads and hi-res wheels get proportionally smaller steps.

## Band solo

Auditions one band's frequency range on its own. DSP, schema and persistence stay in Rust per the plugin contract — the editor is a thin view over a real parameter.

- A new `solo_band` parameter drives a bandpass at the band's frequency, using the band's own Q for bells and notches and a fixed wide Q for shapes with no meaningful centre width (shelves, pass filters).
- Solo **replaces** the chain rather than adding to it, and deliberately ignores Mix — blending the dry signal back in would defeat the audition. Output level still applies so the audition can be level-matched.
- Editing the soloed band retunes it, so the audition follows while you drag rather than staying where the band used to be.

**Three ways in**, because this is worth reaching for mid-mix:

| Gesture | Behaviour |
|---|---|
| Hold **right button** on a node | Momentary — sweep and listen; releasing restores whatever solo state was there before |
| **Alt-click** a node | Latches on/off |
| Solo button in the rack | Latches on/off |

It releases on Escape, on unmount, and on a pointer release outside the window. A missed release would leave the EQ silently stuck bandpassing one band, so every teardown path routes through one function.

## Compatibility

`soloBand` is appended **after** the per-band block rather than inserted beside the other globals: band wire indices derive from `BAND_BASE_INDEX`, so inserting ahead of them would renumber every band and silently repoint in-flight edits. A test pins this. Projects saved before solo existed load with it off, on both sides of the bridge.

## Verification

```
cargo test -p equz8            ->  18 passed (was 7)
cargo test -p builtin_dsp_core ->  2 passed
cargo check -p BuiltinAudioPlugins -> clean
bun run build (tsc -b + vite)  -> clean
bun run lint (eslint)          -> clean
cargo fmt                      -> clean
```

The solo tests measure real DSP rather than checking a flag: a sine is run through the processor and the output level sampled. A band soloed at 1 kHz must pass >0.5 while 100 Hz and 10 kHz drop below 20% of it, and there are separate tests for solo surviving `mix = 0`, for clearing solo restoring the full chain, and for an out-of-range index clearing rather than wedging the DSP.

`eslint` caught a genuine bug during development — a ref written during render — which is fixed.

## Not verified

The pointer gestures themselves are UI-only and are not covered by automated tests; they need a run in the real plugin editor. In particular the right-button drag depends on CEF delivering pointer moves while the right button is held. The native path forwards `MouseButton::Right` for down/up/up-out and sets the right-button modifier flag on outgoing moves, so it should, but that is read from the code rather than observed.

The drag is driven from window-level pointer events rather than the SVG's own handlers, because Blink fires `pointercancel` when it opens a context menu, which drops pointer capture and would strand the gesture the instant it began.