### PR TITLE
Fix Linux export, plugin restore, and MP3 encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,10 @@ sphere-audio-processor = { path = "crates/SphereAudioProcessor" }
 sphere-stem-extractor = { path = "crates/SphereStemExtractor", package = "SphereFBStemExtractor" }
 sphere-audio-editor = { path = "crates/SphereAudioEditor" }
 sphere-audio-plugins = { path = "crates/SphereAudioPlugins" }
-sphere-encoder = { path = "crates/SphereEncoder" }
+# MP3 is optional in sphere-encoder (needs libmp3lame via mp3lame-sys). Enable
+# it for Studio export so `mp3_available()` is true on Linux/macOS/Windows
+# builds that have a C toolchain — which every supported Studio build has.
+sphere-encoder = { path = "crates/SphereEncoder", features = ["mp3"] }
 sphere-graphic-engine = { path = "crates/SphereGraphicEngine" }
 sphere-midi-service = { path = "crates/SphereMidiService", package = "SphereMidiService" }
 sphere-plugin-host = { path = "crates/SpherePluginHost", default-features = false }

--- a/crates/SphereUIComponents/src/export/export_window.rs
+++ b/crates/SphereUIComponents/src/export/export_window.rs
@@ -27,11 +27,8 @@ use DirectAudio::{
 use crate::components::form::select::{select, SelectOption};
 use crate::components::progress_dialog::{progress_bar, ProgressBarValue};
 use crate::components::title_bar::external_window_titlebar_compact;
-#[cfg(target_os = "windows")]
 use crate::components::title_bar::TITLEBAR_HEIGHT;
 use crate::theme::{self, Colors};
-// `AppContext` (for `cx.new`) is only used by the Windows window-open path below.
-#[cfg(target_os = "windows")]
 use gpui::AppContext;
 
 use super::export_settings::{
@@ -1292,7 +1289,6 @@ fn open_in_file_manager(dir: &std::path::Path) -> std::io::Result<()> {
 // ── Opener ───────────────────────────────────────────────────────────────────
 
 /// Open the external Export Arrangement window centered over `owner_bounds`.
-#[cfg(target_os = "windows")]
 pub fn open_export_arrangement_window(
     owner_bounds: Option<Bounds<gpui::Pixels>>,
     project_name: String,
@@ -1335,18 +1331,4 @@ pub fn open_export_arrangement_window(
         })
     })
     .map_err(|e| e.to_string())
-}
-
-#[cfg(not(target_os = "windows"))]
-pub fn open_export_arrangement_window(
-    _owner_bounds: Option<Bounds<gpui::Pixels>>,
-    _project_name: String,
-    _snapshot: EngineProjectSnapshot,
-    _bridge_sinks: PluginBridgeSinkMap,
-    _audio_engine: Option<DirectAudio::AudioEngine>,
-    _defaults: ExportProjectDefaults,
-    _default_output: Option<PathBuf>,
-    _cx: &mut App,
-) -> Result<WindowHandle<ExportArrangementWindow>, String> {
-    Err("native export window is only available on Windows".to_string())
 }

