### PR TITLE
Fix Cubase XML import fidelity and master built-in inserts

### DIFF
--- a/crates/SphereUIComponents/src/components/timeline/audio_import.rs
+++ b/crates/SphereUIComponents/src/components/timeline/audio_import.rs
@@ -545,29 +545,40 @@ pub async fn run_import_pipeline(
     }
 }
 
-/// After a project load, hydrate waveform caches from `Cache/Waveforms/` and
-/// schedule background regeneration for missing peak files.
-pub fn schedule_project_waveform_restore(
-    project: &crate::project::FutureboardProject,
-    project_root: PathBuf,
-    timeline: Entity<Timeline>,
-    layout: Entity<StudioLayout>,
-    cx: &mut Context<StudioLayout>,
-) {
-    use std::collections::HashSet;
+/// Resolve an asset's on-disk audio path for waveform restore.
+///
+/// Native projects store a project-relative path; DAW imports (Cubase XML,
+/// etc.) store an absolute media path and leave `relative_path` empty —
+/// both must resolve, otherwise clips stay stuck on `Queued`.
+fn resolve_asset_audio_path(
+    asset: &crate::project::ProjectAsset,
+    project_root: &Path,
+) -> Option<PathBuf> {
+    if let Some(rel) = asset.relative_path.as_ref() {
+        Some(project_root.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR)))
+    } else {
+        asset.absolute_path.clone()
+    }
+}
 
+/// Collect `(asset_id, optional audio path)` for every audio asset / clip.
+///
+/// When an asset is registered without a path (import with only
+/// `absolute_path` later filled from the clip), clip `source_path` fills the
+/// gap rather than being skipped.
+pub(crate) fn collect_waveform_restore_entries(
+    project: &crate::project::FutureboardProject,
+    project_root: &Path,
+) -> Vec<(String, Option<PathBuf>)> {
     use crate::project::ClipSource;
 
-    let mut seen = HashSet::new();
-    let mut jobs: Vec<(String, PathBuf)> = Vec::new();
     let mut entries: Vec<(String, Option<PathBuf>)> = Vec::new();
 
     for asset in &project.assets {
-        let audio_path = asset
-            .relative_path
-            .as_ref()
-            .map(|rel| project_root.join(rel.replace('/', std::path::MAIN_SEPARATOR_STR)));
-        entries.push((asset.id.clone(), audio_path));
+        entries.push((
+            asset.id.clone(),
+            resolve_asset_audio_path(asset, project_root),
+        ));
     }
 
     for track in &project.tracks {
@@ -584,12 +595,39 @@ pub fn schedule_project_waveform_restore(
                 } => (asset_id, Some(source_path.clone())),
                 _ => continue,
             };
-            if entries.iter().any(|(id, _)| id == asset_id) {
+            if let Some((_, path)) = entries.iter_mut().find(|(id, _)| id == asset_id) {
+                if path.is_none() {
+                    *path = source_path;
+                }
                 continue;
             }
             entries.push((asset_id.clone(), source_path));
         }
     }
