### PR TITLE
perf(rodharerist): cut NAM/IR latency 22x and chain CPU 3.3x

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/builtin_dsp_core/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/builtin_dsp_core/src/lib.rs
@@ -78,6 +78,25 @@ pub fn time_constant(sample_rate: f32, seconds: f32) -> f32 {
     (-1.0 / samples).exp()
 }
 
+/// Below this magnitude a filter or envelope state is silence: 1e-25 is
+/// −500 dBFS, far under anything a converter can represent.
+pub const DENORMAL_FLOOR: f32 = 1.0e-25;
+
+/// Snap a decaying recursive state to zero before it reaches the subnormal
+/// range.
+///
+/// Every IIR state — envelope followers, one-poles, filter feedback taps —
+/// decays geometrically once the input goes quiet. Left alone it crosses into
+/// denormal floats, where x86 hands the operation to microcode at tens to
+/// hundreds of cycles apiece, so a *silent* plugin can cost several times what
+/// a playing one does. Apply this wherever a state is fed back into itself.
+///
+/// Compiles to a compare and a select, and nothing at −500 dBFS is audible.
+#[inline]
+pub fn flush_denormal(x: f32) -> f32 {
+    if x.abs() < DENORMAL_FLOOR { 0.0 } else { x }
+}
+
 /// Soft-knee peak compressor (Giannoulis / Reiss style gain computer).
 ///
 /// Envelope detection is allocation-free. Sidechain HPF uses `biquad`.
@@ -160,7 +179,10 @@ impl SoftKneeCompressor {
         } else {
             self.release_coeff
         };
-        self.envelope = coeff * self.envelope + (1.0 - coeff) * level;
+        // Flushed: the envelope decays toward zero on every release, and a
+        // subnormal envelope makes a *silent* compressor cost several times
+        // what a working one does.
+        self.envelope = flush_denormal(coeff * self.envelope + (1.0 - coeff) * level);
 
         let level_db = linear_to_db(self.envelope.max(1.0e-12));
         let gr_db = self.compute_gr_db(level_db);
@@ -180,7 +202,10 @@ impl SoftKneeCompressor {
         } else {
             self.release_coeff
         };