--- a/crates/SphereUIComponents/src/layout/engine_snapshot.rs
+++ b/crates/SphereUIComponents/src/layout/engine_snapshot.rs
@@ -292,10 +292,13 @@ fn build_engine_inserts_for(
 ) -> Vec<EngineInsertSnapshot> {
     use crate::components::timeline::timeline_state::InsertPluginFormat;
 
-    // Offline export always renders plugins in-process (the live out-of-process
-    // bridge has no host attached to the isolated offline graph), so it skips the
-    // bridge branch and carries each insert's saved VST3 state for restore.
-    if !export_mode && super::plugin_bridge_runtime::bridge_enabled() {
+    // When the external bridge is active, live inserts (VST3 + built-in) are
+    // `external-bridge-plugin` descriptors processed through realtime bridge
+    // sinks. Offline export detaches those sinks and drives them from the
+    // export worker (`export_window::BridgeSinkHandoff`), so the export snapshot
+    // must keep the same insert kinds — not rebuild as in-process `native-plugin`
+    // inserts (which would bypass the live DSP and render dry/raw audio).
+    if super::plugin_bridge_runtime::bridge_enabled() {
         return slots
             .iter()
             .enumerate()
@@ -581,11 +584,11 @@ pub(crate) fn build_engine_project_snapshot(
     )
 }
 
-/// Offline-export snapshot: plugin inserts are forced in-process and carry their
-/// saved VST3 state so the isolated offline graph renders instruments/effects the
-/// out-of-process bridge would otherwise own. `pdc_enabled` / `latency_graph_version`
-/// are stamped from the live engine so the offline render uses the *same*
-/// latency-compensated graph as playback. See `export_ops` / `offline_renderer`.
+/// Offline-export snapshot: when the external bridge is active, inserts mirror
+/// the live bridge graph so export can drive the detached realtime bridge sinks.
+/// Legacy in-process export (bridge off) carries saved VST3 state instead.
+/// `pdc_enabled` / `latency_graph_version` are stamped from the live engine so the
+/// offline render uses the *same* latency-compensated graph as playback.
 pub(super) fn build_engine_project_snapshot_for_export(
     state: &TimelineState,
     sample_rate: u32,
@@ -1006,6 +1009,7 @@ mod tests {
     use super::*;
     use crate::components::edit::EditCommand;
     use crate::components::timeline::timeline_state::{CreateTrackOptions, MidiControllerKind};
+    use crate::layout::plugin_bridge_runtime;
 
     fn instrument_state_with_clip() -> (TimelineState, String) {
         let mut state = TimelineState::default();
@@ -1751,7 +1755,7 @@ mod tests {
     }
 
     #[test]
-    fn export_snapshot_forces_in_process_inserts_and_carries_state() {
+    fn export_snapshot_uses_bridge_inserts_when_bridge_enabled() {
         use crate::components::timeline::timeline_state::InsertPluginFormat;
 
         let mut state = TimelineState::default();
@@ -1780,8 +1784,6 @@ mod tests {
             None,
             "Plugin A".to_string(),
         );
-        // Stamp a saved-state blob the way refresh_bridge_plugin_states does
-        // before an export.
         let state_bytes = vec![9u8, 8, 7, 6];
         for track in &mut state.tracks {
             for ins in &mut track.inserts {
@@ -1791,25 +1793,36 @@ mod tests {
             }
         }
 
-        // Export snapshot: in-process kind + carried state, regardless of the
-        // live bridge setting.
-        let exported =
-            build_engine_project_snapshot_for_export(&state, 48_000, None, None, true, 0);
-        let insert = exported
-            .tracks
-            .iter()
-            .find(|t| t.id == track_id)
-            .and_then(|t| t.inserts.iter().find(|i| i.id == slot))
-            .expect("insert in export snapshot");
-        assert_eq!(
-            insert.kind, "native-plugin",
-            "export must force in-process inserts"
-        );
-        assert_eq!(
-            insert.state.as_deref(),
-            Some(state_bytes.as_slice()),
-            "export must carry the saved VST3 state"
-        );
+        if plugin_bridge_runtime::bridge_enabled() {
+            let exported =
+                build_engine_project_snapshot_for_export(&state, 48_000, None, None, true, 0);
+            let insert = exported
+                .tracks
+                .iter()
+                .find(|t| t.id == track_id)
+                .and_then(|t| t.inserts.iter().find(|i| i.id == slot))
+                .expect("insert in export snapshot");
+            assert_eq!(
+                insert.kind,
+                "external-bridge-plugin",
+                "export must mirror live bridge inserts so offline render can drive bridge sinks"
+            );
+            assert!(
+                insert.state.is_none(),
+                "bridge-owned inserts do not carry in-process restore blobs"
+            );
+        } else {
+            let exported =
+                build_engine_project_snapshot_for_export(&state, 48_000, None, None, true, 0);
+            let insert = exported
+                .tracks
+                .iter()
+                .find(|t| t.id == track_id)
+                .and_then(|t| t.inserts.iter().find(|i| i.id == slot))
+                .expect("insert in export snapshot");
+            assert_eq!(insert.kind, "native-plugin");
+            assert_eq!(insert.state.as_deref(), Some(state_bytes.as_slice()));
+        }
 
         // Live snapshot never carries the export state (bridged host owns restore).
         let live = build_engine_project_snapshot(&state, 48_000, None, None);

--- a/crates/SphereUIComponents/src/layout/export_ops.rs
+++ b/crates/SphereUIComponents/src/layout/export_ops.rs
@@ -60,9 +60,9 @@ impl StudioLayout {
             .as_ref()
             .map(|engine| engine.plugin_bridge_sinks())
             .unwrap_or_default();
-        // Export renders plugins in-process from the saved VST3 state captured by
-        // refresh_bridge_plugin_states above — the isolated offline graph has no
-        // out-of-process bridge host attached.
+        // Export detaches the live bridge sinks and drives them from the offline
+        // worker; the snapshot must keep external-bridge inserts (not in-process
+        // native-plugin stubs) so effects/built-ins render through the real DSP.
         let snapshot = build_engine_project_snapshot_for_export(
             &tl_state,
             sample_rate,

--- a/crates/SphereUIComponents/src/layout/plugin_restore.rs
+++ b/crates/SphereUIComponents/src/layout/plugin_restore.rs
@@ -456,12 +456,18 @@ fn target_from_slot(
     slot: &crate::components::timeline::timeline_state::InsertSlotState,
     is_instrument: bool,
 ) -> Option<PluginRestoreTarget> {
-    if slot.plugin_format != Some(InsertPluginFormat::Vst3) {
-        return None;
-    }
-    let path = slot.plugin_path.as_ref()?;
-    if path.as_os_str().is_empty() {
-        return None;
+    let is_builtin = slot
+        .plugin_id
+        .as_deref()
+        .is_some_and(SpherePluginHost::builtin_audio_bridge_supported);
+    if !is_builtin {
+        if slot.plugin_format != Some(InsertPluginFormat::Vst3) {
+            return None;
+        }
+        let path = slot.plugin_path.as_ref()?;
+        if path.as_os_str().is_empty() {
+            return None;
+        }
     }
     Some(PluginRestoreTarget {
         track_id: track_id.to_string(),

--- a/crates/SphereUIComponents/src/pre_studio_install.rs
+++ b/crates/SphereUIComponents/src/pre_studio_install.rs
@@ -206,12 +206,18 @@ fn target_from_slot(
     slot: &crate::components::timeline::timeline_state::InsertSlotState,
     _is_instrument: bool,
 ) -> Option<RestoreTarget> {
-    if slot.plugin_format != Some(InsertPluginFormat::Vst3) {
-        return None;
-    }
-    let path = slot.plugin_path.as_ref()?;
-    if path.as_os_str().is_empty() {
-        return None;
+    let is_builtin = slot
+        .plugin_id
+        .as_deref()
+        .is_some_and(SpherePluginHost::builtin_audio_bridge_supported);
+    if !is_builtin {
+        if slot.plugin_format != Some(InsertPluginFormat::Vst3) {
+            return None;
+        }
+        let path = slot.plugin_path.as_ref()?;
+        if path.as_os_str().is_empty() {
+            return None;
+        }
     }
     Some(RestoreTarget {
         track_id: track_id.to_string(),
@@ -240,7 +246,11 @@ fn restore_bridge_target(
         return RestoreOutcome::Failed;
     };
 
-    if !slot.plugin_path.as_ref().is_some_and(|p| p.exists()) {
+    let is_builtin = slot
+        .plugin_id
+        .as_deref()
+        .is_some_and(SpherePluginHost::builtin_audio_bridge_supported);
+    if !is_builtin && !slot.plugin_path.as_ref().is_some_and(|p| p.exists()) {
         let reason = slot
             .plugin_path
             .as_ref()
@@ -259,9 +269,8 @@ fn restore_bridge_target(
     let path_string = slot
         .plugin_path
         .as_ref()
-        .unwrap()
-        .to_string_lossy()
-        .into_owned();
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_default();
     let descriptor = BridgePluginDescriptor {
         track_id: target.track_id.clone(),
         insert_id: target.slot_id.clone(),
@@ -281,7 +290,16 @@ fn restore_bridge_target(
         PluginRuntimeState::Loading,
         host_pid,
     );
-    if let Err(error) = bridge.send_load_plugin(descriptor, sample_rate, max_block_size) {
+    let load_result = if is_builtin {
+        let state_json = slot
+            .vst3_state
+            .as_deref()
+            .and_then(|bytes| String::from_utf8(bytes.to_vec()).ok());
+        bridge.send_load_builtin_plugin(descriptor, sample_rate, max_block_size, state_json)
+    } else {
+        bridge.send_load_plugin(descriptor, sample_rate, max_block_size)
+    };
+    if let Err(error) = load_result {
         timeline_state.set_insert_runtime(
             &target.track_id,
             &target.slot_id,
@@ -291,8 +309,10 @@ fn restore_bridge_target(
         );
         return RestoreOutcome::Failed;
     }
-    if let Some(state) = slot.vst3_state.as_ref() {
-        let _ = bridge.send_plugin_state(&target.slot_id, state);
+    if !is_builtin {
+        if let Some(state) = slot.vst3_state.as_ref() {
+            let _ = bridge.send_plugin_state(&target.slot_id, state);
+        }
     }
     drop(bridge);
     poll_bridge_events(runtime, timeline_state);


### PR DESCRIPTION
## Summary
- Enable the native Export Arrangement window on Linux/macOS (was Windows-only).
- Restore built-in inserts on project reopen via pre-studio and session restore paths.
- Make export snapshots use live bridge inserts so effects render instead of dry/raw audio.
- Enable `sphere-encoder` MP3 feature for Studio builds so MP3 export is available.

## Test plan
- [x] Open Export Arrangement on Linux and complete a WAV mixdown
- [x] Export MP3 and confirm the option is enabled and encodes successfully
- [x] Add a built-in effect, save, close, reopen — effect still processes audio
- [x] Export a mix with built-in/bridged effects and confirm FX are present in the file
- [x] `cargo check -p sphere_ui_components`
- [x] `cargo test -p sphere_ui_components export_snapshot_uses_bridge_inserts_when_bridge_enabled`
- [x] `cargo test -p sphere-encoder encodes_stereo_44k_nonempty_with_mp3_sync`

Made with [Cursor](https://cursor.com)