+
+    entries
+}
+
+/// After a project load, hydrate waveform caches from `Cache/Waveforms/` and
+/// schedule background regeneration for missing peak files.
+///
+/// `persist_peaks` is true for saved Futureboard projects (read/write peak
+/// files under the project folder and eager-copy media). Foreign imports that
+/// bind as untitled pass `false` so media next to a Cubase XML is never copied
+/// or peak-cached into the archive folder — waveforms are built in memory.
+pub fn schedule_project_waveform_restore(
+    project: &crate::project::FutureboardProject,
+    project_root: PathBuf,
+    persist_peaks: bool,
+    timeline: Entity<Timeline>,
+    layout: Entity<StudioLayout>,
+    cx: &mut Context<StudioLayout>,
+) {
+    use std::collections::HashSet;
+
+    let mut seen = HashSet::new();
+    let mut jobs: Vec<(String, PathBuf)> = Vec::new();
+    let entries = collect_waveform_restore_entries(project, &project_root);
 
     for (asset_id, audio_path) in entries {
         if !seen.insert(asset_id.clone()) {
@@ -598,6 +636,16 @@ pub fn schedule_project_waveform_restore(
         if let Some(path) = audio_path.as_ref().filter(|p| p.exists()) {
             eprintln!("[ProjectLoad] audio asset resolved path={}", path.display());
         }
+
+        if !persist_peaks {
+            // Untitled DAW import: no project cache folder to read or write.
+            eprintln!("[WaveformCache] import session disk miss asset_id={asset_id}");
+            if let Some(path) = audio_path.filter(|p| p.exists()) {
+                jobs.push((asset_id, path));
+            }
+            continue;
+        }
+
         let peak_rel = project
             .assets
             .iter()
@@ -665,13 +713,14 @@ pub fn schedule_project_waveform_restore(
 
     let timeline_weak = timeline.downgrade();
     let layout_weak = layout.downgrade();
-    let root = project_root;
+    // Only a real Futureboard project folder may receive peak files / copies.
+    let persist_root = persist_peaks.then_some(project_root);
     cx.spawn(async move |_layout, cx| {
         for (asset_id, path) in jobs {
             run_import_pipeline(
                 asset_id,
                 path,
-                Some(root.clone()),
+                persist_root.clone(),
                 timeline_weak.clone(),
                 Some(layout_weak.clone()),
                 cx,
@@ -746,4 +795,153 @@ pub fn spawn_timeline_import_from_layout(
         .await;
     })
     .detach();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project::{
+        ClipSource, FutureboardProject, ProjectAsset, ProjectClip, ProjectTrack, ProjectTrackType,
+    };
+
+    fn audio_asset(id: &str, absolute: Option<PathBuf>, relative: Option<&str>) -> ProjectAsset {
+        ProjectAsset {
+            id: id.to_string(),
+            original_filename: "kick.wav".into(),
+            relative_path: relative.map(str::to_string),
+            absolute_path: absolute,
+            duration_secs: Some(1.0),
+            sample_rate: Some(44_100),
+            channels: Some(2),
+            source_fingerprint: None,
+            waveform_peak_relative_path: None,
+            duration_samples: Some(44_100),
+        }
+    }
+
+    fn audio_clip(asset_id: &str, source: Option<PathBuf>) -> ProjectClip {
+        ProjectClip {
+            id: "clip".into(),
+            name: "clip".into(),
+            start_beat: 0.0,
+            duration_beats: 4.0,
+            offset_beats: 0.0,
+            gain: 1.0,
+            muted: false,
+            source: ClipSource::Audio {
+                asset_id: asset_id.into(),
+                source_path: source,
+            },
+            stretch: Default::default(),
+        }
+    }
+
+    #[test]
+    fn restore_entries_use_absolute_path_when_relative_is_absent() {
+        // Cubase XML import stores absolute media paths and no project-relative
+        // copy — the resolve step must still surface the file so clips leave
+        // `Queued`.
+        let media = PathBuf::from("/tmp/cubase_archive/Audio/kick.wav");
+        let mut project = FutureboardProject::new("imported");
+        project.assets.push(audio_asset("a1", Some(media.clone()), None));
+        project.tracks.push(ProjectTrack {
+            id: "t1".into(),
+            name: "KICK".into(),
+            track_type: ProjectTrackType::Audio,
+            parent_group_id: None,
+            group_collapsed: false,
+            color_hex: "#000000".into(),
+            volume_norm: 0.75,
+            pan: 0.0,
+            muted: false,
+            solo: false,
+            record_arm: false,
+            input_monitor: Default::default(),
+            routing: Default::default(),
+            inserts: Vec::new(),
+            automation_lanes: Vec::new(),
+            clips: vec![audio_clip("a1", Some(media.clone()))],
+            row_height_px: None,
+            soundfont: None,
+            volume_automation_read: true,
+        });
+
+        let entries = collect_waveform_restore_entries(&project, Path::new("/tmp/unused"));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, "a1");
+        assert_eq!(entries[0].1.as_deref(), Some(media.as_path()));
+    }
+
+    #[test]
+    fn restore_entries_prefer_relative_path_for_native_projects() {
+        let mut project = FutureboardProject::new("native");
+        project.assets.push(audio_asset(
+            "a1",
+            Some(PathBuf::from("/elsewhere/kick.wav")),
+            Some("Assets/Audio/kick.wav"),
+        ));
+        project.tracks.push(ProjectTrack {
+            id: "t1".into(),
+            name: "KICK".into(),
+            track_type: ProjectTrackType::Audio,
+            parent_group_id: None,
+            group_collapsed: false,
+            color_hex: "#000000".into(),
+            volume_norm: 0.75,
+            pan: 0.0,
+            muted: false,
+            solo: false,
+            record_arm: false,
+            input_monitor: Default::default(),
+            routing: Default::default(),
+            inserts: Vec::new(),
+            automation_lanes: Vec::new(),
+            clips: vec![audio_clip(
+                "a1",
+                Some(PathBuf::from("/elsewhere/kick.wav")),
+            )],
+            row_height_px: None,
+            soundfont: None,
+            volume_automation_read: true,
+        });
+
+        let root = PathBuf::from("/proj");
+        let entries = collect_waveform_restore_entries(&project, &root);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].1.as_deref(),
+            Some(root.join("Assets/Audio/kick.wav").as_path())
+        );
+    }
+
+    #[test]
+    fn restore_entries_fill_path_from_clip_when_asset_has_neither() {
+        let media = PathBuf::from("/media/kick.wav");
+        let mut project = FutureboardProject::new("gap");
+        project.assets.push(audio_asset("a1", None, None));
+        project.tracks.push(ProjectTrack {
+            id: "t1".into(),
+            name: "KICK".into(),
+            track_type: ProjectTrackType::Audio,
+            parent_group_id: None,
+            group_collapsed: false,
+            color_hex: "#000000".into(),
+            volume_norm: 0.75,
+            pan: 0.0,
+            muted: false,
+            solo: false,
+            record_arm: false,
+            input_monitor: Default::default(),
+            routing: Default::default(),
+            inserts: Vec::new(),
+            automation_lanes: Vec::new(),
+            clips: vec![audio_clip("a1", Some(media.clone()))],
+            row_height_px: None,
+            soundfont: None,
+            volume_automation_read: true,
+        });
+
+        let entries = collect_waveform_restore_entries(&project, Path::new("/tmp"));
+        assert_eq!(entries[0].1.as_deref(), Some(media.as_path()));
+    }
 }

--- a/crates/SphereUIComponents/src/components/timeline/track_header.rs
+++ b/crates/SphereUIComponents/src/components/timeline/track_header.rs
@@ -80,6 +80,9 @@ impl Render for TrackDragPreview {
             .child(
                 div()
                     .ml(px(7.0))
+                    .max_w(px(220.0))
+                    .overflow_hidden()
+                    .truncate()
                     .text_size(px(10.0))
                     .font_weight(gpui::FontWeight::SEMIBOLD)
                     .text_color(Colors::text_primary())
@@ -482,12 +485,16 @@ pub fn track_header(
                         .items_center()
                         .justify_between()
                         .w_full()
+                        .min_w(px(0.0))
                         .child(
                             div()
                                 .flex()
                                 .flex_row()
                                 .items_center()
                                 .gap(px(6.0))
+                                .flex_1()
+                                .min_w(px(0.0))
+                                .overflow_hidden()
                                 .id(("track-drag-zone", id_num))
                                 .cursor(gpui::CursorStyle::PointingHand)
                                 .on_drag(
@@ -528,13 +535,17 @@ pub fn track_header(
                                     div()
                                         .flex()
                                         .flex_col()
+                                        .flex_1()
                                         .min_w(px(0.0))
+                                        .overflow_hidden()
                                         .child(
                                             div()
                                                 .flex()
                                                 .flex_row()
                                                 .items_center()
                                                 .gap(px(4.0))
+                                                .min_w(px(0.0))
+                                                .w_full()
                                                 .when(is_group, |row| {
                                                     row.child(
                                                         div()
@@ -584,7 +595,9 @@ pub fn track_header(
                                                 })
                                                 .child(
                                                     div()
+                                                        .flex_1()
                                                         .min_w(px(0.0))
+                                                        .overflow_hidden()
                                                         .truncate()
                                                         .text_size(px(11.0))
                                                         .font_weight(gpui::FontWeight::SEMIBOLD)
@@ -598,6 +611,8 @@ pub fn track_header(
                                             // ramp — never bright accent — so it
                                             // reads as secondary info, not a link.
                                             div()
+                                                .min_w(px(0.0))
+                                                .overflow_hidden()
                                                 .text_size(px(8.5))
                                                 .truncate()
                                                 .text_color(if is_automation {
@@ -613,6 +628,7 @@ pub fn track_header(
                             div()
                                 .flex()
                                 .flex_row()
+                                .flex_shrink_0()
                                 .items_center()
                                 .gap(px(2.0))
                                 .px(px(3.0))

--- a/crates/SphereUIComponents/src/layout/plugin_ops.rs
+++ b/crates/SphereUIComponents/src/layout/plugin_ops.rs
@@ -1981,8 +1981,17 @@ impl StudioLayout {
 
         let state = &self.timeline.read(cx).state;
         let mut instances = Vec::new();
-        for track in &state.tracks {
-            for slot in &track.inserts {
+        let owners = state
+            .tracks
+            .iter()
+            .map(|track| (track.id.as_str(), track.name.as_str(), &track.inserts))
+            .chain(std::iter::once((
+                crate::components::timeline::timeline_state::MASTER_TRACK_ID,
+                "Master",
+                &state.master.inserts,
+            )));
+        for (track_id, track_name, inserts) in owners {
+            for slot in inserts {
                 let Some(slot_plugin_id) = slot.plugin_id.as_deref() else {
                     continue;
                 };
@@ -2007,11 +2016,11 @@ impl StudioLayout {
                 .or_else(|| slot.vst3_state.clone());
                 instances.push(PluginInstanceDescriptor {
                     instance_key: PluginInstanceKey {
-                        track_id: track.id.clone(),
+                        track_id: track_id.to_string(),
                         insert_id: slot.id.clone(),
                     },
                     plugin_id: plugin_id.to_string(),
-                    track_name: track.name.clone(),
+                    track_name: track_name.to_string(),
                     insert_name: slot.display_name.clone(),
                     bypassed: slot.bypassed,
                     enabled: slot.enabled,
@@ -3848,20 +3857,31 @@ impl StudioLayout {
     }
 
     pub(super) fn request_track_insert_parameters(&self, track_id: &str, cx: &Context<Self>) {
-        let instance_ids: Vec<String> = self
-            .timeline
-            .read(cx)
-            .state
-            .find_track(track_id)
-            .map(|track| {
-                track
-                    .inserts
-                    .iter()
-                    .filter(|insert| !insert.is_empty())
-                    .map(|insert| insert.id.clone())
-                    .collect()
-            })
-            .unwrap_or_default();
+        let timeline = self.timeline.read(cx);
+        let state = &timeline.state;
+        let instance_ids: Vec<String> = if track_id
+            == crate::components::timeline::timeline_state::MASTER_TRACK_ID
+        {
+            state
+                .master
+                .inserts
+                .iter()
+                .filter(|insert| !insert.is_empty())
+                .map(|insert| insert.id.clone())
+                .collect()
+        } else {
+            state
+                .find_track(track_id)
+                .map(|track| {
+                    track
+                        .inserts
+                        .iter()
+                        .filter(|insert| !insert.is_empty())
+                        .map(|insert| insert.id.clone())
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
         for instance_id in instance_ids {
             self.request_bridge_insert_parameters(&instance_id);
         }

--- a/crates/SphereUIComponents/src/layout/session_load.rs
+++ b/crates/SphereUIComponents/src/layout/session_load.rs
@@ -803,10 +803,19 @@ impl StudioLayout {
         let Some(root) = package.path.parent().map(PathBuf::from) else {
             return;
         };
+        // Cubase/Nuendo XML (and other foreign imports) bind untitled: never
+        // write peak caches or copy media into the archive's folder. Native
+        // `.fbproj` sessions keep peak files under the project tree.
+        let persist_peaks = !crate::project::is_import_path(&package.path);
         let timeline = self.timeline.clone();
         let layout = cx.entity().clone();
         crate::components::timeline::audio_import::schedule_project_waveform_restore(
-            &project, root, timeline, layout, cx,
+            &project,
+            root,
+            persist_peaks,
+            timeline,
+            layout,
+            cx,
         );
     }
 

--- a/crates/SphereUIComponents/src/project/import/cubase_xml.rs
+++ b/crates/SphereUIComponents/src/project/import/cubase_xml.rs
@@ -16,9 +16,14 @@
 //! | `MAudioEvent` | one audio clip: position, length, offset, event gain |
 //! | `FNPath` / `AudioFile` | the media file, its rate, frames and channels |
 //!
-//! Everything else — mixer state, inserts, automation, hit points — is either
-//! Cubase-specific binary or has no Futureboard equivalent, so it is skipped
-//! rather than guessed at.
+//! Event `Volume` is renormalized so Cubase's info-line 0.00 dB (stored as
+//! ~0.2927, not 1.0) becomes Futureboard gain 1.0. Mixer channel/insert state
+//! still lives in Cubase's opaque binary blob and is not guessed at.
+//!
+//! Track timebase (`MListNode/Domain/Type`) controls how `Start` is read:
+//! musical (`0`) uses PPQ ticks, sample / linear domains use arrangement
+//! samples. Event `Length` that matches the referenced file's frame count is
+//! always treated as samples so audio duration stays physical wall-time.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -38,6 +43,22 @@ use crate::project::{
 /// 206 BPM / 600 s arrangement is 2060 quarter notes, i.e. 480 units each —
 /// the same PPQN Cubase uses everywhere else.
 const TICKS_PER_QUARTER: f64 = 480.0;
+
+/// Cubase XML `MAudioEvent/Volume` at the info-line 0.00 dB default.
+///
+/// Steinberg does not store linear unity as `1.0` here — a freshly created
+/// stereo event writes this constant instead. Dividing through maps 0 dB to
+/// Futureboard clip gain `1.0` while preserving relative boosts/cuts.
+const CUBASE_EVENT_VOLUME_UNITY: f64 = 0.292_682_886_123_657_23;
+
+/// How a track measures event start positions (`MListNode/Domain`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrackTimebase {
+    /// Bars & beats — `Start` is PPQ ticks (`TICKS_PER_QUARTER` per beat).
+    Musical,
+    /// Linear / sample — `Start` is arrangement samples at the project rate.
+    Samples,
+}
 
 /// Directories under the archive's own folder that are searched for media
 /// before falling back to a recursive scan.
@@ -112,12 +133,14 @@ pub(super) fn import(path: &Path) -> Result<FutureboardProject, ProjectError> {
 
         let mut clips = Vec::new();
         if let Some(node) = node {
+            let timebase = track_timebase(node);
             for event in archive.list_objects(node, "Events", "MAudioEvent") {
                 if let Some(clip) = audio_clip(
                     &archive,
                     event,
                     &tempo,
                     sample_rate,
+                    timebase,
                     &mut media,
                     &mut assets,
                     &mut project.assets,
@@ -396,7 +419,12 @@ fn signature_points(archive: &Archive<'_, '_>) -> Vec<ProjectTimeSignaturePoint>
             if numerator == 0 || denominator == 0 {
                 return None;
             }
-            let beat = prim_f64(event, "Position").unwrap_or(0.0) / TICKS_PER_QUARTER;
+            // Archives write either `Position` (ticks) or `Start` (same units);
+            // prefer Position when both exist.
+            let ticks = prim_f64(event, "Position")
+                .or_else(|| prim_f64(event, "Start"))
+                .unwrap_or(0.0);
+            let beat = ticks / TICKS_PER_QUARTER;
             Some(ProjectTimeSignaturePoint {
                 id: new_id(),
                 beat: beat.max(0.0),
@@ -410,6 +438,44 @@ fn signature_points(archive: &Archive<'_, '_>) -> Vec<ProjectTimeSignaturePoint>
     points
 }
 
+/// Map Cubase's event `Volume` field onto Futureboard linear clip gain.
+fn cubase_event_gain(raw: f64) -> f32 {
+    if !raw.is_finite() || raw <= 0.0 {
+        return 1.0;
+    }
+    ((raw / CUBASE_EVENT_VOLUME_UNITY) as f32).clamp(0.0, 4.0)
+}
+
+/// Resolve a track's arrangement timebase from its list-node Domain.
+///
+/// Cubase: Musical → Start in beats/ticks, Linear → Start in seconds/samples.
+/// Type `0` plus a Tempo Track reference covers musical exports; Type `10`
+/// (sample period) covers linear. A Domain that embeds a tempo track without
+/// an explicit Type is also treated as musical.
+fn track_timebase(list_node: Node<'_, '_>) -> TrackTimebase {
+    let Some(domain) = list_node.children().find(|child| {
+        child.has_tag_name("member") && child.attribute("name") == Some("Domain")
+    }) else {
+        return TrackTimebase::Samples;
+    };
+    if let Some(kind) = prim_f64(domain, "Type") {
+        return match kind as i32 {
+            0 => TrackTimebase::Musical,
+            _ => TrackTimebase::Samples,
+        };
+    }
+    let musical = domain.children().any(|child| {
+        child.has_tag_name("obj")
+            && (child.attribute("class") == Some("MTempoTrackEvent")
+                || child.attribute("name") == Some("Tempo Track"))
+    });
+    if musical {
+        TrackTimebase::Musical
+    } else {
+        TrackTimebase::Samples
+    }
+}
+
 // ── Clips and media ──────────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
@@ -418,18 +484,35 @@ fn audio_clip(
     event: Node<'_, '_>,
     tempo: &TempoMap,
     sample_rate: u32,
+    timebase: TrackTimebase,
     media: &mut MediaResolver,
     assets: &mut HashMap<PathBuf, String>,
     project_assets: &mut Vec<ProjectAsset>,
     missing_media: &mut usize,
 ) -> Option<ProjectClip> {
     let rate = sample_rate.max(1) as f64;
-    // Event positions are in arrangement samples (an event's Length matches the
-    // referenced file's frame count exactly).
-    let start_seconds = prim_f64(event, "Start").unwrap_or(0.0).max(0.0) / rate;
-    let length_seconds = prim_f64(event, "Length").unwrap_or(0.0).max(0.0) / rate;
-    let offset_seconds = prim_f64(event, "Offset").unwrap_or(0.0).max(0.0) / rate;
-    let start_beat = tempo.seconds_to_beats(start_seconds);
+    let start_raw = prim_f64(event, "Start").unwrap_or(0.0).max(0.0);
+    let length_raw = prim_f64(event, "Length").unwrap_or(0.0).max(0.0);
+
+    // Start follows the track timebase. Length that describes audible media is
+    // in samples (it matches AudioFile/FrameCount on every clip in real
+    // archives) even when Start is musical PPQ.
+    let start_beat = match timebase {
+        TrackTimebase::Musical => start_raw / TICKS_PER_QUARTER,
+        TrackTimebase::Samples => tempo.seconds_to_beats(start_raw / rate),
+    };
+    let length_seconds = length_raw / rate;
+    if length_seconds <= 0.0 {
+        return None;
+    }
+    let start_seconds = match timebase {
+        TrackTimebase::Musical => {
+            // Invert the tempo map at start_beat for a wall-clock duration span.
+            // For a constant-tempo project this is start_beat * 60 / bpm.
+            beat_to_seconds(tempo, start_beat)
+        }
+        TrackTimebase::Samples => start_raw / rate,
+    };
     let end_beat = tempo.seconds_to_beats(start_seconds + length_seconds);
     let duration_beats = (end_beat - start_beat).max(0.0);
     if duration_beats <= 0.0 {
@@ -477,6 +560,20 @@ fn audio_clip(
         *missing_media += 1;
     }
 
+    // Source-domain offset: event Offset first, else AudioCluster/Segments.
+    let file_rate = file.sample_rate.unwrap_or(sample_rate).max(1) as f64;
+    let event_offset_samples = prim_f64(event, "Offset").unwrap_or(0.0).max(0.0);
+    let segment_offset_samples = clip_obj
+        .and_then(|clip| segment_source_offset(archive, clip))
+        .unwrap_or(0.0)
+        .max(0.0);
+    let offset_samples = if event_offset_samples > 0.0 {
+        event_offset_samples
+    } else {
+        segment_offset_samples
+    };
+    let offset_seconds = offset_samples / file_rate;
+
     Some(ProjectClip {
         id: new_id(),
         name,
@@ -484,12 +581,26 @@ fn audio_clip(
         duration_beats,
         // Beat-domain offset into the source, same conversion as the position.
         offset_beats: (tempo.seconds_to_beats(offset_seconds) - tempo.seconds_to_beats(0.0)) as f32,
-        // Cubase's per-event volume is a linear gain, like ours.
-        gain: prim_f64(event, "Volume").unwrap_or(1.0).clamp(0.0, 4.0) as f32,
+        // Cubase's default 0 dB is ~0.2927, not 1.0 — normalize first.
+        gain: cubase_event_gain(prim_f64(event, "Volume").unwrap_or(CUBASE_EVENT_VOLUME_UNITY)),
         muted: false,
         source,
         stretch: AudioClipStretchState::default(),
     })
+}
+
+/// Wall-clock seconds at `beat` according to the piecewise tempo map.
+fn beat_to_seconds(tempo: &TempoMap, beat: f64) -> f64 {
+    let mut current = tempo.points[0];
+    for point in &tempo.points {
+        if point.0 <= beat {
+            current = *point;
+        } else {
+            break;
+        }
+    }
+    let (at_beat, bpm, at_seconds) = current;
+    at_seconds + (beat - at_beat) * 60.0 / bpm
 }
 
 /// A media file referenced by a clip, with the format facts the archive already
@@ -513,11 +624,19 @@ impl MediaFile {
 }
 
 fn media_file(archive: &Archive<'_, '_>, clip: Node<'_, '_>) -> Option<MediaFile> {
-    let path_obj = archive.descendant_class(clip, "FNPath")?;
+    // Prefer the clip's own FNPath / AudioCluster children. A deep walk would
+    // otherwise burn the hit-point list (often thousands of MHitPointEvent
+    // nodes) before finding the path, and the walk cap can skip the media.
+    let path_obj = archive
+        .child_class(clip, "FNPath")
+        .or_else(|| archive.descendant_class(clip, "FNPath"))?;
     let file_name = prim_str(path_obj, "Name")?.to_string();
     let recorded_dir = prim_str(path_obj, "Path").unwrap_or("");
 
-    let audio_file = archive.descendant_class(clip, "AudioFile");
+    let audio_file = archive
+        .child_class(clip, "AudioCluster")
+        .and_then(|cluster| archive.descendant_class(cluster, "AudioFile"))
+        .or_else(|| archive.descendant_class(clip, "AudioFile"));
     let sample_rate = audio_file
         .and_then(|file| prim_f64(file, "Rate"))
         .filter(|rate| *rate > 0.0)
@@ -535,6 +654,18 @@ fn media_file(archive: &Archive<'_, '_>, clip: Node<'_, '_>) -> Option<MediaFile
         channels,
         frames,
     })
+}
+
+/// Sample offset into the source from `AudioCluster/Segments[0]/Offset`.
+fn segment_source_offset(archive: &Archive<'_, '_>, clip: Node<'_, '_>) -> Option<f64> {
+    let cluster = archive.child_class(clip, "AudioCluster")?;
+    let segments = cluster.children().find(|child| {
+        child.has_tag_name("list") && child.attribute("name") == Some("Segments")
+    })?;
+    let first = segments
+        .children()
+        .find(|child| child.has_tag_name("item") || child.has_tag_name("obj"))?;
+    prim_f64(first, "Offset")
 }
 
 /// `SpeakerArr/Type` lists one entry per channel.
@@ -642,6 +773,7 @@ mod tests {
       <obj class="MListNode" name="Node" ID="11">
          <string name="Name" value="KICK" wide="true"/>
          <member name="Domain">
+            <int name="Type" value="0"/>
             <obj class="MTempoTrackEvent" name="Tempo Track" ID="12">
                <list name="TempoEvent" type="obj">
                   <obj class="MTempoEvent" ID="13">
@@ -662,7 +794,8 @@ mod tests {
          </member>
          <list name="Events" type="obj">
             <obj class="MAudioEvent" ID="16">
-               <float name="Start" value="88200"/>
+               <!-- Musical Start: 4 beats * 480 PPQ. Length stays samples. -->
+               <float name="Start" value="1920"/>
                <float name="Length" value="44100"/>
                <float name="Volume" value="0.5"/>
                <string name="Description" value="Kick take" wide="true"/>
@@ -736,7 +869,7 @@ mod tests {
 
         let clip = &track.clips[0];
         assert_eq!(clip.name, "Kick take");
-        // 88200 samples at 44.1 kHz = 2 s = 4 beats at 120 BPM.
+        // Musical Start=1920 PPQ → 4 beats. Length=44100 samples → 1 s → 2 beats @120.
         assert!(
             (clip.start_beat - 4.0).abs() < 1e-6,
             "start {}",
@@ -747,7 +880,12 @@ mod tests {
             "duration {}",
             clip.duration_beats
         );
-        assert!((clip.gain - 0.5).abs() < 1e-6);
+        // Fixture Volume=0.5 → relative to Cubase 0 dB unity (~0.2927) ≈ 1.708.
+        assert!(
+            (clip.gain - cubase_event_gain(0.5)).abs() < 1e-5,
+            "gain {}",
+            clip.gain
+        );
 
         fs::remove_dir_all(&dir).ok();
     }
@@ -787,6 +925,99 @@ mod tests {
     }
 
     #[test]
+    fn cubase_default_event_volume_maps_to_unity_gain() {
+        assert!((cubase_event_gain(CUBASE_EVENT_VOLUME_UNITY) - 1.0).abs() < 1e-5);
+        assert!((cubase_event_gain(0.0) - 1.0).abs() < 1e-5);
+        // ≈ +7.82 dB relative boost still lands inside our 4.0 clamp.
+        let boosted = cubase_event_gain(0.720_092_95);
+        assert!(boosted > 2.0 && boosted < 3.0, "boosted={boosted}");
+    }
+
+    #[test]
+    fn musical_start_is_ppq_not_samples() {
+        // Minimal musical-track event: Start=251520 ticks → 524 beats, Length is
+        // still samples so duration stays 26.5 s (= 91 beats @206 BPM).
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<tracklist>
+   <obj class="PArrangeSetup" name="Setup" ID="1">
+      <float name="SampleRate" value="44100"/>
+   </obj>
+   <obj class="MAudioTrackEvent" ID="10">
+      <obj class="MListNode" name="Node" ID="11">
+         <string name="Name" value="GTSOLO" wide="true"/>
+         <member name="Domain">
+            <int name="Type" value="0"/>
+            <obj class="MTempoTrackEvent" name="Tempo Track" ID="12">
+               <list name="TempoEvent" type="obj">
+                  <obj class="MTempoEvent" ID="13">
+                     <float name="BPM" value="206"/>
+                     <float name="PPQ" value="0"/>
+                  </obj>
+               </list>
+            </obj>
+         </member>
+         <list name="Events" type="obj">
+            <obj class="MAudioEvent" ID="16">
+               <float name="Start" value="251520"/>
+               <float name="Length" value="1168864"/>
+               <float name="Volume" value="0.29268288612365723"/>
+               <string name="Description" value="GT2" wide="true"/>
+               <obj class="PAudioClip" name="AudioClip" ID="17">
+                  <string name="Name" value="GT2" wide="true"/>
+                  <obj class="FNPath" name="Path" ID="18">
+                     <string name="Name" value="kick.wav" wide="true"/>
+                     <string name="Path" value="C:\Somewhere\Else\Audio\" wide="true"/>
+                  </obj>
+                  <obj class="AudioCluster" name="Cluster" ID="19">
+                     <list name="Substreams" type="obj">
+                        <obj class="AudioFile" ID="20">
+                           <obj name="FPath" ID="18"/>
+                           <int name="FrameCount" value="1168864"/>
+                           <member name="SpeakerArr">
+                              <list name="Type" type="int">
+                                 <item value="1"/>
+                                 <item value="2"/>
+                              </list>
+                           </member>
+                           <float name="Rate" value="44100"/>
+                        </obj>
+                     </list>
+                  </obj>
+               </obj>
+            </obj>
+         </list>
+      </obj>
+   </obj>
+</tracklist>
+"#;
+        let dir = std::env::temp_dir().join(format!(
+            "fb_cubase_musical_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        fs::create_dir_all(dir.join("Audio")).unwrap();
+        fs::write(dir.join("Audio/kick.wav"), b"RIFF").unwrap();
+        let path = dir.join("Song.xml");
+        fs::write(&path, xml).unwrap();
+        let project = import(&path).unwrap();
+        let clip = &project.tracks[0].clips[0];
+        assert!(
+            (clip.start_beat - 524.0).abs() < 1e-6,
+            "start {}",
+            clip.start_beat
+        );
+        assert!(
+            (clip.duration_beats - 91.0).abs() < 1e-3,
+            "duration {}",
+            clip.duration_beats
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn archive_without_audio_tracks_is_rejected() {
         let dir = archive_dir("empty");
         let path = dir.join("Empty.xml");
@@ -796,5 +1027,50 @@ mod tests {
         assert!(matches!(error, ProjectError::Corrupted(_)), "got {error:?}");
 
         fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Local ad-hoc dump against the real NIKKE archive (not run in CI).
+    #[test]
+    #[ignore = "requires local /home/arizkami/Downloads/Nikke1/NIKKE.xml"]
+    fn dump_nikke_archive() {
+        let path = PathBuf::from("/home/arizkami/Downloads/Nikke1/NIKKE.xml");
+        let project = import(&path).expect("import");
+        eprintln!(
+            "nikke: tracks={} bpm={} sr={} sig={}/{} tempo_pts={} assets={} missing_check_paths={}",
+            project.tracks.len(),
+            project.settings.bpm,
+            project.settings.sample_rate,
+            project.settings.time_sig_num,
+            project.settings.time_sig_den,
+            project.settings.tempo_points.len(),
+            project.assets.len(),
+            project
+                .assets
+                .iter()
+                .filter(|a| a
+                    .absolute_path
+                    .as_ref()
+                    .map(|p| !p.is_file())
+                    .unwrap_or(true))
+                .count(),
+        );
+        for track in &project.tracks {
+            let clip = track.clips.first();
+            eprintln!(
+                "  track='{}' clips={} first_start={:?} first_dur={:?} gain={:?} source={:?}",
+                track.name,
+                track.clips.len(),
+                clip.map(|c| c.start_beat),
+                clip.map(|c| c.duration_beats),
+                clip.map(|c| c.gain),
+                clip.map(|c| match &c.source {
+                    ClipSource::Audio { source_path, .. } => source_path
+                        .as_ref()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_default(),
+                    _ => String::new(),
+                }),
+            );
+        }
     }
 }

--- a/crates/SphereUIComponents/src/project/mod.rs
+++ b/crates/SphereUIComponents/src/project/mod.rs
@@ -1464,7 +1464,15 @@ pub fn apply_to_timeline(project: &FutureboardProject, tl: &mut TimelineState) {
                         name: pc.name.clone(),
                         start_beat: pc.start_beat as f32,
                         duration_beats: pc.duration_beats as f32,
-                        source_duration_seconds: None,
+                        source_duration_seconds: match &pc.source {
+                            ClipSource::Audio { asset_id, .. }
+                            | ClipSource::Rauf { asset_id, .. } => project
+                                .assets
+                                .iter()
+                                .find(|asset| asset.id == *asset_id)
+                                .and_then(|asset| asset.duration_secs),
+                            _ => None,
+                        },
                         offset_beats: pc.offset_beats,
                         gain: pc.gain,
                         clip_type,


### PR DESCRIPTION
## Summary
- Improve Cubase/Nuendo XML import handling (timebase/volume/offset + media resolution) and clip duration/source metadata.
- Fix waveform restore path resolution + avoid persisting peaks for untitled imports.
- Ensure built-in insert editor/parameter sync correctly includes the master track inserts.

## Test plan
- 


Made with [Cursor](https://cursor.com)