### PR TITLE
Bake in the Discord application ID

### DIFF
--- a/apps/native/studio/build.rs
+++ b/apps/native/studio/build.rs
@@ -11,9 +11,10 @@ fn main() {
     stage_exclusive_sources();
     download_onnxruntime();
 
-    // Keep the local Discord application id out of source control while still
-    // making it available to `option_env!` in the native binary. An explicit
-    // build environment value wins for CI/distribution builds.
+    // Optional override for the Discord application id. Futureboard's own is
+    // compiled into `sphere_discord_rpc` (`DEFAULT_APPLICATION_ID`), so this
+    // only matters for a fork or a build that targets a different Discord
+    // application. An explicit build environment value wins over the file.
     if std::env::var_os("FUTUREBOARD_DISCORD_CLIENT_ID").is_none() {
         if let Ok(application_id) = std::fs::read_to_string("../../../.discordrpcsecret") {
             let application_id = application_id.trim();

--- a/apps/native/studio/src/main.rs
+++ b/apps/native/studio/src/main.rs
@@ -56,22 +56,14 @@ fn main() {
     // app-visible plugin window from spawning a stray taskbar identity.
     sphere_ui_components::plugin_host_lifecycle::set_futureboard_app_user_model_id();
 
-    // Discord IPC is optional and never runs on the GPUI thread. Production
-    // builds can bake in FUTUREBOARD_DISCORD_CLIENT_ID; development builds may
-    // provide it at runtime. Missing Discord/config must not block app startup.
+    // Discord IPC is optional and never runs on the GPUI thread. The
+    // application ID resolves to Futureboard's own unless a build or runtime
+    // override points elsewhere, so a plain checkout gets Rich Presence without
+    // any local configuration. Missing Discord itself must not block startup.
     let discord_rpc_enabled = sphere_ui_components::settings::SettingsSchema::load_from_disk()
         .general
         .discord_rpc_enabled;
-    let discord_application_id = std::env::var("FUTUREBOARD_DISCORD_CLIENT_ID")
-        .ok()
-        .or_else(|| option_env!("FUTUREBOARD_DISCORD_CLIENT_ID").map(str::to_owned));
-    let discord_rpc = discord_application_id
-        .and_then(|application_id| {
-            sphere_discord_rpc::DiscordRpcConfig::from_application_id(
-                application_id,
-                env!("CARGO_PKG_VERSION"),
-            )
-        })
+    let discord_rpc = sphere_discord_rpc::DiscordRpcConfig::from_env(env!("CARGO_PKG_VERSION"))
         .and_then(|config| {
             match sphere_discord_rpc::DiscordRpc::start(
                 config,

--- a/crates/SphereDiscordRPC/src/lib.rs
+++ b/crates/SphereDiscordRPC/src/lib.rs
@@ -13,6 +13,19 @@ use thiserror::Error;
 const RETRY_INTERVAL: Duration = Duration::from_secs(15);
 const DEFAULT_LARGE_TEXT: &str = "Futureboard Studio";
 
+/// Futureboard's own Discord application ID.
+///
+/// Baked in rather than sourced from a file or environment variable so a plain
+/// checkout builds with Rich Presence working. Previously it came only from
+/// `.discordrpcsecret` or `FUTUREBOARD_DISCORD_CLIENT_ID`, and a build without
+/// either silently shipped with Discord integration switched off.
+///
+/// This is not a credential. A Discord application ID is a public identifier —
+/// it is sent in the RPC handshake and is visible to anyone running the app.
+/// The client *secret* and bot tokens are the sensitive values, and neither is
+/// used here: Rich Presence over local IPC needs no authentication.
+pub const DEFAULT_APPLICATION_ID: &str = "1517963140170649640";
+
 /// Runtime configuration for the Discord IPC worker.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscordRpcConfig {
@@ -24,14 +37,16 @@ pub struct DiscordRpcConfig {
 }
 
 impl DiscordRpcConfig {
-    /// Builds configuration from the Futureboard Discord environment flags.
+    /// Builds configuration from the Futureboard Discord environment flags,
+    /// falling back to [`DEFAULT_APPLICATION_ID`].
     ///
-    /// `FUTUREBOARD_DISCORD_CLIENT_ID` can be supplied at build time for a
-    /// distributable binary or at runtime for development. Runtime wins.
+    /// Resolution order, most specific first: a runtime
+    /// `FUTUREBOARD_DISCORD_CLIENT_ID`, the same name baked in at build time,
+    /// then the built-in default. The overrides exist so a fork or a CI build
+    /// can point at its own Discord application; nothing has to be configured
+    /// for the shipped one to work.
     pub fn from_env(app_version: impl Into<String>) -> Option<Self> {
-        let application_id = non_empty_env("FUTUREBOARD_DISCORD_CLIENT_ID")
-            .or_else(|| option_env!("FUTUREBOARD_DISCORD_CLIENT_ID").and_then(non_empty))?;
-        Self::from_application_id(application_id, app_version)
+        Self::from_application_id(resolve_application_id(), app_version)
     }
 
     /// Builds configuration around an application ID supplied by the native
@@ -310,6 +325,16 @@ fn unix_time_ms() -> i64 {
         .min(i64::MAX as u128) as i64
 }
 
+/// The Discord application ID this build should use.
+///
+/// Always yields something, so Rich Presence no longer depends on the build
+/// host having a `.discordrpcsecret` or an exported environment variable.
+pub fn resolve_application_id() -> String {
+    non_empty_env("FUTUREBOARD_DISCORD_CLIENT_ID")
+        .or_else(|| option_env!("FUTUREBOARD_DISCORD_CLIENT_ID").and_then(non_empty))
+        .unwrap_or_else(|| DEFAULT_APPLICATION_ID.to_string())
+}
+
 fn non_empty_env(name: &str) -> Option<String> {
     std::env::var(name).ok().and_then(|value| non_empty(&value))
 }
@@ -335,6 +360,50 @@ fn debug_log(message: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Rich Presence has to work from a plain checkout. This used to return
+    /// `None` unless the build host had a `.discordrpcsecret` or an exported
+    /// `FUTUREBOARD_DISCORD_CLIENT_ID`, which silently shipped the app with
+    /// Discord integration switched off.
+    #[test]
+    fn config_resolves_without_any_local_configuration() {
+        // Not `set_var`: the resolver reads the process environment, and tests
+        // share it. This asserts the fallback, which is what has no override.
+        let config =
+            DiscordRpcConfig::from_env("2026.7.2").expect("an application id must always resolve");
+        assert!(!config.application_id.trim().is_empty());
+        config
+            .validate()
+            .expect("the resolved config must be startable");
+    }
+
+    /// The baked-in id has to be a plausible Discord snowflake — a typo here
+    /// would fail only at runtime, as a handshake Discord silently ignores.
+    #[test]
+    fn default_application_id_is_a_snowflake() {
+        assert!(
+            DEFAULT_APPLICATION_ID.len() >= 17 && DEFAULT_APPLICATION_ID.len() <= 20,
+            "unexpected length: {DEFAULT_APPLICATION_ID}"
+        );
+        assert!(
+            DEFAULT_APPLICATION_ID
+                .chars()
+                .all(|character| character.is_ascii_digit()),
+            "must be all digits: {DEFAULT_APPLICATION_ID}"
+        );
+    }
+
+    #[test]
+    fn an_empty_application_id_is_still_rejected() {
+        let config = DiscordRpcConfig {
+            application_id: "  ".to_string(),
+            ..config(false)
+        };
+        assert!(matches!(
+            config.validate(),
+            Err(DiscordRpcStartError::MissingApplicationId)
+        ));
+    }
 
     fn config(show_project_name: bool) -> DiscordRpcConfig {
         DiscordRpcConfig {


### PR DESCRIPTION
Rich Presence only worked if the build host happened to have a `.discordrpcsecret` file or an exported `FUTUREBOARD_DISCORD_CLIENT_ID`. With neither, config resolution returned `None` and the app shipped with Discord integration **silently switched off** — which is what a plain checkout got. (This machine had no such file, so it had been off the whole time.)

## Change

The application ID is compiled into `sphere_discord_rpc` as `DEFAULT_APPLICATION_ID` and resolution goes through it:

1. runtime `FUTUREBOARD_DISCORD_CLIENT_ID`
2. the same name baked in at build time
3. the built-in default

The overrides are kept deliberately — a fork or a CI build can still target its own Discord application — but nothing has to be configured for the shipped one to work. `.discordrpcsecret` keeps its name and its place in `.gitignore`; it is now an override rather than a requirement, and `build.rs` says so.

`main.rs` was duplicating the same environment lookup and dropping Discord entirely when it came up empty. It now goes through `DiscordRpcConfig::from_env`, so there is one resolution path instead of two that could disagree.

## On committing this value

**A Discord application ID is not a credential.** It is a public identifier: it travels in the RPC handshake and is visible to anyone running the app, and it appears in OAuth URLs. The sensitive values are the client *secret* and bot tokens, and neither is used here — Rich Presence over local IPC needs no authentication. The reasoning is written into the doc comment so the next reader does not have to re-derive it, since the file it used to come from is called `.discordrpcsecret` and reads as though it were one.

## Verification

```
cargo test -p SphereDiscordRPC   ->  7 passed (was 4)
cargo check -p futureboard_native -> clean
cargo fmt                        -> clean
```

Three new tests:

- `config_resolves_without_any_local_configuration` — a config now resolves and validates with no environment variable and no file present, which is exactly the case that used to yield `None`
- `default_application_id_is_a_snowflake` — all digits, 17–20 characters; a typo here would otherwise surface only at runtime, as a handshake Discord quietly ignores
- `an_empty_application_id_is_still_rejected` — the existing `MissingApplicationId` guard is not weakened by the fallback

## Not verified

Not run against a live Discord client, so "presence actually appears and reads correctly" is unconfirmed — what is checked is that the config resolves, validates, and compiles into the app.