-        self.envelope = coeff * self.envelope + (1.0 - coeff) * level;
+        // Flushed: the envelope decays toward zero on every release, and a
+        // subnormal envelope makes a *silent* compressor cost several times
+        // what a working one does.
+        self.envelope = flush_denormal(coeff * self.envelope + (1.0 - coeff) * level);
 
         let level_db = linear_to_db(self.envelope.max(1.0e-12));
         let gr_db = self.compute_gr_db(level_db);

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/Footer.tsx
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/Footer.tsx
@@ -37,8 +37,8 @@ function formatCpu(load: number | undefined): string {
  *
  * Every engine-supplied figure renders as `—` until the host actually reports
  * it. Latency in particular is never shown as zero on the assumption that the
- * chain is zero-latency: a loaded NAM capture has a real receptive-field delay,
- * and the host is the only thing that knows the total.
+ * chain is zero-latency: the NAM and IR engines both buffer a block, and the
+ * host is the only thing that knows the total.
  */
 export function Footer({ globalBypass }: FooterProps) {
   const [status, setStatus] = useState<HostStatus>(() => getStatus());

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/ModuleEditor.tsx
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/ModuleEditor.tsx
@@ -186,7 +186,7 @@ export function ModuleEditor({
               >
                 {namStatus.kind === "loading" && `Loading “${namStatus.name}”…`}
                 {namStatus.kind === "loaded" &&
-                  `Loaded “${namStatus.name}” (${namStatus.receptiveField} sample latency)`}
+                  `Loaded “${namStatus.name}” (${namStatus.receptiveField} sample receptive field)`}
                 {namStatus.kind === "error" &&
                   `“${namStatus.name}” failed: ${namStatus.message}`}
               </div>

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/bridge.ts
@@ -61,7 +61,7 @@ export type HostStatus = {
   sampleRate?: number;
   /** Engine block size in samples. */
   blockSize?: number;
-  /** Total plugin latency in samples (includes any NAM receptive field). */
+  /** Total plugin latency in samples (NAM and IR block buffering). */
   latencySamples?: number;
   /** Plugin CPU share, 0..1. */
   cpuLoad?: number;

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/examples/cpu_profile.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/examples/cpu_profile.rs
@@ -1,0 +1,385 @@
+//! Offline CPU / latency profile — NOT part of the shipping plugin.
+//!
+//! Renders a fixed amount of audio through each stage in isolation and prints
+//! the cost as a percentage of one core's realtime budget, plus the latency
+//! each engine reports to the host. Read it as: "at 48 kHz, one instance of
+//! this stage eats N % of a core". A full chain over ~100 % cannot keep up and
+//! is what a user hears as lag/xruns.
+//!
+//! ```text
+//! cargo run -p rodharerist --example cpu_profile --release
+//! ```
+
+use std::time::Instant;
+
+use builtin_dsp_core::StereoEffect;
+use rodharerist::{
+    CabModel, Dsp, PATH_SLOTS, Params, StageKind, ToneEngineKind, default_params,
+    prepare_ir_runtime,
+};
+
+const SR: f32 = 48_000.0;
+/// Two seconds of audio per measurement — long enough to average out cache
+/// warm-up, short enough that the whole profile runs in a few seconds.
+const N: usize = 96_000;
+
+fn lcg(state: &mut u32) -> f32 {
+    *state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+    (*state >> 8) as f32 / (1 << 24) as f32 * 2.0 - 1.0
+}
+
+fn only(stage: StageKind) -> Params {
+    let mut p = default_params();
+    p.stage_order = [None; PATH_SLOTS];
+    p.stage_order[0] = Some(stage);
+    p
+}
+
+/// Realtime factor in percent of one core: 100 % means the stage takes exactly
+/// as long to compute as the audio it produces.
+fn measure(label: &str, dsp: &mut Dsp) -> f64 {
+    let mut rng = 0x1234_5678u32;
+    let input: Vec<f32> = (0..N).map(|_| lcg(&mut rng) * 0.3).collect();
+
+    // Warm the caches / settle the smoothers before timing.
+    for &x in input.iter().take(4_096) {
+        dsp.begin_block();
+        let _ = dsp.process_stereo(x, x);
+    }
+
+    let started = Instant::now();
+    let mut sink = 0.0f32;
+    for (i, &x) in input.iter().enumerate() {
+        if i % 128 == 0 {
+            dsp.begin_block();
+        }
+        let (l, r) = dsp.process_stereo(x, x);
+        sink += l + r;
+    }
+    let elapsed = started.elapsed().as_secs_f64();
+    let audio_seconds = N as f64 / SR as f64;
+    let percent = elapsed / audio_seconds * 100.0;
+    std::hint::black_box(sink);
+    println!(
+        "{label:<34} {percent:>7.2} % of one core   ({:>5.0} ns/sample)",
+        elapsed * 1.0e9 / N as f64
+    );
+    percent
+}
+
+/// Cost of running the chain on the silence *after* a loud passage, relative
+/// to the cost of running it on the passage itself.
+///
+/// Every filter tail in the chain decays toward zero, and once its state falls
+/// under the smallest normal float the CPU switches to denormal arithmetic —
+/// on x86 that is tens to hundreds of cycles per operation. A ratio well over
+/// 1.0 here is the classic "the plugin spikes a second after I stop playing"
+/// fault, and it is invisible to any measurement that only feeds it signal.
+fn measure_decay_ratio(label: &str, dsp: &mut Dsp) {
+    let mut rng = 0x5eed_1234u32;
+    let loud: Vec<f32> = (0..N / 2).map(|_| lcg(&mut rng) * 0.5).collect();
+
+    let started = Instant::now();
+    let mut sink = 0.0f32;
+    for (i, &x) in loud.iter().enumerate() {
+        if i % 128 == 0 {
+            dsp.begin_block();
+        }
+        let (l, r) = dsp.process_stereo(x, x);
+        sink += l + r;
+    }
+    let loud_ns = started.elapsed().as_secs_f64() * 1.0e9 / loud.len() as f64;
+
+    // Now silence, for as long again: every tail decays into the denormal range.
+    let started = Instant::now();
+    for i in 0..loud.len() {
+        if i % 128 == 0 {
+            dsp.begin_block();
+        }
+        let (l, r) = dsp.process_stereo(0.0, 0.0);
+        sink += l + r;
+    }
+    let quiet_ns = started.elapsed().as_secs_f64() * 1.0e9 / loud.len() as f64;
+    std::hint::black_box(sink);
+    println!(
+        "{label:<34} {:>5.0} ns/sample on silence vs {loud_ns:>5.0} on signal  ({:.2}x)",
+        quiet_ns,
+        quiet_ns / loud_ns
+    );
+}
+
+/// One WaveNet layer array: `(input_size, channels, head_size, dilations)`.
+type ArraySpec = (usize, usize, usize, &'static [usize]);
+
+/// The dilation ladder every stock NAM architecture uses.
+const DILATIONS: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 128, 256, 512];
+
+/// Layer-array shapes matching the stock NAM trainer architectures, so the
+/// measured cost is what a user's own `.nam` file actually costs.
+const NAM_SHAPES: &[(&str, &[ArraySpec])] = &[
+    ("feather", &[(1, 8, 4, DILATIONS), (8, 4, 1, DILATIONS)]),
+    ("standard", &[(1, 16, 8, DILATIONS), (16, 8, 1, DILATIONS)]),
+    ("heavy", &[(1, 20, 8, DILATIONS), (20, 8, 1, DILATIONS)]),
+];
+
+/// Build a WaveNet `.nam` from real NAM-shaped layer arrays. The weight
+/// vector's exact length is whatever the config implies, so the first parse is
+/// used to learn it from the mismatch error and the model is then rebuilt at
+/// the right size.
+fn nam_json(arrays: &[ArraySpec]) -> String {
+    let layers: Vec<String> = arrays
+        .iter()
+        .enumerate()
+        .map(|(i, (input_size, channels, head_size, dilations))| {
+            format!(
+                r#"{{"input_size": {input_size}, "condition_size": 1, "channels": {channels},
+                 "head_size": {head_size}, "kernel_size": 3, "dilations": [{}],
+                 "activation": "Tanh", "gated": false, "head_bias": {}}}"#,
+                dilations
+                    .iter()
+                    .map(|d| d.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                i + 1 == arrays.len(),
+            )
+        })
+        .collect();
+    let build = |count: usize| {
+        let mut rng = 0x9e37_79b9u32;
+        let weights: Vec<String> = (0..count)
+            .map(|_| format!("{:.6}", lcg(&mut rng) * 0.05))
+            .collect();
+        format!(
+            r#"{{"version": "0.5.4", "architecture": "WaveNet",
+                 "config": {{"layers": [{}], "head": null, "head_scale": 1.0}},
+                 "weights": [{}], "sample_rate": 48000.0}}"#,
+            layers.join(", "),
+            weights.join(", ")
+        )
+    };
+    // `NamModel::from_json_str` only parses the container; the weight count is
+    // checked when the network is actually built, so probe through `from_nam`.
+    let probe = build(1);
+    let built = nam_rs::NamModel::from_json_str(&probe)
+        .and_then(|model| nam_rs::Model::from_nam(&model).map(|_| ()));
+    match built {
+        Ok(()) => probe,
+        Err(e) => {
+            let text = e.to_string();
+            let expected: usize = text
+                .split("implies ")
+                .nth(1)
+                .and_then(|rest| rest.split(' ').next())
+                .and_then(|n| n.parse().ok())
+                .unwrap_or_else(|| panic!("cannot size weights from `{text}`"));
+            build(expected)
+        }
+    }
+}
+
+fn ir_wav(seconds: f32, channels: u16) -> Vec<u8> {
+    let frames = (SR * seconds) as usize;
+    let mut rng = 0x0bad_f00du32;
+    let mut samples = Vec::with_capacity(frames * channels as usize);
+    for i in 0..frames {
+        // A plausible cabinet shape: bright early reflections into a fast decay.
+        let decay = (-(i as f32) / (SR * 0.02)).exp();
+        for _ in 0..channels {
+            samples.push(lcg(&mut rng) * decay * 0.5);
+        }
+    }
+    let data: Vec<u8> = samples.iter().flat_map(|v| v.to_le_bytes()).collect();
+    let block_align = channels * 4;
+    let mut fmt = Vec::new();
+    fmt.extend_from_slice(&3u16.to_le_bytes());
+    fmt.extend_from_slice(&channels.to_le_bytes());
+    fmt.extend_from_slice(&(SR as u32).to_le_bytes());
+    fmt.extend_from_slice(&((SR as u32) * block_align as u32).to_le_bytes());
+    fmt.extend_from_slice(&block_align.to_le_bytes());
+    fmt.extend_from_slice(&32u16.to_le_bytes());
+
+    let mut out = Vec::new();
+    out.extend_from_slice(b"RIFF");
+    out.extend_from_slice(&(4 + 8 + fmt.len() as u32 + 8 + data.len() as u32).to_le_bytes());
+    out.extend_from_slice(b"WAVE");
+    out.extend_from_slice(b"fmt ");
+    out.extend_from_slice(&(fmt.len() as u32).to_le_bytes());
+    out.extend_from_slice(&fmt);
+    out.extend_from_slice(b"data");
+    out.extend_from_slice(&(data.len() as u32).to_le_bytes());
+    out.extend_from_slice(&data);
+    out
+}
+
+fn main() {
+    println!("Rodhareist CPU profile — {SR} Hz, one stereo instance\n");
+
+    println!("-- individual stages --");
+    let stages = [
+        (StageKind::Gate, "gate_on"),
+        (StageKind::Comp, "comp_on"),
+        (StageKind::Drive, "drive_on"),
+        (StageKind::Eq, "eq_on"),
+        (StageKind::Mod, "mod_on"),
+        (StageKind::Wah, "wah_on"),
+        (StageKind::Delay, "delay_on"),
+        (StageKind::Reverb, "reverb_on"),
+        (StageKind::Cab, "cab_on"),
+        (StageKind::Amp, "amp_on"),
+    ];
+    for (stage, _) in stages {
+        let mut dsp = Dsp::new(SR);
+        dsp.set_params(only(stage));
+        measure(&format!("{stage:?} (default model)"), &mut dsp);
+    }
+
+    println!("\n-- cabinet: modeled vs IR --");
+    for seconds in [0.05f32, 0.2, 0.5] {
+        let mut dsp = Dsp::new(SR);
+        let mut p = only(StageKind::Cab);
+        p.cab_model = CabModel::Ir;
+        dsp.set_params(p);
+        let bytes = ir_wav(seconds, 1);
+        let info = dsp.load_ir_wav(&bytes, "profile").expect("IR loads");
+        dsp.begin_block();
+        measure(
+            &format!("IR {seconds:>4.2} s ({} frames)", info.frames),
+            &mut dsp,
+        );
+        println!(
+            "{:<34} latency {} samples ({:.2} ms)",
+            "  reported",
+            info.latency_samples,
+            info.latency_samples as f32 / SR * 1_000.0
+        );
+    }
+    // Load cost, since it happens while the user waits.
+    let bytes = ir_wav(0.5, 2);
+    let started = Instant::now();
+    let _ = prepare_ir_runtime(&bytes, "load".into(), SR as f64).expect("IR loads");
+    println!(
+        "{:<34} {:>7.1} ms to prepare (stereo)",
+        "IR 0.50 s load",
+        started.elapsed().as_secs_f64() * 1_000.0
+    );
+
+    println!("\n-- NAM capture --");
+    for (label, arrays) in NAM_SHAPES {
+        let json = nam_json(arrays);
+        let mut dsp = Dsp::new(SR);
+        let mut p = only(StageKind::Amp);
+        p.tone_engine = ToneEngineKind::NamCapture;
+        dsp.set_params(p);
+        let started = Instant::now();
+        let info = match dsp.load_nam_capture_json(&json, *label, false, true) {
+            Ok(info) => info,
+            Err(e) => {
+                println!("{label:<34} skipped: {e}");
+                continue;
+            }
+        };
+        let load_ms = started.elapsed().as_secs_f64() * 1_000.0;
+        dsp.begin_block();
+        measure(&format!("NAM {label} (mono)"), &mut dsp);
+        println!(
+            "{:<34} latency {} samples ({:.1} ms), rf {}, {load_ms:.0} ms to load",
+            "  reported",
+            dsp.nam_latency_samples(),
+            dsp.nam_latency_samples() as f32 / SR * 1_000.0,
+            info.receptive_field,
+        );
+    }
+
+    println!("\n-- denormal check: cost of the decay into silence --");
+    for (stage, _) in stages {
+        let mut dsp = Dsp::new(SR);
+        dsp.set_params(only(stage));
+        measure_decay_ratio(&format!("{stage:?}"), &mut dsp);
+    }
+    let mut dsp = Dsp::new(SR);
+    dsp.set_params(default_params());
+    measure_decay_ratio("full chain", &mut dsp);
+
+    println!("\n-- nam-rs kernel: per-sample vs block --");
+    for (label, arrays) in NAM_SHAPES {
+        let json = nam_json(arrays);
+        let Ok(model) = nam_rs::NamModel::from_json_str(&json) else {
+            continue;
+        };
+        let mut rng = 0x2468_1357u32;
+        let input: Vec<f32> = (0..N).map(|_| lcg(&mut rng) * 0.3).collect();
+
+        let mut per_sample = nam_rs::Model::from_nam(&model).expect("builds");
+        let started = Instant::now();
+        let mut sink = 0.0f32;
+        for &x in &input {
+            sink += per_sample.process_sample(x);
+        }
+        let sample_ns = started.elapsed().as_secs_f64() * 1.0e9 / N as f64;
+        std::hint::black_box(sink);
+
+        for block in [32usize, 64, 128, 256] {
+            let mut blocked = nam_rs::Model::from_nam(&model).expect("builds");
+            let mut buffer = vec![0.0f32; block];
+            let started = Instant::now();
+            for chunk in input.chunks(block) {
+                buffer[..chunk.len()].copy_from_slice(chunk);
+                blocked.process_buffer(&mut buffer[..chunk.len()]);
+            }
+            let block_ns = started.elapsed().as_secs_f64() * 1.0e9 / N as f64;
+            std::hint::black_box(buffer[0]);
+            println!(
+                "{:<34} {:>5.0} ns/sample vs {sample_ns:>5.0} per-sample  ({:.2}x)",
+                format!("{label} @ block {block}"),
+                block_ns,
+                sample_ns / block_ns
+            );
+        }
+    }
+
+    println!("\n-- realistic full chains --");
+    let mut dsp = Dsp::new(SR);
+    dsp.set_params(default_params());
+    let all = measure("everything on (modeled amp+cab)", &mut dsp);
+
+    let mut dsp = Dsp::new(SR);
+    let mut p = default_params();
+    p.cab_on = false;
+    dsp.set_params(p);
+    measure("everything on, cabinet slot off", &mut dsp);
+
+    let mut dsp = Dsp::new(SR);
+    let mut p = default_params();
+    p.amp_on = false;
+    dsp.set_params(p);
+    measure("everything on, amp slot off", &mut dsp);
+
+    let mut dsp = Dsp::new(SR);
+    let mut p = default_params();
+    p.cab_model = CabModel::Ir;
+    dsp.set_params(p);
+    let bytes = ir_wav(0.2, 2);
+    dsp.load_ir_wav(&bytes, "chain").expect("IR loads");
+    dsp.begin_block();
+    let with_ir = measure("everything on + stereo IR cab", &mut dsp);
+
+    let json = nam_json(NAM_SHAPES[1].1);
+    let mut dsp = Dsp::new(SR);
+    let mut p = default_params();
+    p.tone_engine = ToneEngineKind::NamCapture;
+    p.cab_model = CabModel::Ir;
+    dsp.set_params(p);
+    dsp.load_nam_capture_json(&json, "chain", false, true)
+        .expect("NAM loads");
+    dsp.load_ir_wav(&bytes, "chain").expect("IR loads");
+    dsp.begin_block();
+    let nam_chain = measure("everything on + NAM + stereo IR", &mut dsp);
+    println!(
+        "\n  total reported latency of that chain: {} samples ({:.1} ms)",
+        dsp.latency_samples(),
+        dsp.latency_samples() as f32 / SR * 1_000.0
+    );
+    println!(
+        "\n  modeled {all:.0} % / IR {with_ir:.0} % / NAM+IR {nam_chain:.0} % of one core per instance"
+    );
+}

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/amp.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/amp.rs
@@ -44,7 +44,7 @@ const INVERTER_COUPLING_SCALE: f32 = 0.42;
 #[inline]
 fn finite(x: f32) -> f32 {
     if x.is_finite() {
-        x.clamp(-8.0, 8.0)
+        super::flush_denormal(x.clamp(-8.0, 8.0))
     } else {
         0.0
     }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/cab.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/cab.rs
@@ -18,7 +18,7 @@ const MAX_DELAY_SECONDS: f32 = 0.035;
 #[inline]
 fn finite(x: f32) -> f32 {
     if x.is_finite() {
-        x.clamp(-6.0, 6.0)
+        super::flush_denormal(x.clamp(-6.0, 6.0))
     } else {
         0.0
     }
@@ -654,7 +654,8 @@ impl CabLane {
             controls.mode2_f,
             (profile.resonance_damping + 0.18).min(1.5),
         );
-        channel.body_low += body_alpha * (channel.hp_y - channel.body_low);
+        channel.body_low =
+            finite(channel.body_low + body_alpha * (channel.hp_y - channel.body_low));
         let body = channel.hp_y - channel.body_low;
         let breakup =
             channel
@@ -726,31 +727,37 @@ impl CabLane {
             }
         };
 
-        channel.envelope += 0.002 * (acoustic.abs() - channel.envelope);
+        channel.envelope = finite(channel.envelope + 0.002 * (acoustic.abs() - channel.envelope));
         acoustic /= 1.0 + channel.envelope * profile.compression;
 
         // Natural loudspeaker radiation loss: two to four cascaded poles.
         for stage in channel.lpf.iter_mut().take(profile.slope) {
-            *stage += controls.speaker_lpf_alpha * (acoustic - *stage);
+            *stage = finite(*stage + controls.speaker_lpf_alpha * (acoustic - *stage));
             acoustic = *stage;
         }
 
         // Position changes proximity and cone breakup as well as high
         // radiation. Distance reduces proximity and introduces a softened,
         // delayed early-room reflection.
-        channel.proximity_low += controls.proximity_alpha * (acoustic - channel.proximity_low);
+        channel.proximity_low = finite(
+            channel.proximity_low + controls.proximity_alpha * (acoustic - channel.proximity_low),
+        );
         let proximity =
             channel.proximity_low * (1.0 - controls.distance) * (0.36 - controls.position * 0.10);
         let close = acoustic + proximity;
 
         // Three capsule topologies, continuously crossfaded for automation.
-        channel.dynamic_mid += controls.dynamic_alpha * (close - channel.dynamic_mid);
+        channel.dynamic_mid =
+            finite(channel.dynamic_mid + controls.dynamic_alpha * (close - channel.dynamic_mid));
         let dynamic = close
             + (close - channel.dynamic_mid) * (0.13 + center * 0.12)
             + breakup * center * 0.035;
-        channel.ribbon_low += controls.ribbon_alpha * (close - channel.ribbon_low);
+        channel.ribbon_low =
+            finite(channel.ribbon_low + controls.ribbon_alpha * (close - channel.ribbon_low));
         let ribbon = channel.ribbon_low + channel.proximity_low * 0.15 * (1.0 - controls.distance);
-        channel.condenser_low += controls.condenser_alpha * (close - channel.condenser_low);
+        channel.condenser_low = finite(
+            channel.condenser_low + controls.condenser_alpha * (close - channel.condenser_low),
+        );
         let condenser = close + (close - channel.condenser_low) * 0.10 + breakup * center * 0.025;
         let mic = if controls.mic_kind <= 1.0 {
             dynamic * (1.0 - controls.mic_kind) + ribbon * controls.mic_kind
@@ -759,7 +766,7 @@ impl CabLane {
             ribbon * (1.0 - blend) + condenser * blend
         };
 
-        channel.room_low += controls.air_alpha * (mic - channel.room_low);
+        channel.room_low = finite(channel.room_low + controls.air_alpha * (mic - channel.room_low));
         let direct = channel.room_low;
         let reflection = delay.read(controls.room_delay);
         let softened_reflection = reflection * (1.0 - controls.position * 0.18);

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/ir.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/ir.rs
@@ -19,9 +19,24 @@
 //! accumulates the FDL against the partition spectra. Latency is exactly
 //! [`PARTITION`] samples, reported to the host for delay compensation.
 //!
-//! Cost scales with IR length, which is why [`MAX_IR_SECONDS`] caps it: this is
-//! a *cabinet* IR engine, and a uniform partitioning is the wrong shape for a
-//! multi-second reverb tail.
+//! Three things keep that affordable:
+//!
+//! - **Both channels ride one transform.** Left goes in the real plane and
+//!   right in the imaginary one, so a stereo block costs one forward and one
+//!   inverse FFT instead of four. The two real spectra are untangled from the
+//!   packed transform with a handful of adds per bin.
+//! - **Only half of each spectrum is stored.** A real signal's transform is
+//!   conjugate-symmetric, so DC..Nyquist ([`BINS`]) is the whole of the
+//!   information — halving both the frequency-delay line and the
+//!   multiply-accumulate loop that dominates the cost.
+//! - **Real and imaginary parts live in separate planes**, so that loop is a
+//!   pair of contiguous `f32` sweeps a compiler can vectorize, rather than a
+//!   stride-2 walk over interleaved complex values.
+//!
+//! Cost still scales with IR length, which is why [`MAX_IR_SECONDS`] caps it
+//! and why the inaudible tail is trimmed at load ([`TAIL_ENERGY_FLOOR`]): this
+//! is a *cabinet* IR engine, and a uniform partitioning is the wrong shape for
+//! a multi-second reverb tail.
 //!
 //! ## Realtime rules
 //!
@@ -45,6 +60,11 @@ pub const PARTITION: usize = 128;
 /// Overlap-save transform length: twice the partition.
 const FFT_SIZE: usize = PARTITION * 2;
 
+/// Bins kept per partition: DC through Nyquist. Everything above is the
+/// conjugate mirror of a real signal's spectrum, so storing it would double
+/// both the memory and the accumulate loop for no extra information.
+const BINS: usize = FFT_SIZE / 2 + 1;
+
 /// Longest IR the engine keeps, in seconds. A guitar cabinet IR is tens of
 /// milliseconds of useful content; anything past this is truncated (with a
 /// fade so the cut is not a click) rather than paying uniform-partition cost
@@ -53,6 +73,21 @@ pub const MAX_IR_SECONDS: f32 = 0.5;
 
 /// Samples of raised-cosine fade applied at a truncation point.
 const TRUNCATE_FADE: usize = 64;
+
+/// Fraction of an IR's total energy allowed to sit in the tail that gets cut.
+///
+/// Cabinet IR files are routinely padded out to a round length — half a second
+/// of file for thirty milliseconds of cabinet — and under a *uniform*
+/// partitioning every one of those padded partitions costs the same
+/// multiply-accumulate sweep as the ones carrying the sound. `1e-7` is −70 dB
+/// of energy: the discarded tail is a hundredth of a percent of the signal,
+/// well under the noise floor of the capture itself, and cutting it is worth
+/// several times the convolution cost on a typical file.
+const TAIL_ENERGY_FLOOR: f32 = 1.0e-7;
+
+/// Never trim below this many samples, however little energy an IR carries —
+/// a short, quiet IR is still the cabinet the user chose.
+const MIN_TAIL_FRAMES: usize = PARTITION * 2;
 
 /// Shortest IR worth loading — below this a file is a click, not a cabinet.
 const MIN_IR_FRAMES: usize = 8;
@@ -102,7 +137,9 @@ pub struct IrInfo {
     pub name: String,
     /// Rate the file declared, before any resampling.
     pub source_sample_rate: f64,
-    /// Frames actually convolved, at the engine's rate.
+    /// Frames actually convolved, at the engine's rate — after resampling and
+    /// after the inaudible tail past [`TAIL_ENERGY_FLOOR`] is trimmed, so this
+    /// is the length the CPU cost scales with rather than the file's.
     pub frames: usize,
     /// True when the file carried two distinct channels (true-stereo IR).
     pub stereo: bool,
@@ -118,24 +155,53 @@ pub struct PreparedIrRuntime {
     info: IrInfo,
     fft: Arc<dyn Fft<f32>>,
     ifft: Arc<dyn Fft<f32>>,
-    /// Partition spectra, `partitions * FFT_SIZE` complex values per channel.
-    /// Already scaled by `1/FFT_SIZE` so the round trip comes back at unity.
-    h_l: Vec<Complex<f32>>,
-    h_r: Vec<Complex<f32>>,
+    /// Partition spectra: `partitions * BINS` bins per channel, real and
+    /// imaginary parts in separate planes. Already scaled by `1/FFT_SIZE` so
+    /// the round trip comes back at unity.
+    h_l: Spectra,
+    h_r: Spectra,
     /// Frequency-delay lines of past input blocks, same layout as `h_*`.
-    fdl_l: Vec<Complex<f32>>,
-    fdl_r: Vec<Complex<f32>>,
+    fdl_l: Spectra,
+    fdl_r: Spectra,
     /// Partition slot holding the newest input block.
     fdl_head: usize,
     partitions: usize,
     /// The previous block's input samples (the overlap in overlap-save).
     prev_l: Vec<f32>,
     prev_r: Vec<f32>,
-    /// Transform/accumulation scratch, all `FFT_SIZE` long.
+    /// The one transform both channels ride: left in the real plane, right in
+    /// the imaginary one. `FFT_SIZE` long.
     block: Vec<Complex<f32>>,
-    accum: Vec<Complex<f32>>,
+    /// Accumulated product of the FDL against the partition spectra, one
+    /// half-spectrum per channel.
+    acc_l: HalfSpectrum,
+    acc_r: HalfSpectrum,
     fft_scratch: Vec<Complex<f32>>,
 }
+
+/// One half-spectrum (DC..Nyquist) in split real/imaginary planes.
+#[derive(Debug, Clone)]
+struct HalfSpectrum {
+    re: Vec<f32>,
+    im: Vec<f32>,
+}
+
+impl HalfSpectrum {
+    fn zeros(bins: usize) -> Self {
+        Self {
+            re: vec![0.0; bins],
+            im: vec![0.0; bins],
+        }
+    }
+
+    fn clear(&mut self) {
+        self.re.fill(0.0);
+        self.im.fill(0.0);
+    }
+}
+
+/// `partitions` consecutive half-spectra, indexed by partition slot.
+type Spectra = HalfSpectrum;
 
 impl std::fmt::Debug for PreparedIrRuntime {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -152,69 +218,128 @@ impl PreparedIrRuntime {
     }
 
     fn clear(&mut self) {
-        self.fdl_l.fill(Complex::new(0.0, 0.0));
-        self.fdl_r.fill(Complex::new(0.0, 0.0));
+        self.fdl_l.clear();
+        self.fdl_r.clear();
         self.fdl_head = 0;
         self.prev_l.fill(0.0);
         self.prev_r.fill(0.0);
     }
 
-    /// Audio thread: convolve one [`PARTITION`]-sample block. Input and output
-    /// buffers are the caller's fixed accumulation buffers; nothing here
-    /// allocates.
+    /// Audio thread: convolve one [`PARTITION`]-sample stereo block. Input and
+    /// output buffers are the caller's fixed accumulation buffers; nothing
+    /// here allocates.
     fn process_block(&mut self, in_l: &[f32], in_r: &[f32], out_l: &mut [f32], out_r: &mut [f32]) {
         self.fdl_head = (self.fdl_head + 1) % self.partitions;
         let head = self.fdl_head;
-        let n = FFT_SIZE;
         let p = self.partitions;
 
-        for channel in 0..2 {
-            let (input, prev, output, h, fdl) = if channel == 0 {
-                (
-                    in_l,
-                    &mut self.prev_l,
-                    &mut *out_l,
-                    &self.h_l,
-                    &mut self.fdl_l,
-                )
-            } else {
-                (
-                    in_r,
-                    &mut self.prev_r,
-                    &mut *out_r,
-                    &self.h_r,
-                    &mut self.fdl_r,
-                )
-            };
-
-            // Overlap-save input block: the previous partition then this one.
-            for i in 0..PARTITION {
-                self.block[i] = Complex::new(prev[i], 0.0);
-                self.block[PARTITION + i] = Complex::new(input[i], 0.0);
-            }
-            self.fft
-                .process_with_scratch(&mut self.block, &mut self.fft_scratch);
-            fdl[head * n..head * n + n].copy_from_slice(&self.block);
-
-            // Accumulate every partition against the matching past block.
-            self.accum.fill(Complex::new(0.0, 0.0));
-            for part in 0..p {
-                let slot = (head + p - part) % p;
-                let x = &fdl[slot * n..slot * n + n];
-                let hp = &h[part * n..part * n + n];
-                for k in 0..n {
-                    self.accum[k] += x[k] * hp[k];
-                }
-            }
-            self.ifft
-                .process_with_scratch(&mut self.accum, &mut self.fft_scratch);
-
-            // Overlap-save: only the second half of the block is valid output.
-            for i in 0..PARTITION {
-                output[i] = self.accum[PARTITION + i].re;
-            }
-            prev.copy_from_slice(input);
+        // Overlap-save input block — the previous partition then this one —
+        // with both channels packed into a single complex transform.
+        for i in 0..PARTITION {
+            self.block[i] = Complex::new(self.prev_l[i], self.prev_r[i]);
+            self.block[PARTITION + i] = Complex::new(in_l[i], in_r[i]);
         }
+        self.fft
+            .process_with_scratch(&mut self.block, &mut self.fft_scratch);
+
+        // Untangle the two real spectra: for X = FFT(l + j·r),
+        // L[k] = (X[k] + conj(X[N-k]))/2 and R[k] = -j·(X[k] - conj(X[N-k]))/2.
+        let base = head * BINS;
+        for k in 0..BINS {
+            let a = self.block[k];
+            let mirror = self.block[(FFT_SIZE - k) % FFT_SIZE];
+            let (b_re, b_im) = (mirror.re, -mirror.im);
+            self.fdl_l.re[base + k] = 0.5 * (a.re + b_re);
+            self.fdl_l.im[base + k] = 0.5 * (a.im + b_im);
+            let d_re = 0.5 * (a.re - b_re);
+            let d_im = 0.5 * (a.im - b_im);
+            self.fdl_r.re[base + k] = d_im;
+            self.fdl_r.im[base + k] = -d_re;
+        }
+
+        // Accumulate every partition against the matching past input block.
+        // Split planes and a half spectrum make this the vectorizable sweep it
+        // needs to be — it is the whole cost of a long IR.
+        let Self {
+            h_l,
+            h_r,
+            fdl_l,
+            fdl_r,
+            acc_l,
+            acc_r,
+            ..
+        } = self;
+        acc_l.clear();
+        acc_r.clear();
+        for part in 0..p {
+            let slot = (head + p - part) % p;
+            let x = slot * BINS;
+            let h = part * BINS;
+            accumulate(
+                &fdl_l.re[x..x + BINS],
+                &fdl_l.im[x..x + BINS],
+                &h_l.re[h..h + BINS],
+                &h_l.im[h..h + BINS],
+                &mut acc_l.re,
+                &mut acc_l.im,
+            );
+            accumulate(
+                &fdl_r.re[x..x + BINS],
+                &fdl_r.im[x..x + BINS],
+                &h_r.re[h..h + BINS],
+                &h_r.im[h..h + BINS],
+                &mut acc_r.re,
+                &mut acc_r.im,
+            );
+        }
+
+        // Repack the two results into one inverse transform (`acc_l + j·acc_r`),
+        // rebuilding the conjugate mirror the half spectrum left implicit.
+        for k in 0..BINS {
+            self.block[k] = Complex::new(
+                self.acc_l.re[k] - self.acc_r.im[k],
+                self.acc_l.im[k] + self.acc_r.re[k],
+            );
+            if k > 0 && k < FFT_SIZE / 2 {
+                self.block[FFT_SIZE - k] = Complex::new(
+                    self.acc_l.re[k] + self.acc_r.im[k],
+                    self.acc_r.re[k] - self.acc_l.im[k],
+                );
+            }
+        }
+        self.ifft
+            .process_with_scratch(&mut self.block, &mut self.fft_scratch);
+
+        // Overlap-save: only the second half of the block is valid output, and
+        // the two channels come back out of the two planes they went in on.
+        for i in 0..PARTITION {
+            out_l[i] = self.block[PARTITION + i].re;
+            out_r[i] = self.block[PARTITION + i].im;
+        }
+        self.prev_l.copy_from_slice(in_l);
+        self.prev_r.copy_from_slice(in_r);
+    }
+}
+
+/// One partition's complex multiply-accumulate over split real/imaginary
+/// planes. Every slice is `BINS` long; the equal lengths are asserted once so
+/// the inner loop carries no bounds checks.
+#[inline]
+fn accumulate(
+    x_re: &[f32],
+    x_im: &[f32],
+    h_re: &[f32],
+    h_im: &[f32],
+    acc_re: &mut [f32],
+    acc_im: &mut [f32],
+) {
+    let n = BINS;
+    let (x_re, x_im) = (&x_re[..n], &x_im[..n]);
+    let (h_re, h_im) = (&h_re[..n], &h_im[..n]);
+    let (acc_re, acc_im) = (&mut acc_re[..n], &mut acc_im[..n]);
+    for k in 0..n {
+        acc_re[k] += x_re[k] * h_re[k] - x_im[k] * h_im[k];
+        acc_im[k] += x_re[k] * h_im[k] + x_im[k] * h_re[k];
     }
 }
 
@@ -248,6 +373,21 @@ fn resample_offline(input: &[f32], from_rate: f64, to_rate: f64) -> Vec<f32> {
             ((c3 * f + c2) * f + c1) * f + p1
         })
         .collect()
+}
+
+/// Length of the shortest prefix that still holds all but
+/// [`TAIL_ENERGY_FLOOR`] of the pair's energy — where the file stops being a
+/// cabinet and starts being padding.
+fn audible_length(left: &[f32], right: &[f32], total_energy: f32) -> usize {
+    let budget = total_energy * TAIL_ENERGY_FLOOR;
+    let mut tail = 0.0f32;
+    for i in (0..left.len()).rev() {
+        tail += 0.5 * (left[i] * left[i] + right[i] * right[i]);
+        if tail > budget {
+            return (i + 1).max(MIN_TAIL_FRAMES).min(left.len());
+        }
+    }
+    left.len().min(MIN_TAIL_FRAMES)
 }
 
 /// Cut to `max_frames`, fading the last [`TRUNCATE_FADE`] samples so the cut
@@ -327,6 +467,15 @@ pub fn prepare_ir_runtime(
         *sample *= gain;
     }
 
+    // Drop the padding past the cabinet. Under a uniform partitioning every
+    // trailing block of near-silence costs exactly as much as a block carrying
+    // sound, and IR files in the wild are mostly padding. The fade window is
+    // kept *past* the audible length so it lands on the sub-floor tail rather
+    // than attenuating content the cabinet still needs.
+    let audible = audible_length(&left, &right, energy * gain * gain) + TRUNCATE_FADE;
+    truncate_with_fade(&mut left, audible);
+    truncate_with_fade(&mut right, audible);
+
     let frames = left.len();
     let partitions = frames.div_ceil(PARTITION).max(1);
 
@@ -341,8 +490,8 @@ pub fn prepare_ir_runtime(
     // Fold the inverse transform's 1/N into the IR spectra so the hot path
     // never scales anything.
     let norm = 1.0 / FFT_SIZE as f32;
-    let mut build = |channel: &[f32]| -> Vec<Complex<f32>> {
-        let mut spectra = vec![Complex::new(0.0, 0.0); partitions * FFT_SIZE];
+    let mut build = |channel: &[f32]| -> Spectra {
+        let mut spectra = Spectra::zeros(partitions * BINS);
         let mut scratch_block = vec![Complex::new(0.0, 0.0); FFT_SIZE];
         for part in 0..partitions {
             let start = part * PARTITION;
@@ -352,7 +501,11 @@ pub fn prepare_ir_runtime(
                 scratch_block[i] = Complex::new(sample * norm, 0.0);
             }
             fft.process_with_scratch(&mut scratch_block, &mut fft_scratch);
-            spectra[part * FFT_SIZE..(part + 1) * FFT_SIZE].copy_from_slice(&scratch_block);
+            // Keep DC..Nyquist only; the rest is the conjugate mirror.
+            for (k, bin) in scratch_block[..BINS].iter().enumerate() {
+                spectra.re[part * BINS + k] = bin.re;
+                spectra.im[part * BINS + k] = bin.im;
+            }
         }
         spectra
     };
@@ -372,14 +525,15 @@ pub fn prepare_ir_runtime(
         ifft,
         h_l,
         h_r,
-        fdl_l: vec![Complex::new(0.0, 0.0); partitions * FFT_SIZE],
-        fdl_r: vec![Complex::new(0.0, 0.0); partitions * FFT_SIZE],
+        fdl_l: Spectra::zeros(partitions * BINS),
+        fdl_r: Spectra::zeros(partitions * BINS),
         fdl_head: 0,
         partitions,
         prev_l: vec![0.0; PARTITION],
         prev_r: vec![0.0; PARTITION],
         block: vec![Complex::new(0.0, 0.0); FFT_SIZE],
-        accum: vec![Complex::new(0.0, 0.0); FFT_SIZE],
+        acc_l: HalfSpectrum::zeros(BINS),
+        acc_r: HalfSpectrum::zeros(BINS),
         fft_scratch,
     })
 }
@@ -542,10 +696,16 @@ impl IrConvolver {
         self.active.as_ref().map(|rt| rt.info())
     }
 
-    /// Latency the convolution adds, in samples — [`PARTITION`] while an IR is
-    /// loaded, 0 when the slot is a dry pass through.
+    /// Latency the convolution adds, in samples: always [`PARTITION`], because
+    /// the block ring runs whether or not a file is loaded.
+    ///
+    /// Reporting 0 for an empty slot — as this used to — left the host
+    /// uncompensated for a delay the engine was applying anyway, so the IR
+    /// cabinet sat [`PARTITION`] samples behind every parallel path in the
+    /// project. Keeping it constant also means loading a file mid-playback
+    /// does not move the plugin's latency under the graph's feet.
     pub(super) fn latency_samples(&self) -> usize {
-        if self.active.is_some() { PARTITION } else { 0 }
+        PARTITION
     }
 
     fn retire(&mut self, runtime: Box<PreparedIrRuntime>) {
@@ -721,9 +881,11 @@ mod tests {
     }
 
     #[test]
-    fn reports_partition_latency_only_while_an_ir_is_loaded() {
+    fn reports_partition_latency_whether_or_not_an_ir_is_loaded() {
         let mut conv = IrConvolver::new(SR as f32);
-        assert_eq!(conv.latency_samples(), 0);
+        // The ring runs either way, so the reported latency must not move when
+        // a file lands — the empty slot is a *delayed* pass through.
+        assert_eq!(conv.latency_samples(), PARTITION);
         assert!(conv.active_info().is_none());
 
         let ir = test_ir(200);

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/mod.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/mod.rs
@@ -63,7 +63,10 @@ pub use ir::{
     PreparedIrRuntime, prepare_ir_runtime,
 };
 use mod_stage::ModStage;
-pub use nam::{NamCaptureInfo, NamLoadError, NamLoader, PreparedNamRuntime, prepare_nam_runtime};
+pub use nam::{
+    NAM_BLOCK as NAM_BLOCK_SAMPLES, NamCaptureInfo, NamLoadError, NamLoader, PreparedNamRuntime,
+    prepare_nam_runtime,
+};
 use reverb::PlateReverb;
 pub use tone_stage::ToneEngineKind;
 use tone_stage::ToneStage;
@@ -1578,9 +1581,15 @@ impl Dsp {
         self.amp_stage.nam_capture_info()
     }
 
-    /// Latency contributed by the active NAM capture's receptive field, in
-    /// engine samples (0 if none loaded), already accounting for a capture
-    /// running through the rate adapter.
+    /// Latency the NAM engine adds, in engine samples: the block it buffers
+    /// for inference plus, for a capture running at a different rate, the rate
+    /// adapter's interpolation delay.
+    ///
+    /// **Not** the receptive field. A WaveNet's dilated convolutions are
+    /// causal, so the field is history the model needs warmed — which
+    /// `prepare_nam_runtime` does at load — rather than a delay it imposes.
+    /// Reporting it as latency put a stock capture 85 ms behind the dry
+    /// signal.
     pub fn nam_latency_samples(&self) -> usize {
         self.amp_stage.nam_latency_samples()
     }
@@ -1622,7 +1631,7 @@ impl Dsp {
     }
 
     /// Total latency this instance reports to the host, in samples: the NAM
-    /// capture's receptive field plus the IR convolution's partition, counting
+    /// engine's inference block plus the IR convolution's partition, counting
     /// each only while the stage that carries it is actually in the path.
     pub fn latency_samples(&self) -> usize {
         let p = &self.params;
@@ -2002,23 +2011,54 @@ impl StereoEffect for Dsp {
 // Shared realtime-safe building blocks used by the stage modules.
 // ---------------------------------------------------------------------------
 
-use biquad::{Biquad, Coefficients, DirectForm1};
+use biquad::Coefficients;
+
+/// One channel's direct-form-I state.
+///
+/// Spelled out here rather than taken from `biquad::DirectForm1` for one
+/// reason: the feedback taps have to be reachable so [`flush_denormal`] can
+/// snap them to zero as a tail decays. A biquad whose `y1`/`y2` slide into the
+/// subnormal range keeps running — just one to two orders of magnitude slower
+/// — and this chain has dozens of them. The arithmetic is otherwise identical.
+#[derive(Debug, Clone, Copy, Default)]
+struct DirectForm1 {
+    x1: f32,
+    x2: f32,
+    y1: f32,
+    y2: f32,
+}
+
+impl DirectForm1 {
+    #[inline]
+    fn run(&mut self, coefficients: &Coefficients<f32>, x: f32) -> f32 {
+        let y = coefficients.b0 * x + coefficients.b1 * self.x1 + coefficients.b2 * self.x2
+            - coefficients.a1 * self.y1
+            - coefficients.a2 * self.y2;
+        self.x2 = self.x1;
+        self.x1 = x;
+        self.y2 = self.y1;
+        self.y1 = flush_denormal(y);
+        y
+    }
+
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
 
 /// A biquad with independent left/right state but shared coefficients, so a
 /// stereo stage filters each channel correctly (a single instance cannot serve
 /// both channels — its state would be stepped at twice the rate).
 #[derive(Debug, Clone, Default)]
 pub(crate) struct StereoBiquad {
-    left: Option<DirectForm1<f32>>,
-    right: Option<DirectForm1<f32>>,
+    coefficients: Option<Coefficients<f32>>,
+    left: DirectForm1,
+    right: DirectForm1,
 }
 
 impl StereoBiquad {
     pub(crate) fn none() -> Self {
-        Self {
-            left: None,
-            right: None,
-        }
+        Self::default()
     }
 
     /// Retune (or clear) the filter for both channels, **keeping its running
@@ -2035,38 +2075,25 @@ impl StereoBiquad {
     /// Going from a filter to `None` still steps — that is a real topology
     /// change (a band switching to true bypass), not a retune.
     pub(crate) fn set(&mut self, coefficients: Option<Coefficients<f32>>) {
-        let Some(coefficients) = coefficients else {
-            self.left = None;
-            self.right = None;
-            return;
-        };
-        match (self.left.as_mut(), self.right.as_mut()) {
-            (Some(left), Some(right)) => {
-                left.update_coefficients(coefficients);
-                right.update_coefficients(coefficients);
-            }
+        let had_filter = self.coefficients.is_some();
+        self.coefficients = coefficients;
+        if !had_filter {
             // First install: there is no history to carry over.
-            _ => {
-                self.left = Some(DirectForm1::<f32>::new(coefficients));
-                self.right = Some(DirectForm1::<f32>::new(coefficients));
-            }
+            self.reset();
         }
     }
 
     pub(crate) fn reset(&mut self) {
-        if let Some(f) = self.left.as_mut() {
-            f.reset_state();
-        }
-        if let Some(f) = self.right.as_mut() {
-            f.reset_state();
-        }
+        self.left.reset();
+        self.right.reset();
     }
 
     #[inline]
     pub(crate) fn run(&mut self, left: f32, right: f32) -> (f32, f32) {
-        let l = self.left.as_mut().map(|f| f.run(left)).unwrap_or(left);
-        let r = self.right.as_mut().map(|f| f.run(right)).unwrap_or(right);
-        (l, r)
+        match self.coefficients.as_ref() {
+            Some(c) => (self.left.run(c, left), self.right.run(c, right)),
+            None => (left, right),
+        }
     }
 }
 
@@ -2163,6 +2190,18 @@ impl Lfo {
 pub(crate) fn soft_clip(x: f32) -> f32 {
     x.tanh()
 }
+
+/// Snap a decaying recursive state to zero before it reaches the subnormal
+/// range — see [`builtin_dsp_core::flush_denormal`].
+///
+/// Every IIR state in this chain (resonators, one-poles, the halfband
+/// allpasses, the biquads) decays geometrically once the player stops. Left
+/// alone they cross into denormal floats, where each operation costs tens to
+/// hundreds of cycles: the modeled cabinet alone measured **19x** slower on
+/// the decay into silence than on signal, which is exactly the "spikes a
+/// moment after I stop playing" fault. Applying this to whatever a filter
+/// feeds back is what keeps a silent chain cheap.
+pub(crate) use builtin_dsp_core::flush_denormal;
 
 #[cfg(test)]
 mod tests {
@@ -2344,7 +2383,12 @@ mod tests {
     fn ir_cabinet_without_a_file_does_not_mute_the_rig() {
         let mut dsp = Dsp::new(48_000.0);
         assert!(dsp.select_model("cab", "ir"));
-        assert_eq!(dsp.latency_samples(), 0, "an empty IR slot adds no latency");
+        assert_eq!(
+            dsp.latency_samples(),
+            IR_PARTITION_SAMPLES,
+            "the IR slot's block ring runs whether or not a file is loaded, and \
+             its latency must be reported so the host compensates it"
+        );
         let mut peak = 0.0f32;
         for n in 0..12_000 {
             if n % 128 == 0 {

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/nam.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/nam.rs
@@ -33,6 +33,18 @@ const SAMPLE_RATE_TOLERANCE_HZ: f64 = 0.5;
 /// Roughly how long a runtime swap crossfades for, in milliseconds.
 const SWAP_FADE_MS: f32 = 8.0;
 
+/// Engine samples the capture buffers before running one inference, and
+/// therefore the engine's exact latency while the NAM tone engine is selected.
+///
+/// nam-rs has two entry points that produce identical output: `process_sample`
+/// and the block kernel `process_buffer`, which pushes a whole chunk through
+/// one weight matrix at a time instead of reloading every matrix per sample.
+/// Measured on a stock "standard" capture the block kernel is ~2.8x faster at
+/// 64 samples (13.6 → 4.8 µs/sample) and ~3.5x at 128. 64 buys most of that
+/// speedup for 1.3 ms at 48 kHz — the trade a per-sample host callback forces,
+/// since the block cannot be computed until its last input sample has arrived.
+pub const NAM_BLOCK: usize = 64;
+
 /// A `.nam` failed to parse/build, or its sample rate is too far from the
 /// engine's for the rate adapter to bridge.
 #[derive(Debug)]
@@ -89,11 +101,20 @@ pub struct PreparedNamRuntime {
     /// runs the model at the capture's own rate from inside the engine's
     /// stream. `None` is the native, zero-overhead path.
     adapter: Option<RateAdapter>,
-    /// The capture's total latency in **engine** samples: its receptive field
-    /// converted out of the model's rate, plus whatever the adapter's own
-    /// interpolation contributes. Equals `receptive_field` when running
-    /// natively.
+    /// The capture's own latency in **engine** samples, on top of the
+    /// [`NAM_BLOCK`] the buffering costs: zero for a natively-run capture,
+    /// and the adapter's interpolation delay for a rate-adapted one.
+    ///
+    /// The receptive field is deliberately *not* part of this. A WaveNet's
+    /// dilated convolutions are causal — output sample `n` is computed from
+    /// inputs up to `n` — so the field is how much history the model needs
+    /// warmed, not a delay it imposes. [`prepare_nam_runtime`] warms it here,
+    /// on the control thread, exactly like the reference NAM plugin.
     latency_samples: usize,
+    /// Inference staging, `NAM_BLOCK` long: the model runs mono, in place, on
+    /// one channel at a time.
+    scratch_l: Vec<f32>,
+    scratch_r: Vec<f32>,
 }
 
 impl std::fmt::Debug for PreparedNamRuntime {
@@ -128,18 +149,20 @@ pub fn prepare_nam_runtime(
     let nam_model = NamModel::from_json_str(json).map_err(NamLoadError::Parse)?;
     let expected = nam_model.expected_sample_rate();
     let adapter = if (expected - engine_sample_rate).abs() > SAMPLE_RATE_TOLERANCE_HZ {
-        Some(RateAdapter::new(expected, engine_sample_rate).ok_or(
-            NamLoadError::SampleRateMismatch {
-                expected,
-                engine: engine_sample_rate,
-            },
-        )?)
+        Some(
+            RateAdapter::new(expected, engine_sample_rate, NAM_BLOCK).ok_or(
+                NamLoadError::SampleRateMismatch {
+                    expected,
+                    engine: engine_sample_rate,
+                },
+            )?,
+        )
     } else {
         None
     };
 
-    let model_l = Model::from_nam(&nam_model).map_err(NamLoadError::Parse)?;
-    let model_r = if stereo {
+    let mut model_l = Model::from_nam(&nam_model).map_err(NamLoadError::Parse)?;
+    let mut model_r = if stereo {
         Some(Model::from_nam(&nam_model).map_err(NamLoadError::Parse)?)
     } else {
         None
@@ -149,12 +172,18 @@ pub fn prepare_nam_runtime(
         .loudness()
         .map(|l| 10f32.powf((TARGET_LUFS - l) / 20.0).clamp(0.05, 20.0))
         .unwrap_or(1.0);
-    // The receptive field is counted in the *model's* samples; the host's
-    // delay compensation works in engine samples.
-    let latency_samples = match adapter.as_ref() {
-        Some(a) => a.inner_to_engine_samples(receptive_field) + a.latency_samples(),
-        None => receptive_field,
-    };
+
+    // Warm the receptive field here rather than making the host delay the whole
+    // track by it. A fresh WaveNet's first `receptive_field` outputs are
+    // computed against zero-filled history — a startup transient, not a
+    // latency — so running silence through it now retires the transient on the
+    // control thread and leaves the audio path aligned with the dry signal.
+    prewarm(&mut model_l, receptive_field);
+    if let Some(model_r) = model_r.as_mut() {
+        prewarm(model_r, receptive_field);
+    }
+
+    let latency_samples = adapter.as_ref().map_or(0, RateAdapter::latency_samples);
 
     Ok(PreparedNamRuntime {
         name,
@@ -166,7 +195,24 @@ pub fn prepare_nam_runtime(
         full_rig,
         adapter,
         latency_samples,
+        scratch_l: vec![0.0; NAM_BLOCK],
+        scratch_r: vec![0.0; NAM_BLOCK],
     })
+}
+
+/// Run `samples` of silence through a freshly built model so its dilation
+/// history holds the model's own steady-state response to silence instead of
+/// hard zeros. Control thread only: this is the expensive part of a load.
+fn prewarm(model: &mut Model, samples: usize) {
+    const CHUNK: usize = 256;
+    let mut silence = [0.0f32; CHUNK];
+    let mut done = 0;
+    while done < samples {
+        let n = CHUNK.min(samples - done);
+        silence[..n].fill(0.0);
+        model.process_buffer(&mut silence[..n]);
+        done += n;
+    }
 }
 
 impl PreparedNamRuntime {
@@ -179,8 +225,16 @@ impl PreparedNamRuntime {
         }
     }
 
-    #[inline]
-    fn process(&mut self, left: f32, right: f32, loudness_on: bool) -> (f32, f32) {
+    /// Audio thread: run one block of at most [`NAM_BLOCK`] engine samples.
+    /// `out_*` receive the model's output; nothing here allocates or locks.
+    fn process_block(
+        &mut self,
+        in_l: &[f32],
+        in_r: &[f32],
+        out_l: &mut [f32],
+        out_r: &mut [f32],
+        loudness_on: bool,
+    ) {
         // Split the borrow so the inference closure and the adapter can be
         // held mutably at the same time.
         let Self {
@@ -188,30 +242,57 @@ impl PreparedNamRuntime {
             model_r,
             adapter,
             loudness_gain,
+            scratch_l,
+            scratch_r,
             ..
         } = self;
         let gain = if loudness_on { *loudness_gain } else { 1.0 };
-        let mut infer = |l: f32, r: f32| {
-            let out_l = model_l.process_sample(l) * gain;
-            let out_r = match model_r.as_mut() {
-                Some(model_r) => model_r.process_sample(r) * gain,
-                None => out_l,
-            };
-            (out_l, out_r)
+        // One call per weight matrix per block instead of per sample — this is
+        // the whole reason the capture is buffered.
+        let mut infer = |l: &mut [f32], r: &mut [f32]| {
+            model_l.process_buffer(l);
+            match model_r.as_mut() {
+                Some(model_r) => {
+                    model_r.process_buffer(r);
+                    for (a, b) in l.iter_mut().zip(r.iter_mut()) {
+                        *a *= gain;
+                        *b *= gain;
+                    }
+                }
+                // Mono capture: one inference, mirrored to both channels.
+                None => {
+                    for (a, b) in l.iter_mut().zip(r.iter_mut()) {
+                        *a *= gain;
+                        *b = *a;
+                    }
+                }
+            }
         };
+
         match adapter.as_mut() {
-            // Rate-adapted: the model still sees its own rate, one inference
-            // per *model* sample, not per engine sample.
-            Some(adapter) => adapter.run(left, right, infer),
-            None => infer(left, right),
+            // Rate-adapted: the model still sees its own rate, and still runs
+            // over a whole staged chunk rather than sample by sample.
+            Some(adapter) => adapter.run_block(in_l, in_r, out_l, out_r, infer),
+            None => {
+                let n = in_l.len();
+                scratch_l[..n].copy_from_slice(in_l);
+                scratch_r[..n].copy_from_slice(in_r);
+                infer(&mut scratch_l[..n], &mut scratch_r[..n]);
+                out_l[..n].copy_from_slice(&scratch_l[..n]);
+                out_r[..n].copy_from_slice(&scratch_r[..n]);
+            }
         }
     }
 
+    /// Clear the streaming state a transport stop should clear — but
+    /// deliberately **not** the model's dilation history.
+    ///
+    /// That history was warmed at load ([`prewarm`]) precisely so the capture
+    /// has no startup transient; zeroing it here would bring the transient
+    /// back on every stop, and the host is no longer delaying the track by the
+    /// receptive field to hide it. A stopped transport feeds the model silence
+    /// anyway, which is the state the prewarm put it in.
     fn reset(&mut self) {
-        self.model_l.reset();
-        if let Some(model_r) = self.model_r.as_mut() {
-            model_r.reset();
-        }
         if let Some(adapter) = self.adapter.as_mut() {
             adapter.reset();
         }
@@ -295,6 +376,25 @@ pub(super) struct NamCapture {
     /// The shared hand-off cells; [`Self::loader`] clones this out.
     channel: Arc<NamChannel>,
 
+    /// Input ring: the block being filled. Doubles as the dry-signal delay
+    /// line, so the wet/dry mix stays phase-aligned instead of comb-filtering
+    /// the block delay against itself.
+    in_l: Vec<f32>,
+    in_r: Vec<f32>,
+    /// The active runtime's output for the previous block.
+    out_l: Vec<f32>,
+    out_r: Vec<f32>,
+    /// The retiring runtime's output for the same block, crossfaded against
+    /// `out_*` while a swap resolves.
+    fade_l: Vec<f32>,
+    fade_r: Vec<f32>,
+    /// Input staging with the input trim applied — the model must see the
+    /// trimmed signal while `in_*` keeps the untrimmed dry.
+    trim_l: Vec<f32>,
+    trim_r: Vec<f32>,
+    /// How many samples of the current block have been written.
+    fill: usize,
+
     sample_rate: f32,
     dc_hpf: StereoBiquad,
 
@@ -319,6 +419,15 @@ impl NamCapture {
                 pending: HandoffCell::new(),
                 retired: HandoffCell::new(),
             }),
+            in_l: vec![0.0; NAM_BLOCK],
+            in_r: vec![0.0; NAM_BLOCK],
+            out_l: vec![0.0; NAM_BLOCK],
+            out_r: vec![0.0; NAM_BLOCK],
+            fade_l: vec![0.0; NAM_BLOCK],
+            fade_r: vec![0.0; NAM_BLOCK],
+            trim_l: vec![0.0; NAM_BLOCK],
+            trim_r: vec![0.0; NAM_BLOCK],
+            fill: 0,
             sample_rate: sample_rate.max(1.0),
             dc_hpf: StereoBiquad::none(),
             input_trim: 1.0,
@@ -351,6 +460,17 @@ impl NamCapture {
 
     pub(super) fn reset(&mut self) {
         self.dc_hpf.reset();
+        for buffer in [
+            &mut self.in_l,
+            &mut self.in_r,
+            &mut self.out_l,
+            &mut self.out_r,
+            &mut self.fade_l,
+            &mut self.fade_r,
+        ] {
+            buffer.fill(0.0);
+        }
+        self.fill = 0;
         if let Some(rt) = self.active.as_mut() {
             rt.reset();
         }
@@ -403,15 +523,21 @@ impl NamCapture {
         self.active.as_ref().map(|rt| rt.info())
     }
 
-    /// Latency contributed by the active capture, in **engine** samples (0 if
-    /// none loaded, or an LSTM capture, which has no warmup). Already accounts
-    /// for a rate-adapted capture, whose receptive field is counted in its own
-    /// rate's samples.
+    /// Latency this engine adds, in **engine** samples: the [`NAM_BLOCK`] the
+    /// inference buffering costs, plus a rate-adapted capture's interpolation
+    /// delay. The receptive field is not part of it — see
+    /// [`PreparedNamRuntime::latency_samples`].
+    ///
+    /// It is reported whether or not a capture is loaded, because the block
+    /// buffer runs either way: an empty slot that reported 0 would force the
+    /// host to redo delay compensation the moment a capture landed, mid-play.
     pub(super) fn latency_samples(&self) -> usize {
-        self.active
-            .as_ref()
-            .map(|rt| rt.latency_samples)
-            .unwrap_or(0)
+        NAM_BLOCK
+            + self
+                .active
+                .as_ref()
+                .map(|rt| rt.latency_samples)
+                .unwrap_or(0)
     }
 
     /// Audio thread: adopt a pending runtime and retire a finished fade.
@@ -432,6 +558,12 @@ impl NamCapture {
                 if let Some(old) = self.active.replace(new_rt) {
                     self.fading_out = Some(old);
                     self.fade = 0.0;
+                    // The current block was already computed by the outgoing
+                    // runtime. Seed the fade buffer with it so the crossfade
+                    // blends continuous audio for the rest of this block
+                    // instead of whatever an earlier swap left behind.
+                    self.fade_l.copy_from_slice(&self.out_l);
+                    self.fade_r.copy_from_slice(&self.out_r);
                 }
             }
         }
@@ -445,22 +577,21 @@ impl NamCapture {
         }
     }
 
-    /// Audio thread hot path: input trim → model(s) → DC block → loudness →
-    /// output trim → wet/dry mix. Crossfades against `fading_out` if a swap is
-    /// in progress. No allocation, no locks, no swap logic (see
-    /// [`Self::begin_block`]).
+    /// Audio thread hot path. One sample in, one sample out, delayed by
+    /// [`NAM_BLOCK`]; the inference itself runs once every [`NAM_BLOCK`] calls
+    /// over the whole block. Per sample this is only the DC blocker, the trims
+    /// and the wet/dry mix — the dry side comes out of the same ring as the
+    /// wet, so the two stay phase-aligned. No allocation, no locks, no swap
+    /// logic (see [`Self::begin_block`]).
     #[inline]
     pub(super) fn process(&mut self, left: f32, right: f32) -> (f32, f32) {
-        let dry = (left, right);
-        let xin = (left * self.input_trim, right * self.input_trim);
+        // Read this slot's finished output and the dry sample that produced it
+        // *before* the slot is overwritten with the newest input.
+        let dry = (self.in_l[self.fill], self.in_r[self.fill]);
+        let new_out = (self.out_l[self.fill], self.out_r[self.fill]);
 
-        let new_out = match self.active.as_mut() {
-            Some(rt) => rt.process(xin.0, xin.1, self.loudness_norm_on),
-            None => xin,
-        };
-
-        let wet = if let Some(old_rt) = self.fading_out.as_mut() {
-            let old_out = old_rt.process(xin.0, xin.1, self.loudness_norm_on);
+        let wet = if self.fading_out.is_some() {
+            let old_out = (self.fade_l[self.fill], self.fade_r[self.fill]);
             self.fade = (self.fade + self.fade_step).min(1.0);
             (
                 old_out.0 * (1.0 - self.fade) + new_out.0 * self.fade,
@@ -470,12 +601,55 @@ impl NamCapture {
             new_out
         };
 
+        self.in_l[self.fill] = left;
+        self.in_r[self.fill] = right;
+        self.fill += 1;
+        if self.fill >= NAM_BLOCK {
+            self.fill = 0;
+            self.run_block();
+        }
+
         let (mut ol, mut or) = self.dc_hpf.run(wet.0, wet.1);
         ol *= self.output_trim;
         or *= self.output_trim;
 
         let m = self.mix;
         (dry.0 * (1.0 - m) + ol * m, dry.1 * (1.0 - m) + or * m)
+    }
+
+    /// Run the just-filled input block through the active runtime (and the
+    /// retiring one, while a swap crossfades). Called from [`Self::process`]
+    /// every [`NAM_BLOCK`] samples; allocates nothing.
+    fn run_block(&mut self) {
+        let trim = self.input_trim;
+        for i in 0..NAM_BLOCK {
+            self.trim_l[i] = self.in_l[i] * trim;
+            self.trim_r[i] = self.in_r[i] * trim;
+        }
+
+        match self.active.as_mut() {
+            Some(rt) => rt.process_block(
+                &self.trim_l,
+                &self.trim_r,
+                &mut self.out_l,
+                &mut self.out_r,
+                self.loudness_norm_on,
+            ),
+            None => {
+                self.out_l.copy_from_slice(&self.trim_l);
+                self.out_r.copy_from_slice(&self.trim_r);
+            }
+        }
+
+        if let Some(old_rt) = self.fading_out.as_mut() {
+            old_rt.process_block(
+                &self.trim_l,
+                &self.trim_r,
+                &mut self.fade_l,
+                &mut self.fade_r,
+                self.loudness_norm_on,
+            );
+        }
     }
 }
 
@@ -500,14 +674,17 @@ mod tests {
     }"#;
 
     /// A rate mismatch inside the adapter's range builds a runtime that runs
-    /// the model at its own rate; the reported latency is in engine samples,
-    /// so it must scale with the ratio rather than echo the raw field.
+    /// the model at its own rate; only the adapter's own interpolation delay
+    /// is latency, and it is counted in engine samples.
     #[test]
     fn adapts_a_mismatched_rate_instead_of_rejecting_it() {
         let native = prepare_nam_runtime(TINY_WAVENET_48K, "t".into(), 48_000.0, false, false)
             .expect("native rate loads");
         assert!(native.adapter.is_none(), "matching rate must not resample");
-        assert_eq!(native.latency_samples, native.receptive_field);
+        assert_eq!(
+            native.latency_samples, 0,
+            "a natively-run capture is causal: no latency beyond the block"
+        );
 
         let adapted = prepare_nam_runtime(TINY_WAVENET_48K, "t".into(), 44_100.0, false, false)
             .expect("a 48 kHz capture must adapt into a 44.1 kHz engine");
@@ -516,9 +693,11 @@ mod tests {
             adapted.sample_rate, 48_000.0,
             "info keeps the capture's rate"
         );
-        // 48 kHz model samples are fewer 44.1 kHz engine samples, plus the
-        // adapter's own interpolation delay.
-        assert!(adapted.latency_samples >= adapted.receptive_field * 44_100 / 48_000);
+        assert!(
+            adapted.latency_samples > 0 && adapted.latency_samples < NAM_BLOCK,
+            "only the adapter's interpolation delay counts as latency, got {}",
+            adapted.latency_samples
+        );
 
         let mut cap = NamCapture::new(44_100.0);
         cap.configure(0.0, 0.0, 100.0, false);
@@ -630,13 +809,91 @@ mod tests {
         assert_eq!(cap.active_info().map(|i| i.name), Some("second".into()));
     }
 
+    /// With no capture loaded the slot passes the signal through — delayed by
+    /// the block the engine always buffers, which is exactly what
+    /// `latency_samples()` reports so the host can compensate it.
     #[test]
-    fn no_capture_loaded_is_pass_through_at_unity() {
+    fn no_capture_loaded_is_a_delayed_pass_through_at_unity() {
         let mut cap = NamCapture::new(48_000.0);
         cap.configure(0.0, 0.0, 100.0, false);
-        let (l, r) = cap.process(0.3, -0.3);
-        // DC blocker still runs, so allow a small tolerance rather than exact equality.
-        assert!((l - 0.3).abs() < 1.0e-3);
-        assert!((r + 0.3).abs() < 1.0e-3);
+        assert_eq!(cap.latency_samples(), NAM_BLOCK);
+
+        // A single pulse, so the delay can be read off directly rather than
+        // through the DC blocker's (tiny, but non-zero) phase shift.
+        let input: Vec<f32> = (0..NAM_BLOCK * 8)
+            .map(|n| if n == 7 { 1.0 } else { 0.0 })
+            .collect();
+        let out: Vec<(f32, f32)> = input.iter().map(|&x| cap.process(x, -x)).collect();
+
+        let peak_at = |pick: fn(&(f32, f32)) -> f32| {
+            out.iter()
+                .enumerate()
+                .max_by(|a, b| pick(a.1).abs().total_cmp(&pick(b.1).abs()))
+                .map(|(i, _)| i)
+                .unwrap()
+        };
+        assert_eq!(
+            peak_at(|s| s.0),
+            7 + NAM_BLOCK,
+            "left delay is not the block"
+        );
+        assert_eq!(
+            peak_at(|s| s.1),
+            7 + NAM_BLOCK,
+            "right delay is not the block"
+        );
+        let energy: f32 = out.iter().map(|(l, _)| l * l).sum();
+        assert!(
+            (energy - 1.0).abs() < 0.05,
+            "the dry path changed level: pulse energy {energy}"
+        );
+    }
+
+    /// The wet/dry mix must blend the *aligned* dry sample. If the dry side
+    /// skipped the block delay, a mix would comb-filter the signal against a
+    /// 64-sample-old copy of itself — at 375 Hz that delay is half a period,
+    /// so a misaligned 50 % mix cancels almost completely.
+    #[test]
+    fn the_wet_dry_mix_stays_phase_aligned_through_the_block_delay() {
+        let mut cap = NamCapture::new(48_000.0);
+        cap.configure(0.0, 0.0, 50.0, false);
+
+        let half_period = std::f32::consts::PI / NAM_BLOCK as f32;
+        let input: Vec<f32> = (0..NAM_BLOCK * 32)
+            .map(|n| (n as f32 * half_period).sin() * 0.5)
+            .collect();
+        let out: Vec<f32> = input.iter().map(|&x| cap.process(x, x).0).collect();
+
+        let rms = |signal: &[f32]| {
+            (signal.iter().map(|x| x * x).sum::<f32>() / signal.len() as f32).sqrt()
+        };
+        let settled = &out[NAM_BLOCK * 4..];
+        let reference = rms(&input[NAM_BLOCK * 4..]);
+        assert!(
+            (rms(settled) / reference - 1.0).abs() < 0.02,
+            "mix comb-filtered: {} vs {reference}",
+            rms(settled)
+        );
+    }
+
+    /// A freshly loaded capture must be warm: the reference plugin runs the
+    /// receptive field through with silence at load rather than making the
+    /// host delay the track by it.
+    #[test]
+    fn a_prepared_runtime_reports_no_receptive_field_latency() {
+        let prepared = prepare_nam_runtime(TINY_WAVENET_48K, "t".into(), 48_000.0, false, false)
+            .expect("matching rate must load");
+        assert!(prepared.receptive_field >= 1, "the field is still reported");
+        assert_eq!(prepared.latency_samples, 0);
+
+        let mut cap = NamCapture::new(48_000.0);
+        cap.configure(0.0, 0.0, 100.0, false);
+        cap.submit(Box::new(prepared));
+        cap.begin_block();
+        assert_eq!(
+            cap.latency_samples(),
+            NAM_BLOCK,
+            "the block buffer is the only latency a native-rate capture adds"
+        );
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/nonlinear.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/nonlinear.rs
@@ -30,7 +30,7 @@
 #[inline]
 fn finite(x: f32) -> f32 {
     if x.is_finite() {
-        x.clamp(-64.0, 64.0)
+        super::flush_denormal(x.clamp(-64.0, 64.0))
     } else {
         0.0
     }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/phaser.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/phaser.rs
@@ -50,7 +50,7 @@ const PEAK_TARGET: f32 = 1.122;
 #[inline]
 fn finite(x: f32) -> f32 {
     if x.is_finite() {
-        x.clamp(-8.0, 8.0)
+        super::flush_denormal(x.clamp(-8.0, 8.0))
     } else {
         0.0
     }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/rate.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/rate.rs
@@ -16,8 +16,9 @@
 //! cabinet) is already heavily band-limited. Running the session at the
 //! capture's own rate is still the better-sounding option.
 //!
-//! Realtime: [`RateAdapter::run`] allocates nothing, locks nothing and never
-//! panics; every buffer is a fixed-size array built in [`RateAdapter::new`].
+//! Realtime: [`RateAdapter::run_block`] allocates nothing, locks nothing and
+//! never panics; every buffer is a fixed-size array or a `Vec` sized once in
+//! [`RateAdapter::new`] on the control thread.
 
 use builtin_dsp_core::make_eq_coefficients;
 
@@ -144,6 +145,14 @@ pub(super) struct RateAdapter {
     ratio: f32,
     /// Engine samples per inner sample (`1 / ratio`).
     inv_ratio: f32,
+    /// Inner-rate staging for [`Self::run_block`], preallocated for the largest
+    /// engine block the caller declared. The inner processor runs over this in
+    /// one call instead of once per inner sample.
+    inner_l: Vec<f32>,
+    inner_r: Vec<f32>,
+    /// How many inner samples each engine sample of the current block produced
+    /// — the bookkeeping that lets phase 3 replay the interleaving exactly.
+    produced: Vec<u8>,
     /// Gap at which the next inner sample is produced. Chosen so the read
     /// position stays inside the interpolatable window for every legal ratio.
     produce_at: f32,
@@ -168,7 +177,11 @@ impl RateAdapter {
     /// rate is not a usable positive number. A ratio of exactly 1 still builds
     /// an adapter — callers that want the zero-cost path skip construction
     /// themselves rather than paying for a pass-through here.
-    pub(super) fn new(inner_rate: f64, engine_rate: f64) -> Option<Self> {
+    ///
+    /// `max_block` is the largest engine block [`Self::run_block`] will be
+    /// handed; the inner-rate staging is sized for it here, on the control
+    /// thread, so the audio thread never grows a buffer.
+    pub(super) fn new(inner_rate: f64, engine_rate: f64, max_block: usize) -> Option<Self> {
         if !inner_rate.is_finite() || !engine_rate.is_finite() {
             return None;
         }
@@ -187,9 +200,16 @@ impl RateAdapter {
         // serves as long as `HIST` covers `MAX_RATIO`.
         let produce_at = 2.0 + inv_ratio;
         let guard_hz = GUARD_FRACTION * (inner_rate.min(engine_rate)) as f32;
+        // Worst case one engine block can ask for: every sample produces
+        // `ceil(ratio)` inner samples, plus the one the fractional carry can
+        // add at the block's first sample.
+        let inner_capacity = (max_block as f32 * ratio).ceil() as usize + 2;
         Some(Self {
             ratio,
             inv_ratio,
+            inner_l: vec![0.0; inner_capacity],
+            inner_r: vec![0.0; inner_capacity],
+            produced: vec![0; max_block],
             produce_at,
             in_gap: produce_at,
             out_gap: 3.0 + ratio,
@@ -216,12 +236,6 @@ impl RateAdapter {
         (self.produce_at + self.out_gap * self.inv_ratio).ceil() as usize
     }
 
-    /// Convert a count of inner-rate samples (e.g. a capture's receptive
-    /// field) into engine samples.
-    pub(super) fn inner_to_engine_samples(&self, inner_samples: usize) -> usize {
-        (inner_samples as f32 * self.inv_ratio).ceil() as usize
-    }
-
     pub(super) fn reset(&mut self) {
         self.in_hist_l.clear();
         self.in_hist_r.clear();
@@ -236,7 +250,11 @@ impl RateAdapter {
     /// One engine sample in, one engine sample out. `inner` is stepped zero or
     /// more times — whatever the ratio calls for at this position — and must
     /// itself be realtime-safe.
-    #[inline]
+    ///
+    /// Kept as the reference the block path is checked against
+    /// (`block_matches_the_per_sample_path`); production runs through
+    /// [`Self::run_block`], which lets the model process a whole chunk at once.
+    #[cfg(test)]
     pub(super) fn run<F>(&mut self, left: f32, right: f32, mut inner: F) -> (f32, f32)
     where
         F: FnMut(f32, f32) -> (f32, f32),
@@ -266,6 +284,72 @@ impl RateAdapter {
         self.out_gap -= self.ratio;
         out
     }
+
+    /// Block twin of [`Self::run`]: `n` engine samples in, `n` engine samples
+    /// out, with the inner processor run **once** over all the inner-rate
+    /// samples the block calls for instead of once per sample. `inner` is
+    /// handed the staged inner-rate buffers and processes them in place.
+    ///
+    /// Bit-for-bit equivalent to `n` calls of [`Self::run`] (see
+    /// `block_matches_the_per_sample_path`): the inner processor's *inputs*
+    /// depend only on the engine-side history, so staging them all up front
+    /// changes nothing, and phase 3 replays the output pushes and reads in the
+    /// original per-sample order. Allocation-free; `n` must not exceed the
+    /// `max_block` the adapter was built with.
+    pub(super) fn run_block<F>(
+        &mut self,
+        in_l: &[f32],
+        in_r: &[f32],
+        out_l: &mut [f32],
+        out_r: &mut [f32],
+        mut inner: F,
+    ) where
+        F: FnMut(&mut [f32], &mut [f32]),
+    {
+        let n = in_l.len().min(self.produced.len());
+        let mut produced_total = 0usize;
+
+        // Phase 1: engine → inner. Interpolate every inner-rate input sample
+        // the block calls for, remembering how many belong to each engine
+        // sample so phase 3 can interleave the outputs identically.
+        for i in 0..n {
+            let (xl, xr) = self.pre_lp.run(in_l[i], in_r[i]);
+            self.in_hist_l.push(xl);
+            self.in_hist_r.push(xr);
+
+            self.in_gap += 1.0;
+            let mut count = 0u8;
+            while self.in_gap > self.produce_at && produced_total < self.inner_l.len() {
+                self.inner_l[produced_total] = self.in_hist_l.read(self.in_gap);
+                self.inner_r[produced_total] = self.in_hist_r.read(self.in_gap);
+                produced_total += 1;
+                count += 1;
+                self.in_gap -= self.inv_ratio;
+            }
+            self.produced[i] = count;
+        }
+
+        // Phase 2: one inner-rate run over the whole staged block.
+        inner(
+            &mut self.inner_l[..produced_total],
+            &mut self.inner_r[..produced_total],
+        );
+
+        // Phase 3: inner → engine, in the same order the per-sample path used.
+        let mut read = 0usize;
+        for i in 0..n {
+            for _ in 0..self.produced[i] {
+                let (ol, or) = self.post_lp.run(self.inner_l[read], self.inner_r[read]);
+                self.out_hist_l.push(ol);
+                self.out_hist_r.push(or);
+                self.out_gap += 1.0;
+                read += 1;
+            }
+            out_l[i] = self.out_hist_l.read(self.out_gap);
+            out_r[i] = self.out_hist_r.read(self.out_gap);
+            self.out_gap -= self.ratio;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -285,13 +369,13 @@ mod tests {
 
     #[test]
     fn rejects_unusable_and_out_of_range_ratios() {
-        assert!(RateAdapter::new(f64::NAN, 48_000.0).is_none());
-        assert!(RateAdapter::new(48_000.0, 0.0).is_none());
-        assert!(RateAdapter::new(-48_000.0, 48_000.0).is_none());
-        assert!(RateAdapter::new(8_000.0, 48_000.0).is_none()); // ratio 1/6
-        assert!(RateAdapter::new(384_000.0, 48_000.0).is_none()); // ratio 8
-        assert!(RateAdapter::new(12_000.0, 48_000.0).is_some()); // ratio 1/4
-        assert!(RateAdapter::new(192_000.0, 48_000.0).is_some()); // ratio 4
+        assert!(RateAdapter::new(f64::NAN, 48_000.0, 64).is_none());
+        assert!(RateAdapter::new(48_000.0, 0.0, 64).is_none());
+        assert!(RateAdapter::new(-48_000.0, 48_000.0, 64).is_none());
+        assert!(RateAdapter::new(8_000.0, 48_000.0, 64).is_none()); // ratio 1/6
+        assert!(RateAdapter::new(384_000.0, 48_000.0, 64).is_none()); // ratio 8
+        assert!(RateAdapter::new(12_000.0, 48_000.0, 64).is_some()); // ratio 1/4
+        assert!(RateAdapter::new(192_000.0, 48_000.0, 64).is_some()); // ratio 4
     }
 
     /// The inner processor must be stepped at the inner rate, on average, for
@@ -299,7 +383,7 @@ mod tests {
     #[test]
     fn steps_the_inner_processor_at_the_inner_rate() {
         for (inner_rate, engine_rate) in PAIRS {
-            let mut adapter = RateAdapter::new(inner_rate, engine_rate).expect("legal ratio");
+            let mut adapter = RateAdapter::new(inner_rate, engine_rate, 64).expect("legal ratio");
             let engine_samples = engine_rate as usize; // one second
             let mut inner_calls = 0usize;
             for _ in 0..engine_samples {
@@ -323,7 +407,7 @@ mod tests {
     #[test]
     fn a_sine_survives_the_round_trip_at_every_supported_pair() {
         for (inner_rate, engine_rate) in PAIRS {
-            let mut adapter = RateAdapter::new(inner_rate, engine_rate).expect("legal ratio");
+            let mut adapter = RateAdapter::new(inner_rate, engine_rate, 64).expect("legal ratio");
             let sr = engine_rate as f32;
             let freq = 440.0f32;
             let n = engine_rate as usize;
@@ -364,7 +448,7 @@ mod tests {
     fn content_above_the_inner_nyquist_is_rejected_not_aliased() {
         // A 22 kHz tone in a 48 kHz engine, through a 24 kHz capture: without
         // the guard this folds back to 2 kHz, right in the guitar's range.
-        let mut adapter = RateAdapter::new(24_000.0, 48_000.0).expect("legal ratio");
+        let mut adapter = RateAdapter::new(24_000.0, 48_000.0, 64).expect("legal ratio");
         let sr = 48_000.0f32;
         for i in 0..4_000 {
             let x = (i as f32 * 22_000.0 * TAU / sr).sin() * 0.5;
@@ -382,7 +466,7 @@ mod tests {
 
     #[test]
     fn reset_clears_state_and_reproduces_the_same_output() {
-        let mut adapter = RateAdapter::new(44_100.0, 48_000.0).expect("legal ratio");
+        let mut adapter = RateAdapter::new(44_100.0, 48_000.0, 64).expect("legal ratio");
         let render = |adapter: &mut RateAdapter| {
             (0..512)
                 .map(|i| {
@@ -400,12 +484,71 @@ mod tests {
         );
     }
 
+    /// The block path exists purely to let the inner processor run over a whole
+    /// chunk at once; it must not change a single sample of the result, or the
+    /// capture would sound different at a mismatched rate than the per-sample
+    /// path it replaced.
+    #[test]
+    fn block_matches_the_per_sample_path() {
+        const BLOCK: usize = 64;
+        for (inner_rate, engine_rate) in PAIRS {
+            let mut per_sample =
+                RateAdapter::new(inner_rate, engine_rate, BLOCK).expect("legal ratio");
+            let mut blocked =
+                RateAdapter::new(inner_rate, engine_rate, BLOCK).expect("legal ratio");
+            // A stand-in for the model: state-dependent, so any reordering of
+            // the inner calls would show up in the output.
+            let mut state = 0.0f32;
+            let inner = |x: f32, state: &mut f32| {
+                *state = 0.85 * *state + 0.15 * x;
+                (x - *state).tanh()
+            };
+
+            let input: Vec<f32> = (0..BLOCK * 24)
+                .map(|i| (i as f32 * 0.021).sin() * 0.4 + (i as f32 * 0.003).cos() * 0.1)
+                .collect();
+
+            let expected: Vec<(f32, f32)> = input
+                .iter()
+                .map(|&x| {
+                    per_sample.run(x, -x, |l, r| (inner(l, &mut state), inner(r, &mut state)))
+                })
+                .collect();
+
+            state = 0.0;
+            let mut actual = Vec::with_capacity(input.len());
+            let mut out_l = [0.0f32; BLOCK];
+            let mut out_r = [0.0f32; BLOCK];
+            for chunk in input.chunks(BLOCK) {
+                let in_l: Vec<f32> = chunk.to_vec();
+                let in_r: Vec<f32> = chunk.iter().map(|x| -x).collect();
+                blocked.run_block(&in_l, &in_r, &mut out_l, &mut out_r, |l, r| {
+                    for (a, b) in l.iter_mut().zip(r.iter_mut()) {
+                        *a = inner(*a, &mut state);
+                        *b = inner(*b, &mut state);
+                    }
+                });
+                actual.extend(
+                    out_l[..chunk.len()]
+                        .iter()
+                        .zip(&out_r[..chunk.len()])
+                        .map(|(&l, &r)| (l, r)),
+                );
+            }
+
+            assert_eq!(
+                expected, actual,
+                "{inner_rate}→{engine_rate}: block path diverged from per-sample"
+            );
+        }
+    }
+
     /// Silence in, silence out — no self-oscillation from the guard filters or
     /// the interpolation bookkeeping.
     #[test]
     fn silence_stays_silent() {
         for (inner_rate, engine_rate) in PAIRS {
-            let mut adapter = RateAdapter::new(inner_rate, engine_rate).expect("legal ratio");
+            let mut adapter = RateAdapter::new(inner_rate, engine_rate, 64).expect("legal ratio");
             for _ in 0..4_000 {
                 let (l, r) = adapter.run(0.0, 0.0, |a, b| (a, b));
                 assert_eq!((l, r), (0.0, 0.0), "{inner_rate}→{engine_rate}");

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/smooth.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/smooth.rs
@@ -79,7 +79,9 @@ impl Allpass1 {
     fn run(&mut self, x: f32) -> f32 {
         let y = self.x1 + self.a * (x - self.y1);
         self.x1 = x;
-        self.y1 = y;
+        // The allpass feeds `y1` back, so a decaying tail parks it in the
+        // subnormal range and the whole oversampler slows down with it.
+        self.y1 = super::flush_denormal(y);
         y
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/wah.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/wah.rs
@@ -39,9 +39,9 @@ impl Svf {
     /// `f` is the SVF frequency coefficient, `q_inv` the damping (1/Q).
     #[inline]
     fn band_pass(&mut self, input: f32, f: f32, q_inv: f32) -> f32 {
-        self.low += f * self.band;
+        self.low = super::flush_denormal(self.low + f * self.band);
         let high = input - self.low - q_inv * self.band;
-        self.band += f * high;
+        self.band = super::flush_denormal(self.band + f * high);
         self.band
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/lib.rs
@@ -13,10 +13,10 @@ mod wire;
 
 pub use dsp::{
     AmpModel, CabModel, DelayModel, DriveModel, Dsp, IR_PARTITION_SAMPLES, IrInfo, IrLoadError,
-    IrLoader, MAX_IR_SECONDS, MicModel, ModModel, NamCaptureInfo, NamLoadError, NamLoader,
-    PATH_SLOTS, PLUGIN_ID, Params, PreparedIrRuntime, PreparedNamRuntime, ReverbModel, StageKind,
-    ToneEngineKind, WahModel, apply_to_params, default_params, descriptor, prepare_ir_runtime,
-    prepare_nam_runtime, ui_values,
+    IrLoader, MAX_IR_SECONDS, MicModel, ModModel, NAM_BLOCK_SAMPLES, NamCaptureInfo, NamLoadError,
+    NamLoader, PATH_SLOTS, PLUGIN_ID, Params, PreparedIrRuntime, PreparedNamRuntime, ReverbModel,
+    StageKind, ToneEngineKind, WahModel, apply_to_params, default_params, descriptor,
+    prepare_ir_runtime, prepare_nam_runtime, ui_values,
 };
 pub use state::{RodhareistState, SCHEMA_VERSION};
 pub use wire::{UI_PARAM_IDS, ui_param_id, ui_param_index};


### PR DESCRIPTION
Rodhareist was lagging and reporting very high latency on both the NAM and IR
engines. Profiled every stage first, then fixed what the numbers pointed at.

## The analyzer

New `examples/cpu_profile.rs` (not shipped) measures per-stage CPU as a share
of one core, the latency each engine reports to the host, load cost, and — the
one that found the lag — **the cost of running the chain on the silence after
a loud passage**.

```bash
cargo run -p rodharerist --example cpu_profile --release
```

## What it found, and what changed

**NAM reported its receptive field as latency.** A WaveNet's dilated
convolutions are causal: output `n` depends on inputs up to `n`, so the field
is history the model needs *warmed*, not a delay it imposes — which is why the
reference NAM plugin prewarms at load and reports none of it. `prepare_nam_runtime`
now runs the field through with silence on the control thread, and the engine
reports only what it actually buffers. **4093 → 64 samples (85.3 ms → 1.3 ms).**

**NAM ran the model one sample at a time.** nam-rs has a block kernel that
produces identical output while keeping each weight matrix hot across a whole
chunk — measured 2.8x faster at 64 samples, 3.3x at 128. `NamCapture` now fills
a block before inference (the input ring doubles as the dry delay, so the
wet/dry mix stays phase-aligned instead of comb-filtering against itself), and
`RateAdapter` grew a block API validated bit-for-bit against the per-sample
path it replaces. **69% → 23% of a core** for a stock capture.

**The IR slot delayed by a partition even with no file loaded — and reported
zero latency.** The host never compensated a delay the engine was applying
anyway, leaving the IR cabinet 2.7 ms behind every parallel path in the
project. It now reports the partition it always applies, so loading a file
mid-playback no longer moves the plugin's latency under the graph's feet.

**The convolution itself got three algorithm changes:** the sub-−70 dB tail is
trimmed at load (cabinet IR files in the wild are mostly padding, and under a
uniform partitioning every padded block costs a full sweep), both channels ride
one complex FFT instead of four transforms per block, and only DC..Nyquist is
stored, in split real/imaginary planes the accumulate loop can vectorize.
**A 0.5 s IR: 2.04% → 0.30% of a core.**

**Denormals were the "it spikes a moment after I stop playing" fault.** Every
IIR tail decays into the subnormal range, where each operation costs tens to
hundreds of cycles. The modeled cabinet measured **19x** slower on silence than
on signal; wah 6.8x, amp 2.8x, the whole chain 1.9x. Added `flush_denormal` to
`builtin_dsp_core` and applied it to every recursive state — including a
hand-rolled `DirectForm1` in `StereoBiquad`, because the `biquad` crate's
feedback taps are unreachable from outside.

## Numbers

| | before | after |
|---|---|---|
| chain with NAM + stereo IR | 84.2% of one core | **25.2%** |
| that chain's reported latency | 4221 samples (87.9 ms) | **192 samples (4.0 ms)** |
| chain with modeled amp + cab | 12.3% | **9.9%** |
| whole chain on decaying silence | 4311 ns/sample | **1895 ns/sample** |
| modeled cabinet, silence vs signal | 19.1x | **0.81x** |
| NAM "standard" capture | 69.1% | **23.1%** |
| IR cabinet, 0.5 s file | 2.04% | **0.30%** |

## Tested

- `cargo test -p rodharerist -p builtin_dsp_core` — 148 + 5 pass, including new
  coverage for block/per-sample equivalence in the rate adapter, wet/dry phase
  alignment through the block delay, the prewarm contract, and the IR slot's
  latency reporting.
- All eight plugins sharing `builtin_dsp_core` still pass their own suites.
- `cargo fmt --check`, clippy clean on both crates; editor bundle builds.

**Not tested:** nothing has been run inside the native app — no listening pass,
and no real `.nam`/`.wav` file loaded through the editor UI.

**Left deliberately:** the Comp stage still costs 2.5x on silence. The source is
the sidechain HPF inside the shared `SoftKneeCompressor`, which is a
`biquad::DirectForm1`; fixing it means touching the DSP of seven other plugins
for ~0.3% of a core here, so it is called out rather than swept in.

## User-facing wording

The editor said `Loaded "x" (4093 sample latency)` for a NAM capture. That
number is the receptive field and is no longer latency, so the label now says
so.