### PR TITLE
fix(audio): stop browser sample preview from ghosting

### DIFF
--- a/crates/SphereDirectAudioEngine/src/audio_file.rs
+++ b/crates/SphereDirectAudioEngine/src/audio_file.rs
@@ -32,6 +32,15 @@ pub struct AudioFileBuffer {
     pub samples: Vec<f32>,
 }
 
+/// Declick ramp lengths for a browser audition, in seconds.
+///
+/// Every Browser selection starts a voice from an arbitrary sample value and
+/// every new selection cuts the previous one mid-waveform. Without these ramps
+/// each step through a folder produces a click, which is what the preview
+/// mostly sounds like when walking a directory with the arrow keys.
+const AUDITION_ATTACK_SECONDS: f32 = 0.002;
+const AUDITION_RELEASE_SECONDS: f32 = 0.008;
+
 /// A pre-decoded, one-shot browser audition voice. It owns immutable PCM data
 /// prepared off the audio thread; rendering only advances a cursor and mixes
 /// samples, so no callback allocation, locks, or I/O are required.
@@ -39,14 +48,41 @@ pub struct AudioFileBuffer {
 pub struct AudioFileAudition {
     source: Box<AudioFileBuffer>,
     source_frame: f64,
+    /// Source frames consumed per output frame (source rate / device rate).
+    step: f64,
+    /// Declick envelope: current gain plus its per-output-frame increment.
+    gain: f32,
+    gain_step: f32,
+    /// Source frame at which the end-of-file fade starts, and the reciprocal of
+    /// that fade's length — precomputed so the mix loop stays division-free.
+    tail_start: f64,
+    inv_tail_len: f64,
 }
 
 impl AudioFileAudition {
-    pub fn new(source: Box<AudioFileBuffer>) -> Self {
+    pub fn new(source: Box<AudioFileBuffer>, output_rate: u32) -> Self {
+        let rate = output_rate.max(1);
+        let step = source.sample_rate.max(1) as f64 / rate as f64;
+        // The tail fade is measured in source frames, so it stays the same
+        // audible length whatever the resample ratio is.
+        let tail_len = (AUDITION_RELEASE_SECONDS as f64 * source.sample_rate.max(1) as f64)
+            .min(source.frames as f64)
+            .max(1.0);
         Self {
-            source,
             source_frame: 0.0,
+            step,
+            gain: 0.0,
+            gain_step: 1.0 / (AUDITION_ATTACK_SECONDS * rate as f32).max(1.0),
+            tail_start: source.frames as f64 - tail_len,
+            inv_tail_len: 1.0 / tail_len,
+            source,
         }
+    }
+
+    /// Start fading this voice out; it retires once the ramp reaches silence.
+    pub fn begin_release(&mut self, output_rate: u32) {
+        let frames = (AUDITION_RELEASE_SECONDS * output_rate.max(1) as f32).max(1.0);
+        self.gain_step = -1.0 / frames;
     }
 
     pub fn into_source(self) -> Box<AudioFileBuffer> {
@@ -54,42 +90,110 @@ impl AudioFileAudition {
     }
 
     /// Mix this source into an interleaved output block. Returns `true` once
-    /// playback reaches EOF. Mono sources are duplicated; source channels
-    /// beyond stereo are downmixed by taking their first stereo pair.
+    /// the voice is finished (EOF, or a release ramp that reached silence).
+    /// Mono sources are duplicated; source channels beyond stereo are downmixed
+    /// by taking their first stereo pair.
     #[inline]
-    pub fn mix_into(
-        &mut self,
-        output: &mut [f32],
-        output_channels: usize,
-        output_rate: u32,
-    ) -> bool {
+    pub fn mix_into(&mut self, output: &mut [f32], output_channels: usize) -> bool {
         if output_channels == 0 || self.source.channels == 0 || self.source.frames == 0 {
             return true;
         }
-        let step = self.source.sample_rate.max(1) as f64 / output_rate.max(1) as f64;
         for frame in output.chunks_mut(output_channels) {
             let source_index = self.source_frame as usize;
             if source_index >= self.source.frames {
                 return true;
+            }
+            self.gain = (self.gain + self.gain_step).clamp(0.0, 1.0);
+            if self.gain <= 0.0 && self.gain_step < 0.0 {
+                return true; // release ramp finished
             }
             let next_index = (source_index + 1).min(self.source.frames - 1);
             let fraction = (self.source_frame - source_index as f64) as f32;
             let sample_at = |frame_index: usize, channel: usize| {
                 self.source.samples[frame_index * self.source.channels + channel]
             };
+            let tail = if self.source_frame > self.tail_start {
+                (((self.source.frames as f64 - self.source_frame) * self.inv_tail_len) as f32)
+                    .clamp(0.0, 1.0)
+            } else {
+                1.0
+            };
+            let env = self.gain * tail;
             let left = sample_at(source_index, 0)
                 + (sample_at(next_index, 0) - sample_at(source_index, 0)) * fraction;
             let right_channel = if self.source.channels > 1 { 1 } else { 0 };
             let right = sample_at(source_index, right_channel)
                 + (sample_at(next_index, right_channel) - sample_at(source_index, right_channel))
                     * fraction;
-            frame[0] = (frame[0] + left).clamp(-1.0, 1.0);
+            frame[0] = (frame[0] + left * env).clamp(-1.0, 1.0);
             if output_channels > 1 {
-                frame[1] = (frame[1] + right).clamp(-1.0, 1.0);
+                frame[1] = (frame[1] + right * env).clamp(-1.0, 1.0);
             }
-            self.source_frame += step;
+            self.source_frame += self.step;
         }
         self.source_frame >= self.source.frames as f64
+    }
+}
+
+/// The realtime side of the Browser sample preview: the voice currently
+/// auditioning plus at most one voice fading out because it was replaced or
+/// stopped. Owned by the render callback, so both slots are plain `Option`s and
+/// finished sources leave through the graveyard rather than being freed here.
+#[derive(Debug, Default)]
+pub struct AuditionPlayer {
+    current: Option<AudioFileAudition>,
+    releasing: Option<AudioFileAudition>,
+}
+
+impl AuditionPlayer {
+    /// Audition `source`, fading out whatever was playing instead of cutting it.
+    pub fn start(&mut self, source: Box<AudioFileBuffer>, output_rate: u32) {
+        let voice = AudioFileAudition::new(source, output_rate);
+        if let Some(previous) = self.current.replace(voice) {
+            self.release(previous, output_rate);
+        }
+    }
+
+    /// Stop the current audition through the same fade-out.
+    pub fn stop(&mut self, output_rate: u32) {
+        if let Some(previous) = self.current.take() {
+            self.release(previous, output_rate);
+        }
+    }
+
+    /// `true` when nothing is playing or fading — the render callback uses this
+    /// to decide whether the graph still has to be woken while stopped.
+    pub fn is_idle(&self) -> bool {
+        self.current.is_none() && self.releasing.is_none()
+    }
+
+    /// Mix both voices into an interleaved output block and retire whichever
+    /// finished during it.
+    #[inline]
+    pub fn mix_into(&mut self, output: &mut [f32], output_channels: usize) {
+        if let Some(voice) = self.current.as_mut() {
+            if voice.mix_into(output, output_channels) {
+                Self::retire(self.current.take());
+            }
+        }
+        if let Some(voice) = self.releasing.as_mut() {
+            if voice.mix_into(output, output_channels) {
+                Self::retire(self.releasing.take());
+            }
+        }
+    }
+
+    fn release(&mut self, mut voice: AudioFileAudition, output_rate: u32) {
+        voice.begin_release(output_rate);
+        // Only one fade-out slot: a third selection inside 8 ms drops the
+        // oldest, which is quieter than letting the queue grow.
+        Self::retire(self.releasing.replace(voice));
+    }
+
+    fn retire(voice: Option<AudioFileAudition>) {
+        if let Some(voice) = voice {
+            crate::graveyard::retire_audio_file(voice.into_source());
+        }
     }
 }
 
@@ -1313,6 +1417,108 @@ fn clamp_i16_as_i32(value: f32) -> i32 {
     (value.clamp(-1.0, 1.0) * 32767.0)
         .round()
         .clamp(-32768.0, 32767.0) as i32
+}
+
+#[cfg(test)]
+mod audition_tests {
+    use super::*;
+
+    const RATE: u32 = 48_000;
+
+    /// Constant full-scale stereo source: any envelope shows up directly in the
+    /// mixed output, so the declick ramps are readable from the block.
+    fn dc_source(seconds: f32) -> Box<AudioFileBuffer> {
+        let frames = (RATE as f32 * seconds) as usize;
+        Box::new(AudioFileBuffer {
+            sample_rate: RATE,
+            channels: 2,
+            frames,
+            samples: vec![1.0; frames * 2],
+        })
+    }
+
+    fn mix_block(player: &mut AuditionPlayer, frames: usize) -> Vec<f32> {
+        let mut block = vec![0.0f32; frames * 2];
+        player.mix_into(&mut block, 2);
+        block
+    }
+
+    #[test]
+    fn audition_ramps_in_rather_than_jumping_to_full_scale() {
+        let mut player = AuditionPlayer::default();
+        player.start(dc_source(1.0), RATE);
+        let attack_frames = (AUDITION_ATTACK_SECONDS * RATE as f32) as usize;
+
+        let block = mix_block(&mut player, 8);
+        assert!(
+            block[0] > 0.0 && block[0] < 0.05,
+            "first frame must start on the ramp, got {}",
+            block[0]
+        );
+
+        let settled = mix_block(&mut player, attack_frames);
+        let last = settled[settled.len() - 1];
+        assert!(
+            (last - 1.0).abs() < 1e-6,
+            "ramp must reach unity gain, got {last}"
+        );
+    }
+
+    #[test]
+    fn replacing_an_audition_fades_the_old_voice_instead_of_cutting_it() {
+        let mut player = AuditionPlayer::default();
+        player.start(dc_source(1.0), RATE);
+        let _ = mix_block(&mut player, 4_800); // let the first voice settle
+
+        player.start(dc_source(1.0), RATE);
+        let block = mix_block(&mut player, 8);
+        // The retiring voice is still audible (near unity) while the new one
+        // ramps up, so the sum stays above the new voice on its own.
+        assert!(
+            block[0] > 0.9,
+            "replaced voice must fade, not cut, got {}",
+            block[0]
+        );
+    }
+
+    #[test]
+    fn stopped_audition_releases_to_silence_and_goes_idle() {
+        let mut player = AuditionPlayer::default();
+        player.start(dc_source(1.0), RATE);
+        let _ = mix_block(&mut player, 4_800);
+
+        player.stop(RATE);
+        assert!(!player.is_idle(), "release voice must keep the mixer awake");
+
+        let release_frames = (AUDITION_RELEASE_SECONDS * RATE as f32) as usize + 2;
+        let block = mix_block(&mut player, release_frames);
+        assert!(
+            block[0] > 0.9,
+            "release must start from the current gain, got {}",
+            block[0]
+        );
+        assert!(
+            block[block.len() - 1].abs() < 1e-6,
+            "release must reach silence, got {}",
+            block[block.len() - 1]
+        );
+        assert!(player.is_idle(), "finished release must retire the voice");
+    }
+
+    #[test]
+    fn source_end_fades_out_before_the_last_frame() {
+        let mut player = AuditionPlayer::default();
+        // 20 ms source: long enough to pass the attack, short enough that the
+        // tail fade covers the end of a single mixed block.
+        player.start(dc_source(0.02), RATE);
+        let block = mix_block(&mut player, (RATE as f32 * 0.02) as usize);
+        let last = block[block.len() - 2];
+        assert!(
+            last.abs() < 0.2,
+            "end of file must fade out, got {last} on the last frame"
+        );
+        assert!(player.is_idle(), "finished source must retire the voice");
+    }
 }
 
 #[cfg(test)]

--- a/crates/SphereDirectAudioEngine/src/backend/render.rs
+++ b/crates/SphereDirectAudioEngine/src/backend/render.rs
@@ -9,7 +9,7 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
 
-use crate::audio_file::AudioFileAudition;
+use crate::audio_file::AuditionPlayer;
 use crate::command::EngineCommand;
 use crate::dsp::{meter::smooth_peak, oscillator::SineOscillator};
 use crate::engine::{SharedState, PEAK_DECAY, TEST_TONE_AMPLITUDE};
@@ -127,7 +127,7 @@ pub struct LocalAudioState {
     /// When true, metronome scheduling and output are suppressed (playhead scrub).
     pub metronome_suspended: bool,
     /// Standalone File Browser audition, owned by this stream/callback.
-    pub audition: Option<AudioFileAudition>,
+    pub audition: AuditionPlayer,
 }
 
 impl LocalAudioState {
@@ -167,7 +167,7 @@ impl LocalAudioState {
             metronome_click_phase_inc: 0.0,
             metronome_click_gain: 0.0,
             metronome_suspended: false,
-            audition: None,
+            audition: AuditionPlayer::default(),
         }
     }
 
@@ -467,15 +467,18 @@ pub fn drain_commands(
                 local.osc_l.set_frequency(frequency as f64);
                 local.osc_r.set_frequency(frequency as f64);
             }
-            EngineCommand::StartAudition { source } => {
-                if let Some(old) = local.audition.replace(AudioFileAudition::new(source)) {
-                    crate::graveyard::retire_audio_file(old.into_source());
+            EngineCommand::StartAudition { token, source } => {
+                // Reject a decode the user has already moved past; the source
+                // leaves through the graveyard so this block never frees it on
+                // the audio thread.
+                if token == shared.audition_request_token.load(Ordering::Relaxed) {
+                    local.audition.start(source, output_sample_rate);
+                } else {
+                    crate::graveyard::retire_audio_file(source);
                 }
             }
             EngineCommand::StopAudition => {
-                if let Some(old) = local.audition.take() {
-                    crate::graveyard::retire_audio_file(old.into_source());
-                }
+                local.audition.stop(output_sample_rate);
             }
             EngineCommand::StartTransport => {
                 let pos = shared.position_samples.load(Ordering::Relaxed);
@@ -992,16 +995,20 @@ fn fill_output_f32_inner(
     // so the plugin's own UI keyboard stays audible (parity with the legacy
     // callback path).
     let bridge_editor_wakeup = runtime.has_bridge_editor_active();
-    let audition_active = local.audition.is_some();
-    let preview_render_active = has_preview
+    let audition_active = !local.audition.is_idle();
+    // Reasons the *graph* has to run while the transport is stopped. A Browser
+    // preview is deliberately not one of them: it is a decoded buffer mixed
+    // into the master output, so pulling every track's plugin chain through a
+    // block of silence just to audition it only buys xruns on a loaded project.
+    let graph_wake_active = has_preview
         || pending_midi
         || panic_flush
         || bridge_preview_tail
         || bridge_editor_wakeup
         || local.preview_tail_samples > 0
         || local.stop_tail_samples > 0
-        || audition_active
         || software_monitoring;
+    let preview_render_active = graph_wake_active || audition_active;
     if preview_render_active
         && !transport_playing
         && (has_preview || pending_midi || local.preview_tail_samples > 0)
@@ -1060,7 +1067,12 @@ fn fill_output_f32_inner(
     };
 
     if channels >= 2 && (transport_playing || preview_render_active) {
-        frames = if software_monitoring && monitor_input_ready {
+        frames = if !transport_playing && !graph_wake_active {
+            // Audition-only block: the graph would render silence, so hand the
+            // rest of this callback a zeroed buffer instead of processing it.
+            data.fill(0.0);
+            frames_in_block
+        } else if software_monitoring && monitor_input_ready {
             render_project_block_interleaved_with_live_input(
                 runtime,
                 base_sample,
@@ -1087,16 +1099,6 @@ fn fill_output_f32_inner(
                 loop_bounds,
             )
         };
-        let audition_finished = local
-            .audition
-            .as_mut()
-            .map(|audition| audition.mix_into(data, channels, runtime.sample_rate))
-            .unwrap_or(false);
-        if audition_finished {
-            if let Some(audition) = local.audition.take() {
-                crate::graveyard::retire_audio_file(audition.into_source());
-            }
-        }
         if !local.render_path_logged {
             local.render_path_logged = true;
             if callback_debug_enabled() {
@@ -1223,6 +1225,12 @@ fn fill_output_f32_inner(
             *sample = v;
             frames += 1;
         }
+    }
+
+    // Browser sample preview, summed after the graph so it is metered like the
+    // rest of the output but never counts as bridge-tail activity above.
+    if channels >= 2 {
+        local.audition.mix_into(data, channels);
     }
 
     // Legacy master-bus bridge fallback (disabled by default — per-track routing

--- a/crates/SphereDirectAudioEngine/src/command.rs
+++ b/crates/SphereDirectAudioEngine/src/command.rs
@@ -119,7 +119,12 @@ pub enum EngineCommand {
         sink: Option<std::sync::Arc<dyn crate::plugin_bridge::PluginBridgeSink>>,
     },
     /// Play a pre-decoded standalone browser sample through the master output.
+    /// `token` is the `SharedState::audition_request_token` value this decode
+    /// was started for; the callback drops the source when a newer selection
+    /// has since been made, so a slow decode can never resurrect a sample the
+    /// user already moved past.
     StartAudition {
+        token: u64,
         source: Box<crate::audio_file::AudioFileBuffer>,
     },
     /// Stop the current standalone browser sample audition.

--- a/crates/SphereDirectAudioEngine/src/engine.rs
+++ b/crates/SphereDirectAudioEngine/src/engine.rs
@@ -21,7 +21,7 @@ use crossbeam_channel::{bounded, Receiver, Sender};
 use parking_lot::Mutex;
 use sphere_audio_plugins::{canonical_plugin_id, process_stereo_sample};
 
-use crate::audio_file::AudioFileAudition;
+use crate::audio_file::AuditionPlayer;
 use crate::audio_graph::is_routing_track_type;
 use crate::audio_source::{sample_source_stereo, ClipAudioSource};
 #[cfg(target_os = "windows")]
@@ -489,6 +489,11 @@ pub struct SharedState {
     /// Monotonic generation of the latency-compensation graph (bumped on PDC
     /// toggle). Stamped into the offline-export snapshot for graph-version parity.
     pub latency_graph_version: AtomicU64,
+    /// Monotonic id of the newest Browser sample-preview request (control →
+    /// audio). Decodes run off the realtime thread and finish out of order, so
+    /// both the decode worker and the callback compare against this before a
+    /// source is allowed to start playing.
+    pub audition_request_token: AtomicU64,
 }
 
 impl Default for SharedState {
@@ -561,6 +566,7 @@ impl Default for SharedState {
             device_lost: AtomicBool::new(false),
             pdc_enabled: AtomicBool::new(true),
             latency_graph_version: AtomicU64::new(1),
+            audition_request_token: AtomicU64::new(0),
         }
     }
 }
@@ -756,6 +762,24 @@ pub struct EngineInner {
     // Settings input test reads the ASIO session peak instead of owning a
     // stream (true only between start/stop_input_test on the ASIO backend).
     input_test_uses_session: std::sync::atomic::AtomicBool,
+
+    // Browser sample-preview decode requests (see `AuditionRequests`).
+    audition_requests: Arc<AuditionRequests>,
+}
+
+/// Single-slot mailbox for Browser sample-preview decode requests.
+///
+/// Arrow-keying through a folder selects files far faster than they decode, and
+/// a thread per selection let those decodes finish in any order: an older,
+/// slower one could land last and audition a sample the user had already moved
+/// past. One worker drains this mailbox, only the newest request survives in
+/// it, and every request carries the token the callback checks before playing.
+#[derive(Default)]
+struct AuditionRequests {
+    /// Newest un-decoded request; replaced (not queued) by a later selection.
+    pending: Mutex<Option<(u64, String)>>,
+    ready: parking_lot::Condvar,
+    worker_running: AtomicBool,
 }
 
 #[derive(Clone)]
@@ -820,6 +844,7 @@ impl EngineInner {
             live_input: Mutex::new(None),
             asio_caps: Mutex::new(None),
             input_test_uses_session: std::sync::atomic::AtomicBool::new(false),
+            audition_requests: Arc::new(AuditionRequests::default()),
         }
     }
 
@@ -3665,30 +3690,112 @@ impl EngineInner {
             .map_err(|e| SphereAudioError::NativeError(e.to_string()))
     }
 
+    /// Queue a Browser sample preview. The decode itself runs on the single
+    /// audition worker, so a burst of selections collapses to the newest one
+    /// instead of racing a thread per click.
     pub(crate) fn audition_file_async(
         self: &Arc<Self>,
         path: String,
     ) -> Result<(), SphereAudioError> {
         self.cmd_sender().ok_or(SphereAudioError::EngineNotOpen)?;
-        let engine = Arc::clone(self);
-        std::thread::Builder::new()
-            .name("browser-audition-decode".to_string())
-            .spawn(move || match crate::audio_file::load_audio_file(&path) {
-                Ok(source) => {
-                    if let Err(error) = engine.send_command(EngineCommand::StartAudition {
-                        source: Box::new(source),
-                    }) {
-                        eprintln!("[audition] could not start preview for {path}: {error}");
-                    }
-                }
-                Err(error) => eprintln!("[audition] could not decode {path}: {error}"),
-            })
-            .map_err(|error| SphereAudioError::NativeError(error.to_string()))?;
-        Ok(())
+        // Retiring a previous preview is the callback's first graveyard use in
+        // a session that never loaded a project; prime it from here so that
+        // enqueue can't spawn the drop thread on the audio thread.
+        crate::graveyard::prime();
+        let token = self
+            .shared
+            .audition_request_token
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        *self.audition_requests.pending.lock() = Some((token, path));
+        self.audition_requests.ready.notify_one();
+        self.ensure_audition_worker()
     }
 
     pub(crate) fn stop_audition(&self) -> Result<(), SphereAudioError> {
+        // Invalidate any decode still in flight so it cannot start playing
+        // after the user asked for silence.
+        self.shared
+            .audition_request_token
+            .fetch_add(1, Ordering::Relaxed);
+        self.audition_requests.pending.lock().take();
         self.send_command(EngineCommand::StopAudition)
+    }
+
+    fn ensure_audition_worker(self: &Arc<Self>) -> Result<(), SphereAudioError> {
+        if self
+            .audition_requests
+            .worker_running
+            .swap(true, Ordering::AcqRel)
+        {
+            return Ok(()); // already draining the mailbox
+        }
+        let requests = Arc::clone(&self.audition_requests);
+        let engine = Arc::downgrade(self);
+        match std::thread::Builder::new()
+            .name("browser-audition-decode".to_string())
+            .spawn(move || audition_decode_worker(requests, engine))
+        {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                self.audition_requests
+                    .worker_running
+                    .store(false, Ordering::Release);
+                Err(SphereAudioError::NativeError(error.to_string()))
+            }
+        }
+    }
+}
+
+/// Decode the newest queued Browser preview and hand it to the callback.
+///
+/// Requests superseded before or during their decode are dropped here rather
+/// than sent, and the ones that do get sent still carry their token so the
+/// callback can reject a source that lost the race after this check.
+fn audition_decode_worker(requests: Arc<AuditionRequests>, engine: std::sync::Weak<EngineInner>) {
+    loop {
+        let next = {
+            let mut pending = requests.pending.lock();
+            while pending.is_none() {
+                // Timed waits let the worker notice a dropped engine instead of
+                // parking forever on a mailbox nobody can fill again.
+                if requests
+                    .ready
+                    .wait_for(&mut pending, std::time::Duration::from_millis(500))
+                    .timed_out()
+                    && engine.strong_count() == 0
+                {
+                    requests.worker_running.store(false, Ordering::Release);
+                    return;
+                }
+            }
+            pending.take()
+        };
+        let Some((token, path)) = next else {
+            continue;
+        };
+        let Some(engine) = engine.upgrade() else {
+            requests.worker_running.store(false, Ordering::Release);
+            return;
+        };
+        let is_current = || token == engine.shared.audition_request_token.load(Ordering::Relaxed);
+        if !is_current() {
+            continue; // superseded while it sat in the mailbox — never decode it
+        }
+        match crate::audio_file::load_audio_file(&path) {
+            Ok(source) => {
+                if !is_current() {
+                    continue; // a newer selection landed while this decoded
+                }
+                if let Err(error) = engine.send_command(EngineCommand::StartAudition {
+                    token,
+                    source: Box::new(source),
+                }) {
+                    eprintln!("[audition] could not start preview for {path}: {error}");
+                }
+            }
+            Err(error) => eprintln!("[audition] could not decode {path}: {error}"),
+        }
     }
 }
 
@@ -3867,7 +3974,7 @@ where
     let mut render_path_logged = false;
     let mut block_scratch: Vec<f32> = Vec::new();
     let mut metronome = crate::backend::render::LocalAudioState::new(sr);
-    let mut audition: Option<AudioFileAudition> = None;
+    let mut audition = AuditionPlayer::default();
 
     // Meter state with peak hold.
     let mut prev_peak_l = 0.0f32;
@@ -3971,15 +4078,20 @@ where
                             osc_l.set_frequency(frequency as f64);
                             osc_r.set_frequency(frequency as f64);
                         }
-                        EngineCommand::StartAudition { source } => {
-                            if let Some(old) = audition.replace(AudioFileAudition::new(source)) {
-                                crate::graveyard::retire_audio_file(old.into_source());
+                        EngineCommand::StartAudition { token, source } => {
+                            // Reject a decode the user has already moved past;
+                            // the source leaves through the graveyard so this
+                            // block never frees it on the audio thread.
+                            if token
+                                == shared.audition_request_token.load(Ordering::Relaxed)
+                            {
+                                audition.start(source, output_sample_rate);
+                            } else {
+                                crate::graveyard::retire_audio_file(source);
                             }
                         }
                         EngineCommand::StopAudition => {
-                            if let Some(old) = audition.take() {
-                                crate::graveyard::retire_audio_file(old.into_source());
-                            }
+                            audition.stop(output_sample_rate);
                         }
                         EngineCommand::StartTransport => {
                             let pos = shared.position_samples.load(Ordering::Relaxed);
@@ -4335,15 +4447,18 @@ where
                         .saturating_sub(frames_in_block);
                 }
                 let bridge_editor_wakeup = runtime.has_bridge_editor_active();
-                let audition_active = audition.is_some();
-                let preview_render_active = has_preview
+                let audition_active = !audition.is_idle();
+                // A Browser preview is mixed into the master output and needs
+                // nothing from the graph, so it is not a graph wake reason —
+                // see the DAUx path for the same split.
+                let graph_wake_active = has_preview
                     || pending_midi
                     || panic_flush
                     || bridge_preview_tail
                     || metronome.preview_tail_samples > 0
                     || metronome.stop_tail_samples > 0
-                    || bridge_editor_wakeup
-                    || audition_active;
+                    || bridge_editor_wakeup;
+                let preview_render_active = graph_wake_active || audition_active;
                 if preview_render_active
                     && !playing_local
                     && (has_preview || pending_midi || metronome.preview_tail_samples > 0)
@@ -4398,26 +4513,25 @@ where
                         block_scratch.resize(scratch_len, 0.0);
                     }
                     let scratch = &mut block_scratch[..scratch_len];
-                    frames = render_project_block_interleaved(
-                        &mut runtime,
-                        base_sample,
-                        master_vol,
-                        scratch,
-                        ch,
-                        playing_local,
-                        shared.time_sig_num.load(Ordering::Relaxed),
-                        shared.time_sig_den.load(Ordering::Relaxed),
-                        loop_bounds,
-                    );
-                    let audition_finished = audition
-                        .as_mut()
-                        .map(|audition| audition.mix_into(scratch, ch, runtime.sample_rate))
-                        .unwrap_or(false);
-                    if audition_finished {
-                        if let Some(audition) = audition.take() {
-                            crate::graveyard::retire_audio_file(audition.into_source());
-                        }
-                    }
+                    frames = if !playing_local && !graph_wake_active {
+                        // Audition-only block: the graph would render silence,
+                        // so zero the scratch instead of processing it.
+                        scratch.fill(0.0);
+                        frames_needed as u64
+                    } else {
+                        render_project_block_interleaved(
+                            &mut runtime,
+                            base_sample,
+                            master_vol,
+                            scratch,
+                            ch,
+                            playing_local,
+                            shared.time_sig_num.load(Ordering::Relaxed),
+                            shared.time_sig_den.load(Ordering::Relaxed),
+                            loop_bounds,
+                        )
+                    };
+                    audition.mix_into(scratch, ch);
                     if !render_path_logged {
                         render_path_logged = true;
                         if callback_debug_enabled() {


### PR DESCRIPTION
## Problem

Auditioning a file from the Browser spawned **one decode thread per selection** with no ordering guard (`EngineInner::audition_file_async`). Arrow-keying through a folder starts several decodes at once and whichever finishes last wins, so a sample the user already scrolled past can start playing. This is worst on Linux, where the decode threads contend with the compositor and the RT-promoted callback thread and finish in near-random order.

Two smaller problems ride along:

- Voices started and were cut mid-waveform with no ramp, so every step through a folder clicked.
- An audition counted as a reason to wake the whole project graph while the transport was stopped, so previewing a sample pulled every plugin chain through a block of silence — the xrun source on a loaded project.

## Changes

- **Ordering**: a single decode worker with a single-slot mailbox replaces the thread per click, so a burst of selections collapses to the newest request. Requests carry a token (`SharedState::audition_request_token`); the worker drops superseded work before and after decoding, and the render callback rejects a stale source as a last line of defence, retiring it through the graveyard rather than freeing it on the audio thread.
- **Declick**: `AudioFileAudition` gets an envelope (2 ms attack, 8 ms release, 8 ms end-of-file fade), and the new `AuditionPlayer` holds the current voice plus at most one fading-out voice, so a replaced preview fades instead of being cut.
- **Graph wake**: the audition is no longer a graph wake reason in either render path. An audition-only block zeroes its buffer instead of rendering the graph (which produces silence in that state anyway — the same state as idle). Mixing moved to after the graph so a loud preview can no longer re-arm the plugin-bridge preview tail.

## Validation

- `cargo test -p sphere_directaudioengine --lib` — 180 passed, including 4 new tests covering the attack ramp, the fade-on-replace, the release-to-silence-then-idle path, and the end-of-file fade
- `cargo check -p sphere_directaudioengine`, `cargo check -p futureboard_native` — clean
- `cargo fmt --all -- --check` — clean for the touched files

Not yet verified by ear on a live device; the diagnosis is from the call path, so an audible pass on Linux (arrow-key through a sample folder, then preview while a heavy project is loaded and stopped) is still worth doing.