### PR TITLE
Fix playback stop, send/return, scroll, menus, MIDI, and recording

### DIFF
--- a/crates/SphereDirectAudioEngine/src/audio_graph.rs
+++ b/crates/SphereDirectAudioEngine/src/audio_graph.rs
@@ -99,6 +99,27 @@ pub fn is_routing_track_type(track_type: &str) -> bool {
     matches!(track_type, "bus" | "return" | "group")
 }
 
+/// True when adding `src → tgt` would close a cycle in the current adjacency.
+fn edge_would_cycle(adjacency: &[Vec<usize>], src: usize, tgt: usize) -> bool {
+    if src == tgt {
+        return true;
+    }
+    // Reachability from tgt back to src means src→tgt closes a loop.
+    let mut stack = vec![tgt];
+    let mut seen = vec![false; adjacency.len()];
+    while let Some(node) = stack.pop() {
+        if node == src {
+            return true;
+        }
+        if seen[node] {
+            continue;
+        }
+        seen[node] = true;
+        stack.extend(adjacency[node].iter().copied());
+    }
+    false
+}
+
 pub fn is_master_track_type(track_type: &str) -> bool {
     track_type == "master"
 }
@@ -211,12 +232,12 @@ pub fn plan_runtime_audio_graph(
                 });
                 continue;
             }
-            if src_routing && tgt_idx <= src_idx {
+            if src_routing && edge_would_cycle(&adjacency, src_idx, tgt_idx) {
                 rejected_routes.push(GraphRouteIssue {
                     from_track_id: track.id.clone(),
                     to_track_id: send.return_track_id.clone(),
                     kind: GraphRouteKind::Send,
-                    reason: "routing source may only send forward in graph order".to_string(),
+                    reason: "send would create a routing cycle".to_string(),
                 });
                 continue;
             }
@@ -254,12 +275,12 @@ pub fn plan_runtime_audio_graph(
                 });
                 continue;
             }
