### PR TITLE
Fix bridge audio_in race that tore wet blocks in live and export.

### DIFF
--- a/crates/SphereDirectAudioEngine/src/engine.rs
+++ b/crates/SphereDirectAudioEngine/src/engine.rs
@@ -5437,12 +5437,16 @@ mod bridge_insert_tests {
 
     #[test]
     fn serial_bridge_effect_chain_applies_both_gains() {
+        // Models the real one-block handshake: read previous wet → write next
+        // dry → request (which processes written dry into the next wet).
         #[derive(Debug)]
         struct MultSink {
             mult: f32,
-            done: AtomicU64,
-            buf_l: std::sync::Mutex<Vec<f32>>,
-            buf_r: std::sync::Mutex<Vec<f32>>,
+            fresh: AtomicU64,
+            in_l: std::sync::Mutex<Vec<f32>>,
+            in_r: std::sync::Mutex<Vec<f32>>,
+            out_l: std::sync::Mutex<Vec<f32>>,
+            out_r: std::sync::Mutex<Vec<f32>>,
         }
 
         impl PluginBridgeSink for MultSink {
@@ -5450,28 +5454,34 @@ mod bridge_insert_tests {
                 true
             }
             fn read_output(&self, out_l: &mut [f32], out_r: &mut [f32], frames: usize) -> usize {
-                let done = self.done.load(Ordering::Acquire);
-                if done == 0 {
+                if self.fresh.swap(0, Ordering::AcqRel) == 0 {
                     return 0;
                 }
-                self.done.store(0, Ordering::Release);
-                let bl = self.buf_l.lock().unwrap();
-                let br = self.buf_r.lock().unwrap();
+                let bl = self.out_l.lock().unwrap();
+                let br = self.out_r.lock().unwrap();
                 let n = frames.min(out_l.len()).min(out_r.len()).min(bl.len());
-                for i in 0..n {
-                    out_l[i] = bl[i] * self.mult;
-                    out_r[i] = br[i] * self.mult;
-                }
+                out_l[..n].copy_from_slice(&bl[..n]);
+                out_r[..n].copy_from_slice(&br[..n]);
                 n
             }
             fn push_midi(&self, _: u8, _: u8, _: u8, _: u32) {}
             fn write_input(&self, in_l: &[f32], in_r: &[f32], frames: usize) {
                 let n = frames.min(in_l.len()).min(in_r.len());
-                *self.buf_l.lock().unwrap() = in_l[..n].to_vec();
-                *self.buf_r.lock().unwrap() = in_r[..n].to_vec();
+                *self.in_l.lock().unwrap() = in_l[..n].to_vec();
+                *self.in_r.lock().unwrap() = in_r[..n].to_vec();
             }
             fn request_block(&self, _: u32) {
-                self.done.store(1, Ordering::Release);
+                let inl = self.in_l.lock().unwrap();
+                let inr = self.in_r.lock().unwrap();
+                let mut outl = self.out_l.lock().unwrap();
+                let mut outr = self.out_r.lock().unwrap();
+                outl.resize(inl.len(), 0.0);
+                outr.resize(inr.len(), 0.0);
+                for i in 0..inl.len() {
+                    outl[i] = inl[i] * self.mult;
+                    outr[i] = inr[i] * self.mult;
+                }
+                self.fresh.store(1, Ordering::Release);
             }
         }
 
@@ -5518,17 +5528,22 @@ mod bridge_insert_tests {
             smoothed_gain_l: 1.0,
             smoothed_gain_r: 1.0,
         };
+        // Pre-seed previous-cycle wet so the first read applies A×2 then B×3.
         let sink_a = Arc::new(MultSink {
             mult: 2.0,
-            done: AtomicU64::new(1),
-            buf_l: std::sync::Mutex::new(vec![0.0; 8]),
-            buf_r: std::sync::Mutex::new(vec![0.0; 8]),
+            fresh: AtomicU64::new(1),
+            in_l: std::sync::Mutex::new(vec![0.0; 8]),
+            in_r: std::sync::Mutex::new(vec![0.0; 8]),
+            out_l: std::sync::Mutex::new(vec![2.0; 8]),
+            out_r: std::sync::Mutex::new(vec![2.0; 8]),
         });
         let sink_b = Arc::new(MultSink {
             mult: 3.0,
-            done: AtomicU64::new(1),
-            buf_l: std::sync::Mutex::new(vec![0.0; 8]),
-            buf_r: std::sync::Mutex::new(vec![0.0; 8]),
+            fresh: AtomicU64::new(1),
+            in_l: std::sync::Mutex::new(vec![0.0; 8]),
+            in_r: std::sync::Mutex::new(vec![0.0; 8]),
+            out_l: std::sync::Mutex::new(vec![6.0; 8]),
+            out_r: std::sync::Mutex::new(vec![6.0; 8]),
         });
         track.inserts[0].bridge_sink = Some(sink_a as Arc<dyn PluginBridgeSink>);
         track.inserts[1].bridge_sink = Some(sink_b as Arc<dyn PluginBridgeSink>);
@@ -5545,9 +5560,11 @@ mod bridge_insert_tests {
         #[derive(Debug)]
         struct MultSink {
             mult: f32,
-            done: AtomicU64,
-            buf_l: std::sync::Mutex<Vec<f32>>,
-            buf_r: std::sync::Mutex<Vec<f32>>,
+            fresh: AtomicU64,
+            in_l: std::sync::Mutex<Vec<f32>>,
+            in_r: std::sync::Mutex<Vec<f32>>,
+            out_l: std::sync::Mutex<Vec<f32>>,
+            out_r: std::sync::Mutex<Vec<f32>>,
         }
 
         impl PluginBridgeSink for MultSink {
@@ -5555,28 +5572,34 @@ mod bridge_insert_tests {
                 true
             }
             fn read_output(&self, out_l: &mut [f32], out_r: &mut [f32], frames: usize) -> usize {
-                let done = self.done.load(Ordering::Acquire);
-                if done == 0 {
+                if self.fresh.swap(0, Ordering::AcqRel) == 0 {
                     return 0;
                 }
-                self.done.store(0, Ordering::Release);
-                let bl = self.buf_l.lock().unwrap();
-                let br = self.buf_r.lock().unwrap();
+                let bl = self.out_l.lock().unwrap();
+                let br = self.out_r.lock().unwrap();
                 let n = frames.min(out_l.len()).min(out_r.len()).min(bl.len());
-                for i in 0..n {
-                    out_l[i] = bl[i] * self.mult;
-                    out_r[i] = br[i] * self.mult;
-                }
+                out_l[..n].copy_from_slice(&bl[..n]);
+                out_r[..n].copy_from_slice(&br[..n]);
                 n
             }
             fn push_midi(&self, _: u8, _: u8, _: u8, _: u32) {}
             fn write_input(&self, in_l: &[f32], in_r: &[f32], frames: usize) {
                 let n = frames.min(in_l.len()).min(in_r.len());
-                *self.buf_l.lock().unwrap() = in_l[..n].to_vec();
-                *self.buf_r.lock().unwrap() = in_r[..n].to_vec();
+                *self.in_l.lock().unwrap() = in_l[..n].to_vec();
+                *self.in_r.lock().unwrap() = in_r[..n].to_vec();
             }
             fn request_block(&self, _: u32) {
-                self.done.store(1, Ordering::Release);
+                let inl = self.in_l.lock().unwrap();
+                let inr = self.in_r.lock().unwrap();
+                let mut outl = self.out_l.lock().unwrap();
+                let mut outr = self.out_r.lock().unwrap();
+                outl.resize(inl.len(), 0.0);
+                outr.resize(inr.len(), 0.0);
+                for i in 0..inl.len() {
+                    outl[i] = inl[i] * self.mult;
+                    outr[i] = inr[i] * self.mult;
+                }
+                self.fresh.store(1, Ordering::Release);
             }
         }
 
@@ -5641,16 +5664,20 @@ mod bridge_insert_tests {
         };
         let sink_a = Arc::new(MultSink {
             mult: 2.0,
-            done: AtomicU64::new(1),
-            buf_l: std::sync::Mutex::new(vec![0.0; 8]),
-            buf_r: std::sync::Mutex::new(vec![0.0; 8]),
+            fresh: AtomicU64::new(1),
+            in_l: std::sync::Mutex::new(vec![0.0; 8]),
+            in_r: std::sync::Mutex::new(vec![0.0; 8]),
+            out_l: std::sync::Mutex::new(vec![2.0; 8]),
+            out_r: std::sync::Mutex::new(vec![2.0; 8]),
         });
         let sink_b = Arc::new(MissSink);
         let sink_c = Arc::new(MultSink {
             mult: 5.0,
-            done: AtomicU64::new(1),
-            buf_l: std::sync::Mutex::new(vec![0.0; 8]),
-            buf_r: std::sync::Mutex::new(vec![0.0; 8]),
+            fresh: AtomicU64::new(1),
+            in_l: std::sync::Mutex::new(vec![0.0; 8]),
+            in_r: std::sync::Mutex::new(vec![0.0; 8]),
+            out_l: std::sync::Mutex::new(vec![10.0; 8]),
+            out_r: std::sync::Mutex::new(vec![10.0; 8]),
         });
         track.inserts[0].bridge_sink = Some(sink_a as Arc<dyn PluginBridgeSink>);
         track.inserts[1].bridge_sink = Some(sink_b as Arc<dyn PluginBridgeSink>);

--- a/crates/SphereDirectAudioEngine/src/engine/render.rs
+++ b/crates/SphereDirectAudioEngine/src/engine/render.rs
@@ -1654,14 +1654,21 @@ pub(crate) fn apply_external_bridge_insert_block(
     // `params["role"]` resolved at build time — no params-map read per block.
     let is_effect = insert.bridge_is_effect;
 
-    if is_effect {
-        sink.write_input(&block_l[..frames], &block_r[..frames], frames);
-    }
-
     if insert.scratch_l.len() < frames {
         insert.scratch_l.resize(frames, 0.0);
         insert.scratch_r.resize(frames, 0.0);
     }
+
+    // One-block handshake ownership (critical):
+    //   1. read previous wet  — proves the host finished the last cycle and
+    //      released `audio_in` (it copies input before publishing `done_seq`);
+    //   2. write next dry     — only now is overwriting `audio_in` safe;
+    //   3. apply wet to block;
+    //   4. request next       — host may read `audio_in` after this.
+    // The old write→read→request order raced the host on the single `audio_in`
+    // buffer. Offline export almost always lost that race (near-zero gap between
+    // request and the next write), tearing wet blocks into stutter / overlap.
+    // Live hits the same bug whenever the host overruns the device period.
     let got = if insert.vsti_output_children.is_empty() {
         // Default single-track path (unchanged): fold the selected channels into
         // this track's stereo.
@@ -1688,6 +1695,11 @@ pub(crate) fn apply_external_bridge_insert_block(
         insert.scratch_r[..got].fill(0.0);
         got
     };
+
+    if is_effect {
+        // Current dry (pre-apply). Host will process this after `request_block`.
+        sink.write_input(&block_l[..frames], &block_r[..frames], frames);
+    }
 
     // Multi-out diagnostic: which plugin output channels actually carry signal
     // this block, and which the engine is folding. Tells separate-out silence

--- a/crates/SphereDirectAudioEngine/src/export/offline_renderer.rs
+++ b/crates/SphereDirectAudioEngine/src/export/offline_renderer.rs
@@ -263,11 +263,15 @@ fn render_offline_impl(
             })
             .collect();
         runtime.resolve_bridge_sinks();
-        // Prime the bridge's one-block pipeline. The first rendered block
-        // consumes this silent/stale response and requests the first timeline
-        // block, matching realtime's one-block bridge latency (covered by PDC).
+        // Prime the bridge's one-block pipeline with silence so the host does
+        // not process leftover realtime `audio_in`. The first rendered block
+        // consumes this silent response and requests the first timeline block,
+        // matching realtime's one-block bridge latency (covered by PDC).
+        let prime_frames = request.block_size.max(1);
+        let zeros = vec![0.0f32; prime_frames];
         for sink in runtime.plugin_bridge_sinks.values() {
-            sink.request_block(request.block_size.max(1) as u32);
+            sink.write_input(&zeros, &zeros, prime_frames);
+            sink.request_block(prime_frames as u32);
         }
     }
     // Deterministic bounce: apply the exact constant per-block fader gain, never
@@ -441,6 +445,7 @@ fn render_offline_impl(
         }
         let frames_u64 = frames as u64;
         let block_end = produced.saturating_add(frames_u64);
+        let mut stop_for_silence = false;
 
         // Emit only the portion that lands in [write_start, write_limit). Full
         // blocks may straddle warmup→content or content→tail; we slice here
@@ -483,17 +488,18 @@ fn render_offline_impl(
             }
             written = written.saturating_add(emit_len as u64);
 
-            // UntilSilence: stop after this block once content is done and the
-            // emitted peak has decayed below threshold.
+            // UntilSilence: stop once content is done and the emitted peak has
+            // decayed below threshold.
             if produced >= content_end && until_silence && block_peak < silence_threshold {
-                produced = produced.saturating_add(frames_u64);
-                pos = pos.saturating_add(frames_u64);
-                break;
+                stop_for_silence = true;
             }
         }
 
         produced = produced.saturating_add(frames_u64);
         pos = pos.saturating_add(frames_u64);
+        if stop_for_silence {
+            break;
+        }
 
         // Throttle progress callbacks (~ every 16 blocks) to avoid flooding.
         progress_throttle = progress_throttle.wrapping_add(1);

--- a/crates/SphereDirectAudioEngine/src/plugin_bridge.rs
+++ b/crates/SphereDirectAudioEngine/src/plugin_bridge.rs
@@ -91,7 +91,10 @@ pub trait PluginBridgeSink: Send + Sync + std::fmt::Debug {
     fn push_param(&self, _param_id: u32, _value: f32, _sample_offset: u32) {}
 
     /// Write the track's pre-plugin stereo input for effect inserts (engine →
-    /// host `audio_in`). Wait-free raw buffer copy.
+    /// host `audio_in`). Must be called only after a successful
+    /// [`Self::read_output`] for the previous cycle (or when no prior request is
+    /// outstanding) so the host is not still copying the last block. Wait-free
+    /// raw buffer copy.
     fn write_input(&self, in_l: &[f32], in_r: &[f32], frames: usize);
 
     /// Publish the request for the host to process `frames` next (sets the block

--- a/crates/SpherePluginHost/src/audio_bridge.rs
+++ b/crates/SpherePluginHost/src/audio_bridge.rs
@@ -450,6 +450,17 @@ impl SharedAudioBuffer {
                 *dst.add(i * 2 + 1) = in_r[i];
             }
         }
+        // Clear any leftover stereo frames so a later larger block_frames never
+        // re-reads a stale dry tail from a shorter write.
+        let clear_from = n * 2;
+        let clear_len = (MAX_BLOCK_FRAMES * 2).saturating_sub(clear_from).min(
+            AUDIO_BUF_LEN.saturating_sub(clear_from),
+        );
+        if clear_len > 0 {
+            unsafe {
+                std::ptr::write_bytes(dst.add(clear_from), 0, clear_len);
+            }
+        }
     }
 }
 

--- a/crates/SpherePluginHost/src/plugin_bridge_sink.rs
+++ b/crates/SpherePluginHost/src/plugin_bridge_sink.rs
@@ -262,7 +262,10 @@ impl PluginBridgeSink for SharedRegionSink {
     }
 
     fn write_input(&self, in_l: &[f32], in_r: &[f32], frames: usize) {
-        // SAFETY: the engine owns `audio_in` for this block (before `request_seq`).
+        // SAFETY: the engine owns `audio_in` only after the host published
+        // `done_seq` for the previous request (consumed by `read_output` above
+        // in `apply_external_bridge_insert_block`) and before this side bumps
+        // `request_seq` again.
         unsafe {
             self.region
                 .bridge()


### PR DESCRIPTION
Read the previous host output before writing the next dry input so the single shared audio_in buffer is never overwritten while the host still copies it. Also prime offline with silence and clear short deinterleaved write tails.