### PR TITLE
Let EQ bands reach 20 kHz, and draw the curve at the real sample rate

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/builtin_dsp_core/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/builtin_dsp_core/src/lib.rs
@@ -209,7 +209,10 @@ impl SoftKneeCompressor {
             return;
         }
         let fs = self.sample_rate.hz();
-        let f0 = self.sc_cutoff_hz.min(self.sample_rate * 0.45).hz();
+        let f0 = self
+            .sc_cutoff_hz
+            .min(max_filter_frequency(self.sample_rate))
+            .hz();
         let Ok(coeffs) = Coefficients::<f32>::from_params(Type::HighPass, fs, f0, 0.707) else {
             self.sidechain_hpf = None;
             return;
@@ -218,12 +221,32 @@ impl SoftKneeCompressor {
     }
 }
 
+/// Fraction of the sample rate a filter's centre frequency may reach.
+///
+/// The bilinear transform degenerates as `f0` approaches Nyquist — `sin(w0)`
+/// goes to zero and with it `alpha`, so the coefficients lose all resolution —
+/// hence a guard band rather than `0.5` outright.
+///
+/// It was `0.45`, which is below 20 kHz at 44.1 kHz: the top of the audio band
+/// was unreachable at the most common sample rate, so an EQ band dragged to
+/// 20 kHz silently sat at 19,845 Hz instead. `0.49` clears 20 kHz at 44.1 kHz
+/// with ~440 Hz still in hand, and stays comfortably stable — at the extreme
+/// (`Q = 12`, ±18 dB) the poles sit at a radius near 0.998.
+pub const MAX_FILTER_FREQUENCY_RATIO: f32 = 0.49;
+
+/// Highest centre frequency a filter may be tuned to at `sample_rate`.
+pub fn max_filter_frequency(sample_rate: f32) -> f32 {
+    sample_rate.max(1.0) * MAX_FILTER_FREQUENCY_RATIO
+}
+
 /// Build biquad coefficients from common EQ band kinds.
 ///
 /// Prefer this over [`make_eq_biquad`] for a filter that is already running:
 /// coefficients can be handed to `Biquad::update_coefficients`, which retunes
 /// in place, whereas installing a fresh `DirectForm1` also installs its zeroed
 /// history and steps the signal.