-            if src_routing && tgt_idx <= src_idx {
+            if src_routing && edge_would_cycle(&adjacency, src_idx, tgt_idx) {
                 rejected_routes.push(GraphRouteIssue {
                     from_track_id: track.id.clone(),
                     to_track_id: output_id.to_string(),
                     kind: GraphRouteKind::MainOutput,
-                    reason: "routing source may only target later routing tracks".to_string(),
+                    reason: "output route would create a routing cycle".to_string(),
                 });
                 continue;
             }
@@ -449,16 +470,39 @@ mod tests {
     }
 
     #[test]
-    fn rejects_backward_bus_send_before_cycle_dfs() {
+    fn rejects_cyclic_bus_send() {
         let tracks = vec![
             track("a", "bus", vec![send("s1", "b")], Some("b")),
             track("b", "return", vec![send("s2", "a")], None),
         ];
         let graph = plan_runtime_audio_graph(&tracks).unwrap();
-        assert_eq!(graph.pass2_routing_indices, vec![0, 1]);
+        // a→b is accepted; b→a closes a cycle and is rejected.
         assert!(graph.rejected_routes.iter().any(|r| {
             r.from_track_id == "b" && r.to_track_id == "a" && r.kind == GraphRouteKind::Send
         }));
+        let ids: Vec<_> = graph
+            .pass2_routing_indices
+            .iter()
+            .map(|&i| tracks[i].id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn accepts_reverse_index_bus_chain_without_cycle() {
+        // Return created before bus (lower index), bus sends into return.
+        let tracks = vec![
+            track("ret", "return", vec![], None),
+            track("bus", "bus", vec![send("s", "ret")], None),
+        ];
+        let graph = plan_runtime_audio_graph(&tracks).unwrap();
+        assert!(graph.rejected_routes.is_empty());
+        let ids: Vec<_> = graph
+            .pass2_routing_indices
+            .iter()
+            .map(|&i| tracks[i].id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["bus", "ret"]);
     }
 
     #[test]

--- a/crates/SphereDirectAudioEngine/src/backend/render.rs
+++ b/crates/SphereDirectAudioEngine/src/backend/render.rs
@@ -423,6 +423,13 @@ pub fn drain_commands(
                 // sinks still needs flushing through the new graph.
                 runtime.bridge_panic_flush_samples = old.bridge_panic_flush_samples;
                 runtime.bridge_preview_tail_samples = old.bridge_preview_tail_samples;
+                // Keep the live master-fader ramp continuous across media/control
+                // graph swaps (clip mute/gain sync). Prefer the live master
+                // atomic (authoritative fader position) so a fresh runtime that
+                // still carries the build-time seed of 1.0 cannot briefly
+                // bypass a lowered master on the first blocks after LoadProject.
+                runtime.smoothed_master_gain =
+                    f32_load(shared.master_volume.load(Ordering::Relaxed));
                 crate::graveyard::retire(old);
                 // Transport/audio-graph separation: a graph swap must never
                 // change the user's transport state.  If the transport was
@@ -535,6 +542,10 @@ pub fn drain_commands(
                     );
                 }
                 runtime.all_notes_off("stop");
+                // Drop latency-compensated pre-stop audio immediately so Stop
+                // cuts at the command. Plugin release / reverb still ring out
+                // via `stop_tail_samples`; only the PDC rings are cleared.
+                runtime.reset_pdc_delay_lines();
             }
             EngineCommand::Seek { position_seconds } => {
                 let sr = shared.sample_rate.load(Ordering::Relaxed) as f64;

--- a/crates/SphereDirectAudioEngine/src/engine.rs
+++ b/crates/SphereDirectAudioEngine/src/engine.rs
@@ -1123,6 +1123,11 @@ impl EngineInner {
     }
 
     pub fn pause(&self) -> Result<(), SphereAudioError> {
+        // Eagerly clear the shared transport flag so UI playhead / polls stop
+        // at the command without waiting for the next audio callback drain.
+        // The audio thread still applies StopTransport (notes-off, PDC clear,
+        // post-stop tail) when it drains the queue.
+        self.shared.playing.store(false, Ordering::Relaxed);
         self.send_command(EngineCommand::StopTransport)
     }
 
@@ -3935,6 +3940,10 @@ where
                             // still needs flushing through the new graph.
                             runtime.bridge_panic_flush_samples = old.bridge_panic_flush_samples;
                             runtime.bridge_preview_tail_samples = old.bridge_preview_tail_samples;
+                            // Keep the live master-fader ramp continuous across
+                            // media/control graph swaps (clip mute/gain sync).
+                            runtime.smoothed_master_gain =
+                                f32_load(shared.master_volume.load(Ordering::Relaxed));
                             let pos = shared.position_samples.load(Ordering::Relaxed);
                             metronome.set_tempo_map(
                                 runtime.tempo_map.clone(),
@@ -4012,6 +4021,9 @@ where
                             shared.playing.store(false, Ordering::Relaxed);
                             // Release held notes so nothing is left stuck.
                             runtime.all_notes_off("stop");
+                            // Drop latency-compensated pre-stop audio immediately so
+                            // Stop cuts at the command (parity with the DAUx path).
+                            runtime.reset_pdc_delay_lines();
                         }
                         EngineCommand::Seek { position_seconds } => {
                             let sr_local = shared.sample_rate.load(Ordering::Relaxed) as f64;
@@ -5919,10 +5931,33 @@ mod routing_tests {
     }
 
     #[test]
-    fn routing_to_earlier_routing_is_rejected_as_cycle_unsafe() {
+    fn routing_chain_to_earlier_index_is_accepted() {
         let frames = 4;
-        // bus "early" at index 0 sends to "late" at index 1 (forward → OK),
-        // and "late" sends back to "early" (backward → rejected).
+        // "late" at index 1 sends to "early" at index 0 — valid DAG when there
+        // is no back-edge. Pass-2 topo order processes late before early.
+        let mut p = RuntimeProject {
+            tracks: vec![
+                track("early", "return", vec![]),
+                track("late", "bus", vec![send("early", 1.0)]),
+            ],
+            ..Default::default()
+        };
+        p.resolve_indices();
+        p.tracks[1].block_l[..frames].fill(1.0);
+
+        accumulate_sends(&mut p, 1, frames, false);
+
+        assert!(p.tracks[0].recv_l[..frames]
+            .iter()
+            .all(|&v| (v - 1.0).abs() < 1e-6));
+    }
+
+    #[test]
+    fn routing_cycle_edge_is_rejected_at_plan_time() {
+        let frames = 4;
+        // Mutual sends form a cycle; the closing edge is rejected by the planner
+        // and never resolves into a live runtime send. Direct accumulate of a
+        // self-cycle is still dropped by the self-target guard.
         let mut p = RuntimeProject {
             tracks: vec![
                 track("early", "bus", vec![send("late", 1.0)]),
@@ -5934,13 +5969,17 @@ mod routing_tests {
         p.tracks[0].block_l[..frames].fill(1.0);
         p.tracks[1].block_l[..frames].fill(1.0);
 
-        accumulate_sends(&mut p, 0, frames, false); // early → late: forward, accepted
-        accumulate_sends(&mut p, 1, frames, false); // late → early: backward, rejected
+        accumulate_sends(&mut p, 0, frames, false);
+        accumulate_sends(&mut p, 1, frames, false);
 
+        // Both directions accumulate at the raw accumulate_sends layer (indices
+        // resolve); the planner is what keeps cycles out of a built project.
         assert!(p.tracks[1].recv_l[..frames]
             .iter()
             .all(|&v| (v - 1.0).abs() < 1e-6));
-        assert!(p.tracks[0].recv_l[..frames].iter().all(|&v| v == 0.0));
+        assert!(p.tracks[0].recv_l[..frames]
+            .iter()
+            .all(|&v| (v - 1.0).abs() < 1e-6));
     }
 
     #[test]

--- a/crates/SphereDirectAudioEngine/src/engine/render.rs
+++ b/crates/SphereDirectAudioEngine/src/engine/render.rs
@@ -424,10 +424,7 @@ pub(crate) fn route_main_output(
         .filter(|&t| t < runtime.tracks.len());
 
     if let Some(t) = target {
-        let src_routing = is_routing_type(&runtime.tracks[src_index].track_type);
-        let accept = t != src_index
-            && is_routing_type(&runtime.tracks[t].track_type)
-            && (!src_routing || t > src_index);
+        let accept = t != src_index && is_routing_type(&runtime.tracks[t].track_type);
         if accept {
             let (src, tgt) = two_mut(&mut runtime.tracks, src_index, t);
             for f in 0..frames {
@@ -467,6 +464,11 @@ fn process_track_block(
     accumulate_sends(runtime, track_index, frames, true);
     let smooth = runtime.fader_smoothing;
     apply_fader(&mut runtime.tracks[track_index], frames, beat, smooth);
+    accumulate_block_meter(&mut runtime.tracks[track_index], frames);
+    // Post-fader sends tap *before* PDC so return FX latency can be compensated
+    // on the dry/main path without also delaying the send feed (which would
+    // push wet further behind dry).
+    accumulate_sends(runtime, track_index, frames, false);
     let pdc_delay = runtime
         .latency_graph
         .track_pdc_delay
@@ -485,10 +487,7 @@ fn process_track_block(
             frames,
         );
     }
-    accumulate_block_meter(&mut runtime.tracks[track_index], frames);
-    // Post-fader sends tap the post-fader (and PDC-aligned) signal in block_*.
-    accumulate_sends(runtime, track_index, frames, false);
-    // Route the post-fader signal to master or the track's output bus.
+    // Route the post-fader (and PDC-aligned) signal to master or the track's output bus.
     route_main_output(runtime, track_index, frames, output, channels);
 }
 
@@ -498,10 +497,11 @@ fn process_track_block(
 /// `pre_fader` flag matches the requested phase are routed.
 ///
 /// Cycle-safe by construction: a send is accepted only when the target is a
-/// routing track (bus/return); a *routing* source may additionally only target
-/// a *later* routing track in array order. Sends to non-routing tracks, to
-/// self, or backward between routing tracks are dropped (logged at build time
-/// under `FUTUREBOARD_ROUTING_DEBUG`). No allocation on the audio thread.
+/// routing track (bus/return). Cyclic routes are rejected at graph-plan time
+/// (`plan_runtime_audio_graph`) and pass-2 processes routing tracks in
+/// topological order so chained bus→return feeds land before the target runs.
+/// Sends to non-routing tracks or to self are dropped. No allocation on the
+/// audio thread.
 #[inline]
 pub(crate) fn accumulate_sends(
     runtime: &mut RuntimeProject,
@@ -513,7 +513,6 @@ pub(crate) fn accumulate_sends(
     if send_count == 0 {
         return;
     }
-    let src_routing = is_routing_type(&runtime.tracks[src_index].track_type);
     for s in 0..send_count {
         let (enabled, level, target_index) = {
             let send = &runtime.tracks[src_index].sends[s];
@@ -530,9 +529,6 @@ pub(crate) fn accumulate_sends(
             continue;
         };
         if t == src_index || !is_routing_type(&runtime.tracks[t].track_type) {
-            continue;
-        }
-        if src_routing && t <= src_index {
             continue;
         }
         let (src, tgt) = two_mut(&mut runtime.tracks, src_index, t);

--- a/crates/SphereDirectAudioEngine/src/latency_graph.rs
+++ b/crates/SphereDirectAudioEngine/src/latency_graph.rs
@@ -16,7 +16,8 @@ pub struct RuntimeLatencyGraph {
     pub track_plugin_latency: Vec<u32>,
     /// Latency at each track's output tap (includes upstream feed for routing tracks).
     pub track_output_latency: Vec<u32>,
-    /// Delay applied to post-fader output before sends / main routing.
+    /// Delay applied to post-fader **main output** after sends, so dry/wet
+    /// paths that diverge through return FX still align at the master bus.
     pub track_pdc_delay: Vec<u32>,
     /// Maximum path latency to the master summing bus (before master inserts).
     pub max_path_latency_samples: u32,
@@ -133,7 +134,46 @@ fn effective_path_to_master(
     id_to_index: &HashMap<String, usize>,
     master_index: Option<usize>,
 ) -> u32 {
-    let mut path = resolve_output_target_index(track_index, tracks, id_to_index)
+    let mut path = main_path_to_master(
+        track_index,
+        tracks,
+        output_latency,
+        plugin_latency,
+        id_to_index,
+        master_index,
+    );
+
+    for send in &tracks[track_index].sends {
+        if !send.enabled {
+            continue;
+        }
+        if let Some(&ret_idx) = id_to_index.get(&send.return_track_id) {
+            let via_return = path_to_master_sum(
+                ret_idx,
+                tracks,
+                output_latency,
+                plugin_latency,
+                id_to_index,
+                master_index,
+            );
+            path = path.max(via_return);
+        }
+    }
+    path
+}
+
+/// Latency of the track's main-output (dry) path only — excludes send/return
+/// branches. Used for PDC delay amounts so dry can catch up to wet without
+/// delaying the send feed itself.
+fn main_path_to_master(
+    track_index: usize,
+    tracks: &[RuntimeTrack],
+    output_latency: &[u32],
+    plugin_latency: &[u32],
+    id_to_index: &HashMap<String, usize>,
+    master_index: Option<usize>,
+) -> u32 {
+    resolve_output_target_index(track_index, tracks, id_to_index)
         .filter(|&target| is_routing_track_type(&tracks[target].track_type))
         .map(|target| {
             path_to_master_sum(
@@ -154,25 +194,7 @@ fn effective_path_to_master(
                 id_to_index,
                 master_index,
             )
-        });
-
-    for send in &tracks[track_index].sends {
-        if !send.enabled {
-            continue;
-        }
-        if let Some(&ret_idx) = id_to_index.get(&send.return_track_id) {
-            let via_return = path_to_master_sum(
-                ret_idx,
-                tracks,
-                output_latency,
-                plugin_latency,
-                id_to_index,
-                master_index,
-            );
-            path = path.max(via_return);
-        }
-    }
-    path
+        })
 }
 
 /// Build latency metadata and per-track PDC delays from runtime tracks and the
@@ -215,6 +237,10 @@ pub fn plan_runtime_latency_graph(
                     feed_max = feed_max.max(output_latency[src_idx]);
                 }
             }
+            // Main-output → bus/return feeds also contribute upstream latency.
+            if resolve_output_target_index(src_idx, tracks, &id_to_index) == Some(idx) {
+                feed_max = feed_max.max(output_latency[src_idx]);
+            }
         }
         output_latency[idx] = plugin_latency[idx].saturating_add(feed_max);
     }
@@ -244,7 +270,9 @@ pub fn plan_runtime_latency_graph(
             if Some(idx) == master_index || is_master_track_type(&tracks[idx].track_type) {
                 continue;
             }
-            let path = effective_path_to_master(
+            // PDC delay is relative to the *main/dry* path so return-FX latency
+            // can pull dry forward without also delaying the send feed.
+            let path = main_path_to_master(
                 idx,
                 tracks,
                 &output_latency,
@@ -384,6 +412,10 @@ mod tests {
         let latency = plan_runtime_latency_graph(&tracks, &audio_graph, true);
         assert_eq!(latency.track_output_latency[1], 128 + 256);
         assert_eq!(latency.max_path_latency_samples, 128 + 256);
+        // Dry main path is 128; wet via return is 384. PDC delays dry by 256
+        // (applied after the send tap) so dry and wet meet at the master.
+        assert_eq!(latency.track_pdc_delay[0], 256);
+        assert_eq!(latency.track_pdc_delay[1], 0);
     }
 
     #[test]

--- a/crates/SphereMidiService/src/lib.rs
+++ b/crates/SphereMidiService/src/lib.rs
@@ -231,7 +231,34 @@ fn real_scan_midi_ports() -> Vec<DetectedMidiDevice> {
         }
         Err(e) => eprintln!("[MidiDeviceScan] MIDI output backend unavailable: {e}"),
     }
-    devices
+    coalesce_detected_midi_devices(devices)
+}
+
+/// Merge same-name input and output ports into a single InputOutput entry so a
+/// bidirectional controller does not appear twice in Preferences / routing lists.
+fn coalesce_detected_midi_devices(devices: Vec<DetectedMidiDevice>) -> Vec<DetectedMidiDevice> {
+    let mut by_name: HashMap<String, DetectedMidiDevice> = HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    for device in devices {
+        match by_name.get_mut(&device.name) {
+            Some(existing) => {
+                if existing.direction != device.direction
+                    && existing.direction != MidiDeviceDirection::InputOutput
+                {
+                    existing.direction = MidiDeviceDirection::InputOutput;
+                    existing.id = stable_id(MidiDeviceDirection::InputOutput, &existing.name);
+                }
+            }
+            None => {
+                order.push(device.name.clone());
+                by_name.insert(device.name.clone(), device);
+            }
+        }
+    }
+    order
+        .into_iter()
+        .filter_map(|name| by_name.remove(&name))
+        .collect()
 }
 
 /// Merge saved preferences with freshly detected devices. Saved-only entries stay visible as missing.
@@ -239,6 +266,7 @@ pub fn resolve_midi_devices(
     saved: &[MidiDeviceSetting],
     detected: &[DetectedMidiDevice],
 ) -> Vec<MidiDeviceSetting> {
+    let detected = coalesce_detected_midi_devices(detected.to_vec());
     if midi_settings_debug_enabled() {
         eprintln!("[MIDI settings] saved preferences ({})", saved.len());
         for device in saved {
@@ -251,22 +279,33 @@ pub fn resolve_midi_devices(
 
     let saved_by_id: HashMap<&str, &MidiDeviceSetting> =
         saved.iter().map(|d| (d.id.as_str(), d)).collect();
+    let saved_by_name: HashMap<&str, &MidiDeviceSetting> =
+        saved.iter().map(|d| (d.name.as_str(), d)).collect();
     let mut resolved = Vec::new();
+    let mut resolved_names = std::collections::HashSet::new();
 
-    for det in detected {
-        let saved = saved_by_id.get(det.id.as_str());
+    for det in &detected {
+        let saved = saved_by_id
+            .get(det.id.as_str())
+            .copied()
+            .or_else(|| saved_by_name.get(det.name.as_str()).copied());
+        resolved_names.insert(det.name.clone());
         resolved.push(MidiDeviceSetting {
             id: det.id.clone(),
             name: det.name.clone(),
             direction: det.direction,
-            enabled: saved.map(|s| s.enabled).unwrap_or(false),
+            // New devices default to enabled so real-time MIDI input works
+            // without a Preferences visit; users can still disable them.
+            enabled: saved.map(|s| s.enabled).unwrap_or(true),
             connected: true,
             clock_enabled: saved.map(|s| s.clock_enabled).unwrap_or(false),
         });
     }
 
     for saved_device in saved {
-        if detected.iter().any(|d| d.id == saved_device.id) {
+        if detected.iter().any(|d| d.id == saved_device.id)
+            || resolved_names.contains(&saved_device.name)
+        {
             continue;
         }
         if midi_settings_debug_enabled() {
@@ -420,6 +459,222 @@ impl Drop for HardwareMidiPlayback {
     fn drop(&mut self) {
         self.stop();
     }
+}
+
+/// One decoded MIDI message received from an enabled hardware input port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HardwareMidiInputMessage {
+    pub device_id: String,
+    pub device_name: String,
+    pub event: MidiInputEvent,
+}
+
+/// Control-thread hardware MIDI input listener. Opens midir connections for
+/// enabled input / input-output devices and pushes decoded events onto a
+/// bounded queue drained by the UI poll loop.
+pub struct HardwareMidiInput {
+    event_rx: Option<std::sync::mpsc::Receiver<HardwareMidiInputMessage>>,
+    /// Cancel + join handles for the active input connections.
+    connections: Vec<HardwareMidiInputConnection>,
+    /// Last synced set of enabled device ids (so we can no-op when unchanged).
+    enabled_ids: Vec<String>,
+}
+
+struct HardwareMidiInputConnection {
+    #[allow(dead_code)]
+    device_id: String,
+    /// Dropping the connection closes the port. Kept alive for the session.
+    #[cfg(not(target_os = "macos"))]
+    _connection: midir::MidiInputConnection<()>,
+    #[cfg(target_os = "macos")]
+    _connection: (),
+}
+
+impl Default for HardwareMidiInput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HardwareMidiInput {
+    pub fn new() -> Self {
+        Self {
+            event_rx: None,
+            connections: Vec::new(),
+            enabled_ids: Vec::new(),
+        }
+    }
+
+    /// Open / refresh connections for every enabled input-capable device.
+    /// Safe to call repeatedly from the UI poll; reconnects only when the
+    /// enabled set changes.
+    pub fn sync_enabled_devices(&mut self, devices: &[MidiDeviceSetting]) {
+        let mut enabled: Vec<(String, String)> = devices
+            .iter()
+            .filter(|d| {
+                d.enabled
+                    && d.connected
+                    && matches!(
+                        d.direction,
+                        MidiDeviceDirection::Input | MidiDeviceDirection::InputOutput
+                    )
+            })
+            .map(|d| (d.id.clone(), d.name.clone()))
+            .collect();
+        enabled.sort_by(|a, b| a.0.cmp(&b.0));
+        let enabled_ids: Vec<String> = enabled.iter().map(|(id, _)| id.clone()).collect();
+        if enabled_ids == self.enabled_ids {
+            return;
+        }
+        self.stop();
+        self.enabled_ids = enabled_ids;
+        if enabled.is_empty() {
+            return;
+        }
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.event_rx = Some(rx);
+        self.connections = open_hardware_midi_inputs(enabled, tx);
+    }
+
+    /// Drain pending hardware MIDI messages (non-blocking). Bounded by caller.
+    pub fn drain(&mut self, max: usize) -> Vec<HardwareMidiInputMessage> {
+        let Some(rx) = self.event_rx.as_ref() else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        while out.len() < max {
+            match rx.try_recv() {
+                Ok(msg) => out.push(msg),
+                Err(_) => break,
+            }
+        }
+        out
+    }
+
+    pub fn stop(&mut self) {
+        self.connections.clear();
+        self.event_rx = None;
+        self.enabled_ids.clear();
+    }
+}
+
+impl Drop for HardwareMidiInput {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn decode_midi_bytes(bytes: &[u8]) -> Option<MidiInputEvent> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let status = bytes[0];
+    let kind = status & 0xF0;
+    let channel = status & 0x0F;
+    match kind {
+        0x90 => {
+            let note = *bytes.get(1)?;
+            let velocity = *bytes.get(2)?;
+            if velocity == 0 {
+                Some(MidiInputEvent::NoteOff { note, channel })
+            } else {
+                Some(MidiInputEvent::NoteOn {
+                    note,
+                    velocity,
+                    channel,
+                })
+            }
+        }
+        0x80 => {
+            let note = *bytes.get(1)?;
+            Some(MidiInputEvent::NoteOff { note, channel })
+        }
+        0xB0 => {
+            let controller = *bytes.get(1)?;
+            let value = *bytes.get(2)?;
+            if controller == 123 {
+                Some(MidiInputEvent::AllNotesOff)
+            } else {
+                Some(MidiInputEvent::ControlChange {
+                    controller,
+                    value,
+                    channel,
+                })
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn open_hardware_midi_inputs(
+    enabled: Vec<(String, String)>,
+    tx: std::sync::mpsc::Sender<HardwareMidiInputMessage>,
+) -> Vec<HardwareMidiInputConnection> {
+    use midir::MidiInput;
+
+    let mut connections = Vec::new();
+    let Ok(scanner) = MidiInput::new("Futureboard MIDI input scan") else {
+        eprintln!("[MIDI input] backend unavailable — cannot open hardware ports");
+        return connections;
+    };
+    let ports = scanner.ports();
+    for (device_id, device_name) in enabled {
+        let Some(port) = ports.iter().find(|port| {
+            scanner
+                .port_name(port)
+                .ok()
+                .is_some_and(|name| name == device_name)
+        }) else {
+            eprintln!("[MIDI input] port not found for enabled device '{device_name}'");
+            continue;
+        };
+        // midir requires a fresh MidiInput per connection.
+        let Ok(input) = MidiInput::new(&format!("Futureboard MIDI in ({device_name})")) else {
+            continue;
+        };
+        let tx = tx.clone();
+        let id = device_id.clone();
+        let name = device_name.clone();
+        match input.connect(
+            port,
+            &format!("Futureboard listen ({device_name})"),
+            move |_stamp, message, _| {
+                if let Some(event) = decode_midi_bytes(message) {
+                    let _ = tx.send(HardwareMidiInputMessage {
+                        device_id: id.clone(),
+                        device_name: name.clone(),
+                        event,
+                    });
+                }
+            },
+            (),
+        ) {
+            Ok(connection) => {
+                if midi_settings_debug_enabled() {
+                    eprintln!("[MIDI input] connected '{device_name}' ({device_id})");
+                }
+                connections.push(HardwareMidiInputConnection {
+                    device_id,
+                    _connection: connection,
+                });
+            }
+            Err(error) => {
+                eprintln!("[MIDI input] failed to open '{device_name}': {error}");
+            }
+        }
+    }
+    connections
+}
+
+#[cfg(target_os = "macos")]
+fn open_hardware_midi_inputs(
+    _enabled: Vec<(String, String)>,
+    _tx: std::sync::mpsc::Sender<HardwareMidiInputMessage>,
+) -> Vec<HardwareMidiInputConnection> {
+    // midir's CoreMIDI backend currently conflicts with gpui's pinned
+    // core-foundation version (same limitation as port scan / output).
+    Vec::new()
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -957,8 +1212,61 @@ mod tests {
         assert!(
             resolved
                 .iter()
-                .any(|d| d.id == "midi-in-new" && d.connected)
+                .any(|d| d.id == "midi-in-new" && d.connected && d.enabled)
         );
+    }
+
+    #[test]
+    fn coalesce_merges_same_name_input_and_output() {
+        let detected = vec![
+            DetectedMidiDevice {
+                id: "midi-in-pad".to_string(),
+                name: "Pad Controller".to_string(),
+                direction: MidiDeviceDirection::Input,
+            },
+            DetectedMidiDevice {
+                id: "midi-out-pad".to_string(),
+                name: "Pad Controller".to_string(),
+                direction: MidiDeviceDirection::Output,
+            },
+            DetectedMidiDevice {
+                id: "midi-in-keys".to_string(),
+                name: "Keys".to_string(),
+                direction: MidiDeviceDirection::Input,
+            },
+        ];
+        let coalesced = coalesce_detected_midi_devices(detected);
+        assert_eq!(coalesced.len(), 2);
+        let pad = coalesced
+            .iter()
+            .find(|d| d.name == "Pad Controller")
+            .expect("pad");
+        assert_eq!(pad.direction, MidiDeviceDirection::InputOutput);
+        assert!(pad.id.starts_with("midi-io-"));
+        let keys = coalesced.iter().find(|d| d.name == "Keys").expect("keys");
+        assert_eq!(keys.direction, MidiDeviceDirection::Input);
+    }
+
+    #[test]
+    fn resolve_dedupes_saved_clone_when_live_name_matches() {
+        let saved = vec![MidiDeviceSetting {
+            id: "midi-in-pad".to_string(),
+            name: "Pad Controller".to_string(),
+            direction: MidiDeviceDirection::Input,
+            enabled: true,
+            connected: false,
+            clock_enabled: false,
+        }];
+        let detected = vec![DetectedMidiDevice {
+            id: "midi-io-pad-controller".to_string(),
+            name: "Pad Controller".to_string(),
+            direction: MidiDeviceDirection::InputOutput,
+        }];
+        let resolved = resolve_midi_devices(&saved, &detected);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].id, "midi-io-pad-controller");
+        assert!(resolved[0].enabled);
+        assert!(resolved[0].connected);
     }
 
     #[test]

--- a/crates/SphereUIComponents/src/components/menu_dropdown.rs
+++ b/crates/SphereUIComponents/src/components/menu_dropdown.rs
@@ -127,14 +127,20 @@ pub fn menu_dropdown(
         panel_left = submenu_left(panel_left, current_width, child_width, viewport_width);
     }
 
-    // Click-blocking backdrop behind every panel.
+    // Click-blocking backdrop behind every panel. Starts below the titlebar so
+    // a second click on the open menu label (or another menu title) reaches the
+    // menubar toggle instead of closing-then-reopening via event fallthrough.
     let backdrop_close = on_close.clone();
     let backdrop = div()
         .absolute()
-        .inset_0()
+        .top(px(TITLEBAR_HEIGHT))
+        .left_0()
+        .right_0()
+        .bottom_0()
         .id("menu-dropdown-backdrop")
         .on_mouse_down(gpui::MouseButton::Left, move |_, w, cx| {
             backdrop_close(&(), w, cx);
+            cx.stop_propagation();
         });
 
     div().absolute().inset_0().child(backdrop).children(panels)

--- a/crates/SphereUIComponents/src/components/mixer_panel.rs
+++ b/crates/SphereUIComponents/src/components/mixer_panel.rs
@@ -1130,35 +1130,29 @@ fn sends_section(
     callbacks: &MixerCallbacks,
     height_px: f32,
 ) -> impl IntoElement {
-    // Routing tracks (bus/return) don't themselves carry an aux-send rack in
-    // this slice — they are send *targets*. Show an empty placeholder.
-    let is_routing = track.track_type.is_routing()
-        && !crate::components::timeline::timeline_state::is_vsti_output_child_track_id(&track.id);
+    // Bus/return strips carry an aux-send rack so chained send/return paths
+    // (bus → return, return → bus) are available from the mixer.
     let mut chips = div().flex().flex_col().flex_none().gap(px(2.0)).px(px(2.0));
-    if is_routing {
-        chips = chips.child(empty_slot());
-    } else {
-        for (send_index, send) in track.sends.iter().enumerate() {
-            // Resolve the live target name (handles renames) with the stored
-            // label as a fallback.
-            let target_name = all_tracks
-                .iter()
-                .find(|t| t.id == send.target_track_id)
-                .map(|t| t.name.clone())
-                .unwrap_or_else(|| send.target_name.clone());
-            chips = chips.child(send_chip(
-                &track.id,
-                send_index,
-                send,
-                &target_name,
-                callbacks,
-            ));
-        }
-        if !track.sends.is_empty() {
-            chips = chips.child(send_drop_end(&track.id, track.sends.len(), callbacks));
-        }
-        chips = chips.child(add_send_button(&track.id, callbacks));
+    for (send_index, send) in track.sends.iter().enumerate() {
+        // Resolve the live target name (handles renames) with the stored
+        // label as a fallback.
+        let target_name = all_tracks
+            .iter()
+            .find(|t| t.id == send.target_track_id)
+            .map(|t| t.name.clone())
+            .unwrap_or_else(|| send.target_name.clone());
+        chips = chips.child(send_chip(
+            &track.id,
+            send_index,
+            send,
+            &target_name,
+            callbacks,
+        ));
     }
+    if !track.sends.is_empty() {
+        chips = chips.child(send_drop_end(&track.id, track.sends.len(), callbacks));
+    }
+    chips = chips.child(add_send_button(&track.id, callbacks));
 
     div()
         .flex()

--- a/crates/SphereUIComponents/src/components/piano_roll.rs
+++ b/crates/SphereUIComponents/src/components/piano_roll.rs
@@ -4573,6 +4573,11 @@ impl PianoRoll {
             return;
         }
         let max_scroll_x = self.max_scroll_x(cx);
+        let natural = cx
+            .try_global::<crate::settings::GlobalSettingsModel>()
+            .map(|g| g.0.read(cx).current.editing.mouse.natural_scroll)
+            .unwrap_or(false);
+        let (dx, dy) = if natural { (-dx, -dy) } else { (dx, dy) };
         if event.modifiers.shift {
             self.scroll_x = (self.scroll_x - dy - dx).clamp(0.0, max_scroll_x);
         } else {

--- a/crates/SphereUIComponents/src/components/routing_matrix_window.rs
+++ b/crates/SphereUIComponents/src/components/routing_matrix_window.rs
@@ -178,7 +178,6 @@ impl Render for RoutingMatrixWindow {
 
         let mut rows = div().flex().flex_col().min_h_0();
         for (index, track) in source_tracks.iter().enumerate() {
-            let source_is_routing = track.track_type.is_routing();
             let alt = index % 2 == 1;
             let mut row = div()
                 .flex()
@@ -217,10 +216,11 @@ impl Render for RoutingMatrixWindow {
                     .as_ref()
                     .map(|dest_id| track.sends.iter().any(|s| &s.target_track_id == dest_id))
                     .unwrap_or(false);
-                // A send is toggleable only from a non-routing source into a
+                // A send is toggleable from any non-master source into a
                 // Bus/Return destination that is not the source itself.
+                // Bus/return → bus/return chains are allowed; the engine rejects
+                // cycles when the graph is planned.
                 let toggleable = dest.accepts_sends
-                    && !source_is_routing
                     && dest.track_id.as_deref() != Some(track.id.as_str());
 
                 let mut cell = div()

--- a/crates/SphereUIComponents/src/components/timeline/state/routing.rs
+++ b/crates/SphereUIComponents/src/components/timeline/state/routing.rs
@@ -422,9 +422,9 @@ impl TimelineState {
             .map(|target| (target.id.clone(), target.name.clone()))?;
 
         let track = self.tracks.iter_mut().find(|t| t.id == track_id)?;
-        if (track.track_type.is_routing() && !is_vsti_output_child_track_id(&track.id))
-            || track.sends.iter().any(|s| s.target_track_id == target_id)
-        {
+        // Allow bus/return → bus/return chains; engine rejects cycles at plan time.
+        // VSTi multi-out children remain send sources as before.
+        if track.sends.iter().any(|s| s.target_track_id == target_id) {
             return None;
         }
         let send_id = format!("send-{}-{}", track.id, track.sends.len() + 1);
@@ -450,9 +450,7 @@ impl TimelineState {
             .tracks
             .iter()
             .find(|track| track.id == track_id)
-            .is_none_or(|track| {
-                track.track_type.is_routing() && !is_vsti_output_child_track_id(&track.id)
-            })
+            .is_none()
         {
             return None;
         }

--- a/crates/SphereUIComponents/src/components/timeline/timeline/render.rs
+++ b/crates/SphereUIComponents/src/components/timeline/timeline/render.rs
@@ -1762,8 +1762,22 @@ impl Render for Timeline {
                 // the timeline offsets describe the content origin. Invert at
                 // this boundary so wheel/trackpad motion follows the direction
                 // users see, matching the middle-button grab-pan behavior.
-                let next_x = this.state.viewport.scroll_x - scroll_x;
-                let next_y = this.state.viewport.scroll_y - scroll_y;
+                // Preferences → Editing → Natural Scroll flips that mapping.
+                let natural = cx
+                    .try_global::<crate::settings::GlobalSettingsModel>()
+                    .map(|g| g.0.read(cx).current.editing.mouse.natural_scroll)
+                    .unwrap_or(false);
+                let (next_x, next_y) = if natural {
+                    (
+                        this.state.viewport.scroll_x + scroll_x,
+                        this.state.viewport.scroll_y + scroll_y,
+                    )
+                } else {
+                    (
+                        this.state.viewport.scroll_x - scroll_x,
+                        this.state.viewport.scroll_y - scroll_y,
+                    )
+                };
                 this.state
                     .set_scroll_immediate(next_x, next_y, max_x, max_y);
                 if scroll_x.abs() > 0.5 || scroll_y.abs() > 0.5 {

--- a/crates/SphereUIComponents/src/layout.rs
+++ b/crates/SphereUIComponents/src/layout.rs
@@ -471,6 +471,8 @@ pub struct StudioLayout {
     /// Control-thread scheduler for MIDI tracks routed to hardware/virtual MIDI
     /// outputs. Kept out of the realtime audio callback.
     hardware_midi_playback: sphere_midi_service::HardwareMidiPlayback,
+    /// Live hardware MIDI input connections (enabled ports → UI poll drain).
+    hardware_midi_input: sphere_midi_service::HardwareMidiInput,
     /// Active recording-session UI state (take start position, UI phase, live
     /// growing-waveform preview). Grouped into
     /// [`recording_ops::RecordingSessionState`] (decomposition slice).
@@ -1003,6 +1005,7 @@ impl StudioLayout {
             overlay: studio_state::OverlayState::default(),
             audio_bridge: audio_transport::AudioBridgeState::default(),
             hardware_midi_playback: sphere_midi_service::HardwareMidiPlayback::new(),
+            hardware_midi_input: sphere_midi_service::HardwareMidiInput::new(),
             recording: recording_ops::RecordingSessionState::default(),
             engine_sync: audio_transport::EngineSyncState::default(),
             bpm_drag: audio_transport::BpmDragState::default(),

--- a/crates/SphereUIComponents/src/layout/audio_transport.rs
+++ b/crates/SphereUIComponents/src/layout/audio_transport.rs
@@ -675,6 +675,11 @@ impl StudioLayout {
         }
         let meter_changed = self.apply_engine_meters(cx);
 
+        // Drain hardware MIDI input on the UI/control poll (never the audio
+        // thread). Opens/refreshes enabled ports, then routes into the same
+        // preview + recording path as the virtual keyboard.
+        self.poll_hardware_midi_input(cx);
+
         // Realtime recording waveform preview (Part 1) — grow the preview clip
         // and append streamed peaks. Self-contained; notifies the timeline.
         self.update_recording_preview(cx);

--- a/crates/SphereUIComponents/src/layout/midi_input_router.rs
+++ b/crates/SphereUIComponents/src/layout/midi_input_router.rs
@@ -1,10 +1,12 @@
 use gpui::{App, Context};
 
 use crate::components;
-use crate::components::timeline::timeline_state::TrackType;
+use crate::components::timeline::timeline_state::{
+    MidiChannel, TrackMidiInputRouting, TrackType,
+};
 use sphere_midi_service::{
-    MidiInputEvent, MidiInputRouteStatus, MidiInputRouter, MidiInputSource, MidiInputTarget,
-    VirtualKeyboardEvent,
+    HardwareMidiInputMessage, MidiInputEvent, MidiInputRouteStatus, MidiInputRouter,
+    MidiInputSource, MidiInputTarget, VirtualKeyboardEvent,
 };
 
 use super::StudioLayout;
@@ -281,6 +283,111 @@ impl StudioLayout {
         route_result(result)
     }
 
+    /// Sync enabled hardware MIDI input ports and route pending messages into
+    /// armed/selected instrument tracks (and the active MIDI recording take).
+    pub(super) fn poll_hardware_midi_input(&mut self, cx: &mut Context<Self>) {
+        let devices = {
+            let settings = self.settings.read(cx);
+            settings.current.hardware.midi.devices.clone()
+        };
+        // Re-resolve against the live scan so connected flags stay current even
+        // when Preferences is closed.
+        let detected = crate::device_registry::cached_midi_devices();
+        let resolved = sphere_midi_service::resolve_midi_devices(&devices, &detected);
+        self.hardware_midi_input.sync_enabled_devices(&resolved);
+
+        let messages = self.hardware_midi_input.drain(64);
+        if messages.is_empty() {
+            return;
+        }
+        for message in messages {
+            self.route_hardware_midi_message(message, cx);
+        }
+    }
+
+    fn route_hardware_midi_message(
+        &mut self,
+        message: HardwareMidiInputMessage,
+        cx: &mut Context<Self>,
+    ) {
+        let channel = match &message.event {
+            MidiInputEvent::NoteOn { channel, .. }
+            | MidiInputEvent::NoteOff { channel, .. }
+            | MidiInputEvent::ControlChange { channel, .. } => Some(*channel),
+            MidiInputEvent::AllNotesOff | MidiInputEvent::Panic => None,
+        };
+        let targets = self.resolve_hardware_midi_targets(
+            &message.device_id,
+            &message.device_name,
+            channel,
+            cx,
+        );
+        if targets.is_empty() {
+            return;
+        }
+        for target in targets {
+            let _ = self.route_midi_input_event(
+                MidiInputSource::Hardware,
+                target,
+                message.event.clone(),
+                cx,
+            );
+        }
+    }
+
+    fn resolve_hardware_midi_targets(
+        &self,
+        device_id: &str,
+        device_name: &str,
+        channel: Option<u8>,
+        cx: &App,
+    ) -> Vec<MidiInputTarget> {
+        let timeline = self.timeline.read(cx);
+        let state = &timeline.state;
+        let mut targets = Vec::new();
+
+        for track in &state.tracks {
+            if !is_keyboard_target_candidate(track) {
+                continue;
+            }
+            if !track_accepts_hardware_midi(&track.routing.midi_input, device_id, device_name) {
+                continue;
+            }
+            if let Some(ch) = channel {
+                let midi_ch = MidiChannel::from_raw(ch);
+                if !track.routing.midi_input_filter.accepts(midi_ch) {
+                    continue;
+                }
+            }
+            // Prefer armed tracks; also accept the selected track so live play
+            // works without arming (same as the virtual keyboard).
+            let selected = state.selection.selected_track_id.as_deref() == Some(track.id.as_str());
+            if !track.armed && !selected {
+                continue;
+            }
+            if let Some(target) = hardware_midi_target_for_track(track) {
+                targets.push(target);
+            }
+        }
+
+        // If nothing matched via arm/selection but a single AllInputs armed
+        // path exists above, we're done. If still empty, fall back to the
+        // virtual-keyboard resolver so an instrument track with default
+        // AllInputs still receives notes when selected.
+        if targets.is_empty() {
+            if let Some(target) = self.resolve_virtual_keyboard_target(cx).target {
+                // Re-check the fallback track still accepts this device.
+                if let Some(track) = state.find_track(&target.track_id) {
+                    if track_accepts_hardware_midi(&track.routing.midi_input, device_id, device_name)
+                    {
+                        targets.push(target);
+                    }
+                }
+            }
+        }
+        targets
+    }
+
     pub(super) fn resolve_virtual_keyboard_target(&self, cx: &App) -> VirtualKeyboardTargetStatus {
         let timeline = self.timeline.read(cx);
         let state = &timeline.state;
@@ -365,6 +472,55 @@ fn route_result<E: std::fmt::Display>(result: Result<(), E>) -> MidiInputRouteSt
 
 fn is_keyboard_target_candidate(track: &components::timeline::timeline_state::TrackState) -> bool {
     matches!(track.track_type, TrackType::Instrument | TrackType::Midi)
+}
+
+fn track_accepts_hardware_midi(
+    routing: &TrackMidiInputRouting,
+    device_id: &str,
+    device_name: &str,
+) -> bool {
+    match routing {
+        TrackMidiInputRouting::None => false,
+        TrackMidiInputRouting::AllInputs => true,
+        TrackMidiInputRouting::MidiDevice {
+            device_id: route_id,
+        } => route_id == device_id || route_id == device_name,
+    }
+}
+
+fn hardware_midi_target_for_track(
+    track: &components::timeline::timeline_state::TrackState,
+) -> Option<MidiInputTarget> {
+    let plugin_instance_id = track
+        .instrument_plugin_instance_id
+        .clone()
+        .or_else(|| first_instrument_insert_id(track));
+    if plugin_instance_id.is_some() {
+        return Some(MidiInputTarget {
+            track_id: track.id.clone(),
+            plugin_instance_id,
+        });
+    }
+    if track.builtin_soundfont_player
+        && track
+            .soundfont_path
+            .as_deref()
+            .is_some_and(|path| !path.is_empty())
+    {
+        return Some(MidiInputTarget {
+            track_id: track.id.clone(),
+            plugin_instance_id: None,
+        });
+    }
+    // MIDI tracks without an instrument still accept input while recording
+    // (notes land in the take buffer via capture_midi_record_event).
+    if track.track_type == TrackType::Midi {
+        return Some(MidiInputTarget {
+            track_id: track.id.clone(),
+            plugin_instance_id: None,
+        });
+    }
+    None
 }
 
 fn first_instrument_insert_id(

--- a/crates/SphereUIComponents/src/layout/plugin_picker_window.rs
+++ b/crates/SphereUIComponents/src/layout/plugin_picker_window.rs
@@ -31,6 +31,8 @@ pub(crate) struct InsertPickerWindow {
     snapshot: InsertPickerSnapshot,
     focus_handle: FocusHandle,
     scroll: PluginPickerScrollHandles,
+    /// Focus the search field once the dialog's own window is live.
+    needs_search_focus: bool,
 }
 
 #[derive(Clone)]
@@ -56,11 +58,20 @@ impl InsertPickerWindow {
             snapshot,
             focus_handle: cx.focus_handle(),
             scroll: PluginPickerScrollHandles::default(),
+            needs_search_focus: true,
         }
     }
 
     fn set_snapshot(&mut self, snapshot: InsertPickerSnapshot) {
         self.snapshot = snapshot;
+    }
+
+    fn focus_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.snapshot
+            .search_input
+            .focus_handle
+            .focus(window, cx);
+        self.needs_search_focus = false;
     }
 
     fn close(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -122,6 +133,9 @@ impl InsertPickerWindow {
 impl Render for InsertPickerWindow {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let build_started = picker_perf_debug().then(std::time::Instant::now);
+        if self.needs_search_focus {
+            self.focus_search(window, cx);
+        }
         let target = cx.entity().clone();
         let snapshot = self.snapshot.clone();
         let search_focused = snapshot.search_input.is_focused(window);
@@ -394,7 +408,11 @@ impl StudioLayout {
     ) {
         if let Some(handle) = self.plugin_picker_window.clone() {
             if handle
-                .update(cx, |_picker, window, _cx| window.activate_window())
+                .update(cx, |picker, window, cx| {
+                    picker.needs_search_focus = true;
+                    picker.focus_search(window, cx);
+                    window.activate_window();
+                })
                 .is_ok()
             {
                 self.notify_insert_picker_window(cx);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses a batch of Studio transport, mixer routing, UI interaction, and MIDI/recording bugs.

### Transport / latency
- **Stop at command:** `StopTransport` now clears PDC delay rings so compensated pre-stop audio does not keep playing; `pause()` also eagerly clears `shared.playing`.
- **Send/return PDC:** Post-fader sends tap **before** PDC; dry-path delay uses main-path latency so return FX no longer misalign dry/wet.
- **Chained send/return:** Bus/return can send to other bus/return targets (mixer + matrix + state). Engine accepts reverse-index DAG edges and rejects only true cycles.

### UI
- **Natural scroll:** Timeline and piano-roll wheel handlers honor Preferences → Editing → Natural Scroll.
- **Clip mute/gain:** `LoadProject` seeds `smoothed_master_gain` from the live master volume so mute/gain sync no longer briefly bypasses the master fader.
- **Menu bar:** Dropdown backdrop starts below the titlebar and stops propagation so a second click on the open menu closes it.
- **Insert picker:** External picker window focuses the search field on open/reactivate.

### MIDI / recording
- **Duplicate devices:** Same-name in+out ports coalesce to `InputOutput`; saved clones with the same name are not shown twice.
- **Realtime MIDI input:** New `HardwareMidiInput` opens enabled (default-on for newly detected) ports and routes into the existing preview + MIDI record path.
- **Recording:** MIDI takes can now receive hardware notes through that input path (primary reason MIDI recording appeared broken).

## Validation

```bash
cargo test -p SphereMidiService --lib
cargo test -p sphere_directaudioengine --lib -- latency_graph audio_graph send_to_return routing_chain routing_cycle return_feed pdc_delays
cargo check -p sphere_ui_components
```

All of the above passed in this environment.

### Not manually verified
- Live hardware MIDI keyboard / audio recording on real devices
- Visual menu/scroll/picker focus on a running Studio build

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f648771-7aa8-4f89-93af-876ef3d13cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f648771-7aa8-4f89-93af-876ef3d13cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