+///
+/// The centre frequency is clamped to [`max_filter_frequency`].
 pub fn make_eq_coefficients(
     kind: &str,
     freq_hz: f32,
@@ -232,7 +255,7 @@ pub fn make_eq_coefficients(
     sample_rate: f32,
 ) -> Option<Coefficients<f32>> {
     let fs = sample_rate.max(1.0);
-    let f0 = clamp(freq_hz, 10.0, fs * 0.45);
+    let f0 = clamp(freq_hz, 10.0, max_filter_frequency(fs));
     let q = clamp(q, 0.1, 12.0);
     let filter_type = match kind {
         "bell" | "peak" | "peaking" => Type::PeakingEQ(gain_db),
@@ -285,5 +308,66 @@ mod tests {
     fn eq_biquad_builds() {
         assert!(make_eq_biquad("bell", 1_000.0, 3.0, 1.0, 48_000.0).is_some());
         assert!(make_eq_biquad("highpass", 80.0, 0.0, 0.7, 48_000.0).is_some());
+    }
+
+    /// The top of the audio band has to be reachable at every supported rate.
+    /// The old 0.45 ratio put the ceiling at 19,845 Hz on 44.1 kHz, so a band
+    /// asked for 20 kHz quietly sat below it.
+    #[test]
+    fn twenty_kilohertz_is_reachable_at_every_common_rate() {
+        for rate in [44_100.0, 48_000.0, 88_200.0, 96_000.0, 192_000.0] {
+            assert!(
+                max_filter_frequency(rate) >= 20_000.0,
+                "{rate} Hz caps filters at {} Hz, below the audio band",
+                max_filter_frequency(rate)
+            );
+        }
+    }
+
+    /// ...but never at or above Nyquist, where the bilinear transform collapses.
+    #[test]
+    fn the_ceiling_stays_below_nyquist() {
+        for rate in [8_000.0, 44_100.0, 48_000.0, 192_000.0] {
+            assert!(max_filter_frequency(rate) < rate * 0.5);
+        }
+    }
+
+    /// A filter built right at the ceiling must stay stable and finite under
+    /// the worst-case settings, not just be constructible.
+    #[test]
+    fn filters_at_the_ceiling_stay_stable() {
+        for rate in [44_100.0f32, 48_000.0, 96_000.0] {
+            let ceiling = max_filter_frequency(rate);
+            for kind in [
+                "bell",
+                "lowshelf",
+                "highshelf",
+                "lowpass",
+                "highpass",
+                "notch",
+            ] {
+                for gain in [-18.0f32, 0.0, 18.0] {
+                    let mut filter = make_eq_biquad(kind, ceiling, gain, 12.0, rate)
+                        .unwrap_or_else(|| panic!("{kind} at {ceiling} Hz should build"));
+                    // Drive it hard, then confirm it settles rather than running away.
+                    let mut peak = 0.0f32;
+                    for i in 0..4_000 {
+                        let input = if i % 2 == 0 { 1.0 } else { -1.0 };
+                        let out = filter.run(input);
+                        assert!(
+                            out.is_finite(),
+                            "{kind} {gain} dB at {rate} Hz produced {out}"
+                        );
+                        if i > 2_000 {
+                            peak = peak.max(out.abs());
+                        }
+                    }
+                    assert!(
+                        peak < 100.0,
+                        "{kind} {gain} dB at {rate} Hz ran away to {peak}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/App.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/App.tsx
@@ -7,6 +7,7 @@ import {
   type EqParams,
   type SpectrumFrame,
 } from './bridge'
+import { DEFAULT_SAMPLE_RATE } from './lib/eq'
 import { BandChips } from './components/BandChips'
 import { ControlRack } from './components/ControlRack'
 import { Header } from './components/Header'
@@ -28,6 +29,11 @@ function App() {
   const [showBandCurves, setShowBandCurves] = useState(true)
   const [showSpectrum, setShowSpectrum] = useState(true)
   const [preset, setPreset] = useState<number | null>(0)
+  /// The rate the host is actually running at, threaded into the curve maths.
+  /// Drawing at a fixed 48 kHz made the picture disagree with what you hear on
+  /// any other rate, most visibly at the top of the range where the bilinear
+  /// transform warps hardest.
+  const [sampleRate, setRate] = useState(DEFAULT_SAMPLE_RATE)
 
   /// Analyser frames land in a ref, never in state: at ~30 Hz a `setState` per
   /// frame would rerender every curve, node and label in the editor to repaint
@@ -50,6 +56,7 @@ function App() {
         (frame) => {
           spectrum.current = frame
         },
+        (rate) => setRate(rate),
       ),
     [],
   )
@@ -164,6 +171,7 @@ function App() {
 
       <section className="stage">
         <ResponseGraph
+          sampleRate={sampleRate}
           bands={params.bands}
           selected={selected}
           bypassed={!params.power}

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/bridge.ts
@@ -69,6 +69,17 @@ type SpectrumMessage = SpectrumFrame & {
   instanceId: string
 }
 
+/// Low-rate (~1 Hz) host telemetry. Only `sampleRate` is consumed here — the
+/// response curve has to be drawn against the rate the audio actually runs at.
+type HostStatusMessage = {
+  type: 'futureboard.hostStatus'
+  protocolVersion: number
+  instanceId: string
+  sampleRate: number
+  blockSize: number
+  latencySamples: number
+}
+
 let binding: Binding | null = null
 const pending = new Map<string, number>()
 let scheduled = false
@@ -139,6 +150,7 @@ export function connectBridge(
   onParams: (params: EqParams) => void,
   onConnection: (connected: boolean) => void,
   onSpectrum?: (frame: SpectrumFrame) => void,
+  onSampleRate?: (sampleRate: number) => void,
 ) {
   post({
     type: 'futureboard.bridgeReady',
@@ -152,6 +164,7 @@ export function connectBridge(
       | SelectInstanceMessage
       | InstanceRemovedMessage
       | SpectrumMessage
+      | HostStatusMessage
       | undefined
     if (!message || typeof message !== 'object') return
 
@@ -167,6 +180,18 @@ export function connectBridge(
         ceilDb: message.ceilDb,
         bins: message.bins,
       })
+      return
+    }
+
+    // The response curve is computed against the rate the audio actually runs
+    // at, so the picture matches what the DSP is doing rather than assuming
+    // 48 kHz. It matters most at the top of the range, where the bilinear
+    // transform warps hardest.
+    if (message.type === 'futureboard.hostStatus') {
+      if (binding?.instanceId !== message.instanceId) return
+      if (typeof message.sampleRate === 'number' && message.sampleRate > 0) {
+        onSampleRate?.(message.sampleRate)
+      }
       return
     }
 

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ResponseGraph.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ResponseGraph.tsx
@@ -62,6 +62,10 @@ export type ResponseGraphProps = {
   spectrumRef: RefObject<SpectrumFrame | null>
   /// Band currently auditioned alone, or `SOLO_NONE`.
   soloBand: number
+  /// Rate the host is running at. Not read directly — the curve helpers take it
+  /// from module state — but listed as a memo dependency so a rate change
+  /// redraws instead of leaving a curve computed for the previous rate.
+  sampleRate: number
   onSelect: (index: number) => void
   onBandChange: (index: number, patch: Partial<Band>) => void
   onToggleSolo: (index: number) => void
@@ -76,6 +80,7 @@ export function ResponseGraph({
   showSpectrum,
   spectrumRef,
   soloBand,
+  sampleRate,
   onSelect,
   onBandChange,
   onToggleSolo,
@@ -112,24 +117,26 @@ export function ResponseGraph({
 
   const { width, height } = size
   const sumPath = useMemo(
-    () => sumCurvePath(bands, width, height),
-    [bands, height, width],
+    () => sumCurvePath(bands, width, height, sampleRate),
+    [bands, height, width, sampleRate],
   )
   const perBandPaths = useMemo(
     () =>
       showBandCurves
         ? bands.map((band, index) =>
             band.active && index !== selected
-              ? bandCurvePath(band, width, height)
+              ? bandCurvePath(band, width, height, sampleRate)
               : null,
           )
         : null,
-    [bands, height, selected, showBandCurves, width],
+    [bands, height, selected, showBandCurves, width, sampleRate],
   )
   const selectedPath = useMemo(() => {
     const band = bands[selected]
-    return band?.active ? bandCurvePath(band, width, height) : null
-  }, [bands, height, selected, width])
+    return band?.active
+      ? bandCurvePath(band, width, height, sampleRate)
+      : null
+  }, [bands, height, selected, width, sampleRate])
 
   /// Client coordinates mapped into the same viewBox space the curves, grid and
   /// nodes are drawn in, so a stale measurement can never make drawing and
@@ -336,7 +343,7 @@ export function ResponseGraph({
           <line x1={cursor.x} x2={cursor.x} y1={0} y2={height} />
           <text x={width - 9} y={16}>
             {formatFrequency(cursorFreq)} Hz{' '}
-            {formatGain(sumDbAt(bands, cursorFreq))} dB
+            {formatGain(sumDbAt(bands, cursorFreq, sampleRate))} dB
           </text>
         </g>
       )}

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/lib/eq.ts
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/lib/eq.ts
@@ -9,7 +9,20 @@ export const MIN_Q = 0.1
 export const MAX_Q = 12
 export const OUTPUT_MIN_DB = -24
 export const OUTPUT_MAX_DB = 12
-export const SAMPLE_RATE = 48_000
+/// Rate assumed before the host reports the real one, and the fallback in a
+/// plain browser where no host is bound.
+export const DEFAULT_SAMPLE_RATE = 48_000
+
+/// Highest centre frequency a filter can be tuned to at `sampleRate`.
+///
+/// Mirrors `builtin_dsp_core::MAX_FILTER_FREQUENCY_RATIO`. The DSP clamps to
+/// this, so the curve has to as well or it would draw a band where the audio
+/// cannot actually put one.
+export const MAX_FILTER_FREQUENCY_RATIO = 0.49
+
+export function maxFilterFrequency(sampleRate: number) {
+  return sampleRate * MAX_FILTER_FREQUENCY_RATIO
+}
 
 /// The graph's two axes, as single shared d3 scales.
 ///
@@ -209,8 +222,17 @@ type Coefficients = {
   a2: number
 }
 
-export function bandCoefficients(band: Band): Coefficients {
-  const w0 = (2 * Math.PI * clamp(band.freq, MIN_FREQ, MAX_FREQ)) / SAMPLE_RATE
+export function bandCoefficients(
+  band: Band,
+  sampleRate: number,
+): Coefficients {
+  // Clamped the same way the DSP clamps it, so the drawn curve cannot show a
+  // band sitting somewhere the filter is not able to go.
+  const f0 = Math.min(
+    clamp(band.freq, MIN_FREQ, MAX_FREQ),
+    maxFilterFrequency(sampleRate),
+  )
+  const w0 = (2 * Math.PI * f0) / sampleRate
   const cos = Math.cos(w0)
   const sin = Math.sin(w0)
   const alpha = sin / (2 * clamp(band.q, MIN_Q, MAX_Q))
@@ -279,8 +301,12 @@ export function bandCoefficients(band: Band): Coefficients {
   return { b0: b0 / a0, b1: b1 / a0, b2: b2 / a0, a1: a1 / a0, a2: a2 / a0 }
 }
 
-function magnitudeDb(coeff: Coefficients, frequency: number) {
-  const w = (2 * Math.PI * frequency) / SAMPLE_RATE
+function magnitudeDb(
+  coeff: Coefficients,
+  frequency: number,
+  sampleRate: number,
+) {
+  const w = (2 * Math.PI * frequency) / sampleRate
   const c1 = Math.cos(w)
   const s1 = Math.sin(w)
   const c2 = Math.cos(2 * w)
@@ -321,22 +347,41 @@ function tracePath(
   return curveBuilder(points) ?? ''
 }
 
-export function sumCurvePath(bands: Band[], width: number, height: number) {
+export function sumCurvePath(
+  bands: Band[],
+  width: number,
+  height: number,
+  sampleRate: number,
+) {
   const active = bands
     .filter((band) => band.active)
-    .map((band) => bandCoefficients(band))
+    .map((band) => bandCoefficients(band, sampleRate))
   return tracePath(width, height, (frequency) =>
-    active.reduce((sum, coeff) => sum + magnitudeDb(coeff, frequency), 0),
+    active.reduce(
+      (sum, coeff) => sum + magnitudeDb(coeff, frequency, sampleRate),
+      0,
+    ),
   )
 }
 
-export function bandCurvePath(band: Band, width: number, height: number) {
-  const coeff = bandCoefficients(band)
-  return tracePath(width, height, (frequency) => magnitudeDb(coeff, frequency))
+export function bandCurvePath(
+  band: Band,
+  width: number,
+  height: number,
+  sampleRate: number,
+) {
+  const coeff = bandCoefficients(band, sampleRate)
+  return tracePath(width, height, (frequency) =>
+    magnitudeDb(coeff, frequency, sampleRate),
+  )
 }
 
-export function sumDbAt(bands: Band[], frequency: number) {
+export function sumDbAt(bands: Band[], frequency: number, sampleRate: number) {
   return bands
     .filter((band) => band.active)
-    .reduce((sum, band) => sum + magnitudeDb(bandCoefficients(band), frequency), 0)
+    .reduce(
+      (sum, band) =>
+        sum + magnitudeDb(bandCoefficients(band, sampleRate), frequency, sampleRate),
+      0,
+    )
 }


### PR DESCRIPTION
Follows #68 (now merged); this is one commit on top of it.

## The clamp

Filter centre frequencies were clamped to `0.45 × sample_rate`.

At **44.1 kHz that is 19,845 Hz** — the top of the audio band was unreachable at the most common sample rate. A band dragged to 20 kHz silently sat below it, which is the reported symptom.

Raised to `0.49`, which clears 20 kHz at 44.1 kHz with ~440 Hz still in hand:

| rate | old ceiling | new ceiling |
|---|---|---|
| 44.1 kHz | 19,845 Hz ❌ | 21,609 Hz |
| 48 kHz | 21,600 Hz | 23,520 Hz |
| 96 kHz | 43,200 Hz | 47,040 Hz |

It cannot be `0.5` outright: the bilinear transform degenerates as `f0` approaches Nyquist — `sin(w0)` and with it `alpha` go to zero, and the coefficients lose all resolution. The ratio is now named rather than repeated as a magic number, and the compressor's sidechain high-pass, which had the same `0.45` hardcoded, uses it too.

## The matching half in the editor

The editor computed its response curve against a **hardcoded 48 kHz** while the DSP evaluated biquads at whatever the host was actually running. The drawn curve therefore disagreed with what you heard on any other rate — worst at the top of the range, where the warping is largest and where a band now sits closest to Nyquist. Raising the clamp widens that discrepancy, so the two belong in one change.

The host already publishes its rate via `futureboard.hostStatus`; this editor simply never listened. It does now, and clamps the drawn curve the same way the DSP clamps the filter, so the graph cannot show a band somewhere the audio is unable to put one.

## Verification

```
cargo test -p builtin_dsp_core ->  5 passed (was 2)
cargo test -p equz8            -> 18 passed
cargo check -p BuiltinAudioPlugins -> clean
bun run build / lint           -> clean
cargo fmt                      -> clean
```

Widening a ceiling cannot destabilise a filter that already fit under the old one, but the new limit is now covered directly: `filters_at_the_ceiling_stay_stable` builds every band kind *at* the ceiling across 44.1/48/96 kHz at maximum Q and ±18 dB, drives it with an alternating full-scale signal, and asserts the output stays finite and does not diverge — not merely that the filter is constructible.

Reverting the ratio to `0.45` makes `twenty_kilohertz_is_reachable_at_every_common_rate` fail, which was confirmed before keeping the test.

## Note on a self-correction

An earlier revision kept the sample rate in module state and passed it as a memo dependency purely to force redraws. `eslint` correctly flagged it as a dependency the memo never reads — the same class of hidden global that let the 48 kHz assumption go unnoticed in the first place. It is now threaded through the curve helpers as an argument. (An even earlier attempt used `key=` to force a remount, which would have torn down the spectrum layer's WebGL context on every rate change.)

## Not verified

Not exercised in a running build. The claim that a band now reaches 20 kHz at 44.1 kHz, and that the drawn curve lines up with what is heard, is unit-level here and worth a look in the real editor.

`verbspace` and `c1073` share the coefficient factory and are unaffected in behaviour, but that is reasoned from the change being a widening rather than observed.