### PR TITLE
Fix bus PDC double-apply and mixer multi-select

### DIFF
--- a/crates/SphereDirectAudioEngine/src/engine/render.rs
+++ b/crates/SphereDirectAudioEngine/src/engine/render.rs
@@ -1654,9 +1654,10 @@ pub(crate) fn apply_external_bridge_insert_block(
     // `params["role"]` resolved at build time — no params-map read per block.
     let is_effect = insert.bridge_is_effect;
 
-    if insert.scratch_l.len() < frames {
-        insert.scratch_l.resize(frames, 0.0);
-        insert.scratch_r.resize(frames, 0.0);
+    if insert.scratch_l.len() < frames || insert.scratch_r.len() < frames {
+        // Scratches are pre-sized at graph build / `resolve_bridge_sinks`.
+        // Growing here would allocate on the audio thread — skip this insert.
+        return;
     }
 
     // One-block handshake ownership (critical):

--- a/crates/SphereDirectAudioEngine/src/latency_graph.rs
+++ b/crates/SphereDirectAudioEngine/src/latency_graph.rs
@@ -270,6 +270,18 @@ pub fn plan_runtime_latency_graph(
             if Some(idx) == master_index || is_master_track_type(&tracks[idx].track_type) {
                 continue;
             }
+            // Main-output → bus/return feeders must not take PDC on the feeder
+            // hop. The bus already carries upstream latency in its path and
+            // compensates once before summing to master. Delaying both the
+            // feeder and the bus double-compensates and makes bus-routed audio
+            // late vs direct-to-master tracks by exactly that extra delay.
+            // Send→return is different: the dry main still goes to master, so
+            // the source keeps its delay (applied after the pre-PDC send tap).
+            if resolve_output_target_index(idx, tracks, &id_to_index)
+                .is_some_and(|target| is_routing_track_type(&tracks[target].track_type))
+            {
+                continue;
+            }
             // PDC delay is relative to the *main/dry* path so return-FX latency
             // can pull dry forward without also delaying the send feed.
             let path = main_path_to_master(
@@ -416,6 +428,37 @@ mod tests {
         // (applied after the send tap) so dry and wet meet at the master.
         assert_eq!(latency.track_pdc_delay[0], 256);
         assert_eq!(latency.track_pdc_delay[1], 0);
+    }
+
+    #[test]
+    fn main_to_bus_does_not_double_pdc_against_longer_direct_path() {
+        // src → bus (0 insert lat) and slow → master (512). Without the feeder
+        // exemption both src and bus got D = max − path(bus), so bus audio
+        // arrived at max+D. Feeder delay must stay 0; only the bus (or other
+        // master-bound hop) compensates.
+        let mut src = track("src", "audio", 0, vec![]);
+        src.output_track_id = Some("bus".to_string());
+        let tracks = vec![
+            src,
+            track("bus", "bus", 0, vec![]),
+            track("slow", "audio", 512, vec![]),
+            track("master", "master", 0, vec![]),
+        ];
+        let audio_graph = plan_runtime_audio_graph(&tracks).unwrap();
+        let latency = plan_runtime_latency_graph(&tracks, &audio_graph, true);
+        assert_eq!(latency.max_path_latency_samples, 512);
+        assert_eq!(
+            latency.track_pdc_delay[0], 0,
+            "main→bus feeder must not take PDC (would double with the bus)"
+        );
+        assert_eq!(
+            latency.track_pdc_delay[1], 512,
+            "bus compensates once to align with the longer direct path"
+        );
+        assert_eq!(latency.track_pdc_delay[2], 0);
+        // Bus-path arrival at master = bus_output_lat + bus_pdc = 0 + 512 = max.
+        let bus_arrival = latency.track_output_latency[1] + latency.track_pdc_delay[1];
+        assert_eq!(bus_arrival, latency.max_path_latency_samples);
     }
 
     #[test]

--- a/crates/SphereDirectAudioEngine/src/runtime.rs
+++ b/crates/SphereDirectAudioEngine/src/runtime.rs
@@ -1127,10 +1127,18 @@ impl RuntimeProject {
     /// Arc clones only — no allocation.
     pub fn resolve_bridge_sinks(&mut self) {
         let sinks = &self.plugin_bridge_sinks;
+        let min_scratch = DEFAULT_AUDIO_BLOCK_CAPACITY
+            .max(crate::plugin_bridge::MAX_BRIDGE_BLOCK_FRAMES);
         for track in &mut self.tracks {
             for insert in &mut track.inserts {
                 if insert.kind_tag == RuntimeInsertKind::ExternalBridge {
                     insert.bridge_sink = sinks.get(&insert.id).cloned();
+                    // Pre-size on the control thread so the audio callback never
+                    // has to grow scratch for a bridged insert mid-block.
+                    if insert.scratch_l.len() < min_scratch {
+                        insert.scratch_l.resize(min_scratch, 0.0);
+                        insert.scratch_r.resize(min_scratch, 0.0);
+                    }
                 }
             }
         }
@@ -1265,9 +1273,24 @@ impl RuntimeProject {
         let pdc_buffer_frames = self.latency_graph.max_path_latency_samples.max(1) as usize
             + DEFAULT_AUDIO_BLOCK_CAPACITY;
         for track in &mut self.tracks {
-            track.pdc_delay_l.resize(pdc_buffer_frames, 0.0);
-            track.pdc_delay_r.resize(pdc_buffer_frames, 0.0);
-            track.pdc_write_pos = 0;
+            let old_len = track.pdc_delay_l.len();
+            if old_len < pdc_buffer_frames {
+                // Growing the ring invalidates the write cursor — reset so we
+                // never read uninitialized slots. Same-size refreshes (common
+                // when bridge latency reports tick) must leave the cursor alone
+                // or mid-playback compensation clicks.
+                track.pdc_delay_l.resize(pdc_buffer_frames, 0.0);
+                track.pdc_delay_r.resize(pdc_buffer_frames, 0.0);
+                track.pdc_write_pos = 0;
+            } else if old_len > pdc_buffer_frames {
+                track.pdc_delay_l.truncate(pdc_buffer_frames);
+                track.pdc_delay_r.truncate(pdc_buffer_frames);
+                if pdc_buffer_frames > 0 {
+                    track.pdc_write_pos %= pdc_buffer_frames;
+                } else {
+                    track.pdc_write_pos = 0;
+                }
+            }
         }
     }
 

--- a/crates/SphereUIComponents/src/components/mixer_panel.rs
+++ b/crates/SphereUIComponents/src/components/mixer_panel.rs
@@ -55,6 +55,20 @@ pub use callbacks::*;
 use drag::SendSlotDrag;
 pub use split::*;
 
+/// True when a mixer strip should paint as selected (multi-select aware).
+#[inline]
+fn mixer_strip_is_selected(
+    track_id: &str,
+    primary: Option<&str>,
+    selected_ids: &[String],
+) -> bool {
+    if !selected_ids.is_empty() {
+        selected_ids.iter().any(|id| id == track_id)
+    } else {
+        primary == Some(track_id)
+    }
+}
+
 /// Maximum insert slots per track. Once reached, the trailing empty "+ Add
 /// Insert" slot and the INSERTS header "+" are hidden/disabled.
 const MAX_INSERT_SLOTS: usize = 8;
@@ -1481,7 +1495,9 @@ fn channel_strip(
     let on_select_strip =
         move |event: &gpui::MouseDownEvent, w: &mut gpui::Window, cx: &mut gpui::App| {
             if event.button == gpui::MouseButton::Left {
-                select_cb(&select_id, w, cx);
+                let additive = event.modifiers.control || event.modifiers.platform;
+                let range = event.modifiers.shift;
+                select_cb(&select_id, additive, range, w, cx);
             }
         };
     let context_id = track.id.clone();
@@ -1630,13 +1646,16 @@ fn vsti_output_sub_strip(
             }
         }
     }
-    let is_selected = selected_track_id == Some(child_track.id.as_str()) || focus_highlight;
+    let is_selected = focus_highlight
+        || selected_track_id == Some(child_track.id.as_str());
     let select_id = child_track.id.clone();
     let select_cb = callbacks.on_select_track.clone();
     let on_select_strip =
         move |event: &gpui::MouseDownEvent, w: &mut gpui::Window, cx: &mut gpui::App| {
             if event.button == gpui::MouseButton::Left {
-                select_cb(&select_id, w, cx);
+                let additive = event.modifiers.control || event.modifiers.platform;
+                let range = event.modifiers.shift;
+                select_cb(&select_id, additive, range, w, cx);
             }
         };
     let context_id = child_track.id.clone();
@@ -2161,6 +2180,7 @@ pub(crate) fn build_mixer_render_snapshot(
     collapsed_vsti_output_groups: &HashSet<String>,
     hidden_mixer_channels: &HashSet<String>,
     selected_track_id: Option<&str>,
+    selected_track_ids: &[String],
     scroll_x: f32,
     channel_area_width: f32,
     strip_height: f32,
@@ -2174,7 +2194,8 @@ pub(crate) fn build_mixer_render_snapshot(
         let geom = match *item {
             MixerRenderItem::Track { track_index } => {
                 let track = &tracks[track_index];
-                let selected = selected_track_id == Some(track.id.as_str());
+                let selected =
+                    mixer_strip_is_selected(&track.id, selected_track_id, selected_track_ids);
                 let bg = if selected {
                     Colors::surface_card_selected()
                 } else if track_index % 2 == 0 {
@@ -2208,7 +2229,8 @@ pub(crate) fn build_mixer_render_snapshot(
             } => {
                 let parent = &tracks[parent_index];
                 let child = &tracks[child_index];
-                let selected = selected_track_id == Some(child.id.as_str());
+                let selected =
+                    mixer_strip_is_selected(&child.id, selected_track_id, selected_track_ids);
                 MixerStripGeom {
                     x,
                     width: STRIP_WIDTH,
@@ -2248,6 +2270,7 @@ pub fn mixer_panel(
     tracks: &[TrackState],
     master: &MasterBusState,
     selected_track_id: Option<&str>,
+    selected_track_ids: &[String],
     callbacks: MixerCallbacks,
     collapsed_vsti_output_groups: &HashSet<String>,
     hidden_mixer_channels: &HashSet<String>,
@@ -2327,6 +2350,7 @@ pub fn mixer_panel(
     let strip_row = mixer_strip_scroller(
         tracks,
         selected_track_id,
+        selected_track_ids,
         callbacks.clone(),
         collapsed_vsti_output_groups,
         hidden_mixer_channels,
@@ -2363,6 +2387,7 @@ pub fn mixer_panel(
             collapsed_vsti_output_groups,
             hidden_mixer_channels,
             selected_track_id,
+            selected_track_ids,
             scroll_x,
             viewport_width,
             strip_available_px,
@@ -2410,6 +2435,7 @@ pub fn mixer_panel(
 pub(crate) fn mixer_strip_scroller(
     tracks: &[TrackState],
     selected_track_id: Option<&str>,
+    selected_track_ids: &[String],
     callbacks: MixerCallbacks,
     collapsed_vsti_output_groups: &HashSet<String>,
     hidden_mixer_channels: &HashSet<String>,
@@ -2453,7 +2479,8 @@ pub(crate) fn mixer_strip_scroller(
         .map(|item| match *item {
             MixerRenderItem::Track { track_index } => {
                 let track = &tracks[track_index];
-                let is_sel = selected_track_id == Some(track.id.as_str());
+                let is_sel =
+                    mixer_strip_is_selected(&track.id, selected_track_id, selected_track_ids);
                 let vsti_group_expanded = track
                     .instrument_insert()
                     .filter(|slot| !slot.is_empty())
@@ -2484,6 +2511,11 @@ pub(crate) fn mixer_strip_scroller(
                 let bus_counts = parent.inserts[insert_index]
                     .output_bus_channel_counts
                     .clone();
+                let child_selected = mixer_strip_is_selected(
+                    &tracks[child_index].id,
+                    selected_track_id,
+                    selected_track_ids,
+                );
                 vsti_output_sub_strip(
                     parent,
                     &tracks[child_index],
@@ -2493,7 +2525,7 @@ pub(crate) fn mixer_strip_scroller(
                     bus_index,
                     &bus_counts,
                     selected_track_id,
-                    false,
+                    child_selected,
                     vsti_output_meters,
                     &callbacks,
                     split,

--- a/crates/SphereUIComponents/src/components/mixer_panel/callbacks.rs
+++ b/crates/SphereUIComponents/src/components/mixer_panel/callbacks.rs
@@ -5,7 +5,8 @@ use gpui::{App, Window};
 /// views can never disagree.
 #[derive(Clone)]
 pub struct MixerCallbacks {
-    pub on_select_track: std::sync::Arc<dyn Fn(&String, &mut Window, &mut App) + 'static>,
+    pub on_select_track:
+        std::sync::Arc<dyn Fn(&String, bool, bool, &mut Window, &mut App) + 'static>,
     pub on_volume_change: std::sync::Arc<dyn Fn(&(String, f32), &mut Window, &mut App) + 'static>,
     pub on_volume_drag_start:
         std::sync::Arc<dyn Fn(&(String, f32), &mut Window, &mut App) + 'static>,
@@ -71,6 +72,7 @@ pub fn noop_mixer_callbacks() -> MixerCallbacks {
     use std::sync::Arc;
 
     let noop_track = Arc::new(|_: &String, _: &mut Window, _: &mut App| {});
+    let noop_select = Arc::new(|_: &String, _: bool, _: bool, _: &mut Window, _: &mut App| {});
     let noop_vol = Arc::new(|_: &(String, f32), _: &mut Window, _: &mut App| {});
     let noop_vol_commit = Arc::new(|_: &String, _: &mut Window, _: &mut App| {});
     let noop_pan = Arc::new(|_: &(String, f32), _: &mut Window, _: &mut App| {});
@@ -86,7 +88,7 @@ pub fn noop_mixer_callbacks() -> MixerCallbacks {
     let noop_send_reorder = Arc::new(|_: &(String, String, usize), _: &mut Window, _: &mut App| {});
     let noop_send_gain = Arc::new(|_: &(String, String, f32), _: &mut Window, _: &mut App| {});
     MixerCallbacks {
-        on_select_track: noop_track.clone(),
+        on_select_track: noop_select,
         on_volume_change: noop_vol.clone(),
         on_volume_drag_start: noop_vol.clone(),
         on_volume_drag_preview: noop_vol,

--- a/crates/SphereUIComponents/src/components/mixer_panel_view.rs
+++ b/crates/SphereUIComponents/src/components/mixer_panel_view.rs
@@ -119,6 +119,7 @@ impl MixerPanelView {
             tracks,
             master,
             selected_track_id: timeline.state.selection.selected_track_id.clone(),
+            selected_track_ids: timeline.state.selection.selected_track_ids.clone(),
             collapsed,
             hidden,
             vsti_output_meters: chrome.vsti_output_meters.clone(),
@@ -139,6 +140,7 @@ impl MixerPanelView {
         state.strip_count.hash(&mut hasher);
         state.track_count.hash(&mut hasher);
         state.selected_track_id.as_deref().hash(&mut hasher);
+        state.selected_track_ids.hash(&mut hasher);
         q(state.scroll_x).hash(&mut hasher);
         q(state.viewport_width).hash(&mut hasher);
         q(state.strip_available_px).hash(&mut hasher);
@@ -155,6 +157,7 @@ struct MixerPanelViewState {
     tracks: Vec<crate::components::timeline::timeline_state::TrackState>,
     master: crate::components::timeline::timeline_state::MasterBusState,
     selected_track_id: Option<String>,
+    selected_track_ids: Vec<String>,
     collapsed: HashSet<String>,
     hidden: HashSet<String>,
     vsti_output_meters: HashMap<String, VstiOutputMeterState>,
@@ -213,6 +216,7 @@ impl Render for MixerPanelView {
             let strip_row = mixer_strip_scroller(
                 &state.tracks,
                 state.selected_track_id.as_deref(),
+                &state.selected_track_ids,
                 callbacks.clone(),
                 &state.collapsed,
                 &state.hidden,
@@ -243,6 +247,7 @@ impl Render for MixerPanelView {
                 &state.collapsed,
                 &state.hidden,
                 state.selected_track_id.as_deref(),
+                &state.selected_track_ids,
                 state.scroll_x,
                 state.viewport_width,
                 state.strip_available_px,

--- a/crates/SphereUIComponents/src/components/mixer_window.rs
+++ b/crates/SphereUIComponents/src/components/mixer_window.rs
@@ -73,6 +73,8 @@ pub struct MixerSnapshot {
     pub tracks: Vec<TrackState>,
     pub master: MasterBusState,
     pub selected_track_id: Option<String>,
+    /// Multi-select set (Ctrl/Cmd additive, Shift range). Highlight uses this.
+    pub selected_track_ids: Vec<String>,
     pub mixer_scroll_x: f32,
     /// Shared insert viewport height (clamped by the owner).
     pub mixer_insert_section_px: f32,
@@ -151,6 +153,7 @@ impl Render for MixerWindow {
             tracks,
             master,
             selected_track_id,
+            selected_track_ids,
             mixer_scroll_x,
             mixer_insert_section_px,
             mixer_send_section_px,
@@ -234,6 +237,7 @@ impl Render for MixerWindow {
                         &tracks,
                         &master,
                         selected_track_id.as_deref(),
+                        &selected_track_ids,
                         mixer_callbacks,
                         &collapsed_vsti_output_groups,
                         &hidden_mixer_channels,

--- a/crates/SphereUIComponents/src/components/timeline/state/mixer.rs
+++ b/crates/SphereUIComponents/src/components/timeline/state/mixer.rs
@@ -319,6 +319,17 @@ impl TimelineState {
         false
     }
 
+    /// Set solo without toggling. Returns `true` when the stored value changed.
+    pub fn set_track_solo(&mut self, track_id: &str, solo: bool) -> bool {
+        if let Some(t) = self.tracks.iter_mut().find(|t| t.id == track_id) {
+            if t.solo != solo {
+                t.solo = solo;
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn toggle_track_arm(&mut self, track_id: &str) -> bool {
         if let Some(t) = self.tracks.iter_mut().find(|t| t.id == track_id) {
             t.armed = !t.armed;

--- a/crates/SphereUIComponents/src/layout.rs
+++ b/crates/SphereUIComponents/src/layout.rs
@@ -2028,7 +2028,11 @@ impl StudioLayout {
                 if let Some(track_id) = self.context_track_id_or_selected(cx) {
                     self.panels.inspector = true;
                     self.timeline.update(cx, |timeline, cx| {
-                        timeline.state.select_track(&track_id);
+                        if timeline.state.is_track_selected(&track_id) {
+                            timeline.state.selection.selected_track_id = Some(track_id.clone());
+                        } else {
+                            timeline.state.select_track(&track_id);
+                        }
                         cx.notify();
                     });
                     self.set_active_panel(WorkspaceActivePanel::Inspector, cx);

--- a/crates/SphereUIComponents/src/layout/input_ops.rs
+++ b/crates/SphereUIComponents/src/layout/input_ops.rs
@@ -1141,6 +1141,9 @@ impl StudioLayout {
                 ContextMenuEntry::Separator,
                 ContextMenuEntry::item("Mute", "track:mute"),
                 ContextMenuEntry::item("Solo", "track:solo"),
+                ContextMenuEntry::Separator,
+                ContextMenuEntry::item("Track Color", "track:color"),
+                ContextMenuEntry::danger_item("Delete Track", "track:delete"),
             ],
             ContextTarget::SendPicker { track_id } => {
                 let state = &self.timeline.read(cx).state;

--- a/crates/SphereUIComponents/src/layout/inspector_ops.rs
+++ b/crates/SphereUIComponents/src/layout/inspector_ops.rs
@@ -406,7 +406,15 @@ impl StudioLayout {
             let id = id.clone();
             let color = *color;
             let changed = timeline_color.update(cx, |t, cx| {
-                let changed = t.state.set_track_color(&id, color);
+                let mut changed = t.state.set_track_color(&id, color);
+                if t.state.is_track_selected(&id) && t.state.selection.selected_track_ids.len() > 1 {
+                    for other in t.state.selection.selected_track_ids.clone() {
+                        if other == id {
+                            continue;
+                        }
+                        changed |= t.state.set_track_color(&other, color);
+                    }
+                }
                 if changed {
                     cx.notify();
                 }

--- a/crates/SphereUIComponents/src/layout/mixer_ops.rs
+++ b/crates/SphereUIComponents/src/layout/mixer_ops.rs
@@ -206,6 +206,7 @@ impl StudioLayout {
             tracks,
             master,
             selected_track_id: timeline.state.selection.selected_track_id.clone(),
+            selected_track_ids: timeline.state.selection.selected_track_ids.clone(),
             mixer_scroll_x: self.mixer_view.scroll_x,
             mixer_insert_section_px: clamp_mixer_section_height_px(
                 self.mixer_view.insert_section_px,
@@ -966,29 +967,22 @@ impl StudioLayout {
         let mixer_panel_select = self.mixer_panel.clone();
         let owner_select = owner.clone();
         let on_select_track: std::sync::Arc<
-            dyn Fn(&String, &mut Window, &mut gpui::App) + 'static,
-        > = std::sync::Arc::new(move |id: &String, _w, cx| {
+            dyn Fn(&String, bool, bool, &mut Window, &mut gpui::App) + 'static,
+        > = std::sync::Arc::new(move |id: &String, additive: bool, range: bool, _w, cx| {
             let _interaction = crate::perf::PerfScope::enter("MixerSelectInteraction");
             let id = id.clone();
             if external_mixer_debug_enabled() {
-                external_mixer_debug(&format!("mixer command dispatched select_track id={id}"));
-            }
-            if timeline_select
-                .read(cx)
-                .state
-                .selection
-                .selected_track_id
-                .as_deref()
-                == Some(id.as_str())
-            {
-                return;
+                external_mixer_debug(&format!(
+                    "mixer command dispatched select_track id={id} additive={additive} range={range}"
+                ));
             }
             // Commit the shared selection without scheduling the full Timeline
             // repaint first. That repaint may include waveform work; when mixer
             // invalidation was deferred behind it, the strip highlight visibly
             // lagged even though the model had already changed.
             timeline_select.update(cx, |t, _cx| {
-                t.state.select_track(&id);
+                t.state
+                    .select_track_with_modifiers(&id, additive, range);
             });
             // Queue the lightweight mixer repaint first so selection feedback is
             // not blocked by Timeline/Inspector/tree work.
@@ -1181,6 +1175,19 @@ impl StudioLayout {
                             .find_track(&id)
                             .map(|track| track.muted)
                             .unwrap_or(false);
+                        // Ctrl/Shift multi-select: apply the same mute state to
+                        // every selected strip when the clicked one is in the set.
+                        if t.state.is_track_selected(&id)
+                            && t.state.selection.selected_track_ids.len() > 1
+                        {
+                            let ids = t.state.selection.selected_track_ids.clone();
+                            for other in ids {
+                                if other == id {
+                                    continue;
+                                }
+                                t.state.set_track_mute(&other, muted);
+                            }
+                        }
                     });
                 }
                 // Dispatch the bounded, non-blocking realtime command before
@@ -1189,9 +1196,27 @@ impl StudioLayout {
                 {
                     let _dispatch = crate::perf::PerfScope::enter("MixerMuteCommandDispatch");
                     if let Some(engine) = audio_engine.as_ref() {
-                        audio_router_applied = engine
-                            .update_track_param(&id, "muted", if muted { 1.0 } else { 0.0 })
-                            .is_ok();
+                        let ids: Vec<String> = timeline_mute.read(cx).state.selection.selected_track_ids
+                            .iter()
+                            .cloned()
+                            .collect();
+                        let batch = if ids.len() > 1
+                            && ids.iter().any(|selected| selected == &id)
+                        {
+                            ids
+                        } else {
+                            vec![id.clone()]
+                        };
+                        for track_id in &batch {
+                            audio_router_applied = engine
+                                .update_track_param(
+                                    track_id,
+                                    "muted",
+                                    if muted { 1.0 } else { 0.0 },
+                                )
+                                .is_ok()
+                                || audio_router_applied;
+                        }
                     }
                 }
                 // Give the control that was clicked immediate visual feedback.
@@ -1270,15 +1295,44 @@ impl StudioLayout {
                             .find_track(&id)
                             .map(|track| track.solo)
                             .unwrap_or(false);
+                        if t.state.is_track_selected(&id)
+                            && t.state.selection.selected_track_ids.len() > 1
+                        {
+                            let ids = t.state.selection.selected_track_ids.clone();
+                            for other in ids {
+                                if other == id {
+                                    continue;
+                                }
+                                t.state.set_track_solo(&other, solo);
+                            }
+                        }
                     });
                 }
                 let mut audio_router_applied = false;
                 {
                     let _dispatch = crate::perf::PerfScope::enter("MixerSoloCommandDispatch");
                     if let Some(engine) = audio_engine.as_ref() {
-                        audio_router_applied = engine
-                            .update_track_param(&id, "solo", if solo { 1.0 } else { 0.0 })
-                            .is_ok();
+                        let ids: Vec<String> = timeline_solo
+                            .read(cx)
+                            .state
+                            .selection
+                            .selected_track_ids
+                            .iter()
+                            .cloned()
+                            .collect();
+                        let batch = if ids.len() > 1
+                            && ids.iter().any(|selected| selected == &id)
+                        {
+                            ids
+                        } else {
+                            vec![id.clone()]
+                        };
+                        for track_id in &batch {
+                            audio_router_applied = engine
+                                .update_track_param(track_id, "solo", if solo { 1.0 } else { 0.0 })
+                                .is_ok()
+                                || audio_router_applied;
+                        }
                     }
                 }
                 crate::perf::record_notify("mixer_solo");
@@ -1542,7 +1596,13 @@ impl StudioLayout {
                 let window_id = window.window_handle().window_id();
                 StudioLayout::defer_update(&this, cx, move |this, cx| {
                     let _ = this.timeline.update(cx, |timeline, cx| {
-                        timeline.state.select_track(&track_id);
+                        // Preserve Ctrl/Shift multi-select when the strip is
+                        // already in the set; only retarget the primary.
+                        if timeline.state.is_track_selected(&track_id) {
+                            timeline.state.selection.selected_track_id = Some(track_id.clone());
+                        } else {
+                            timeline.state.select_track(&track_id);
+                        }
                         cx.notify();
                     });
                     this.try_open_context_menu(

--- a/crates/SphereUIComponents/src/layout/track_clip_ops.rs
+++ b/crates/SphereUIComponents/src/layout/track_clip_ops.rs
@@ -111,24 +111,31 @@ impl StudioLayout {
     }
 
     pub(super) fn delete_selected_track(&mut self, cx: &mut Context<Self>) {
-        let Some(track_id) = self
-            .timeline
-            .read(cx)
-            .state
-            .selection
-            .selected_track_id
-            .clone()
-        else {
-            return;
+        let ids: Vec<String> = {
+            let state = &self.timeline.read(cx).state;
+            let mut ids = state.selection.selected_track_ids.clone();
+            if ids.is_empty() {
+                if let Some(primary) = state.selection.selected_track_id.clone() {
+                    ids.push(primary);
+                }
+            }
+            ids
         };
+        if ids.is_empty() {
+            return;
+        }
         // Close editors + MIDI panic BEFORE the model mutation so the engine
         // reload triggered by `mark_dirty` can actually release the instances.
-        self.cleanup_track_plugins_before_delete(&track_id, cx);
+        for track_id in &ids {
+            self.cleanup_track_plugins_before_delete(track_id, cx);
+        }
         let _ = self.timeline.update(cx, |timeline, cx| {
-            let Some(snapshot) = TrackSnapshot::capture(&timeline.state, &track_id) else {
-                return;
-            };
-            timeline.run_edit_command(EditCommand::DeleteTrack { snapshot }, cx);
+            for track_id in &ids {
+                let Some(snapshot) = TrackSnapshot::capture(&timeline.state, track_id) else {
+                    continue;
+                };
+                timeline.run_edit_command(EditCommand::DeleteTrack { snapshot }, cx);
+            }
         });
         self.mark_dirty();
     }
@@ -634,12 +641,26 @@ impl StudioLayout {
             let id = timeline.state.selection.selected_track_id.clone()?;
             timeline.state.toggle_track_mute(&id);
             let muted = timeline.state.find_track(&id).map(|t| t.muted)?;
+            let mut ids = vec![id.clone()];
+            if timeline.state.is_track_selected(&id)
+                && timeline.state.selection.selected_track_ids.len() > 1
+            {
+                for other in timeline.state.selection.selected_track_ids.clone() {
+                    if other == id {
+                        continue;
+                    }
+                    timeline.state.set_track_mute(&other, muted);
+                    ids.push(other);
+                }
+            }
             cx.notify();
-            Some((id, muted))
+            Some((ids, muted))
         });
-        if let Some((id, muted)) = toggled {
+        if let Some((ids, muted)) = toggled {
             if let Some(engine) = self.audio_bridge.engine.as_ref() {
-                let _ = engine.update_track_param(&id, "muted", if muted { 1.0 } else { 0.0 });
+                for id in &ids {
+                    let _ = engine.update_track_param(id, "muted", if muted { 1.0 } else { 0.0 });
+                }
             }
             self.push_mixer_snapshot_to_window(cx);
         }
@@ -652,12 +673,26 @@ impl StudioLayout {
             let id = timeline.state.selection.selected_track_id.clone()?;
             timeline.state.toggle_track_solo(&id);
             let solo = timeline.state.find_track(&id).map(|t| t.solo)?;
+            let mut ids = vec![id.clone()];
+            if timeline.state.is_track_selected(&id)
+                && timeline.state.selection.selected_track_ids.len() > 1
+            {
+                for other in timeline.state.selection.selected_track_ids.clone() {
+                    if other == id {
+                        continue;
+                    }
+                    timeline.state.set_track_solo(&other, solo);
+                    ids.push(other);
+                }
+            }
             cx.notify();
-            Some((id, solo))
+            Some((ids, solo))
         });
-        if let Some((id, solo)) = toggled {
+        if let Some((ids, solo)) = toggled {
             if let Some(engine) = self.audio_bridge.engine.as_ref() {
-                let _ = engine.update_track_param(&id, "solo", if solo { 1.0 } else { 0.0 });
+                for id in &ids {
+                    let _ = engine.update_track_param(id, "solo", if solo { 1.0 } else { 0.0 });
+                }
             }
             self.push_mixer_snapshot_to_window(cx);
         }
@@ -674,15 +709,30 @@ impl StudioLayout {
     }
 
     pub(super) fn reset_selected_track_volume(&mut self, cx: &mut Context<Self>) {
-        self.mark_dirty();
-        let _ = self.timeline.update(cx, |timeline, cx| {
-            if let Some(id) = timeline.state.selection.selected_track_id.clone() {
-                timeline
-                    .state
-                    .set_track_volume(&id, timeline_state::volume::db_to_norm(0.0));
+        self.mark_dirty_view_only();
+        let norm = timeline_state::volume::db_to_norm(0.0);
+        let ids: Vec<String> = self.timeline.update(cx, |timeline, cx| {
+            let mut ids = timeline.state.selection.selected_track_ids.clone();
+            if ids.is_empty() {
+                if let Some(primary) = timeline.state.selection.selected_track_id.clone() {
+                    ids.push(primary);
+                }
+            }
+            for id in &ids {
+                timeline.state.set_track_volume(id, norm);
+            }
+            if !ids.is_empty() {
                 cx.notify();
             }
+            ids
         });
+        if let Some(engine) = self.audio_bridge.engine.as_ref() {
+            let linear = super::engine_snapshot::volume_norm_to_linear(norm) as f64;
+            for id in &ids {
+                let _ = engine.update_track_param(id, "volume", linear);
+            }
+        }
+        self.push_mixer_snapshot_to_window(cx);
     }
 
     /// Create a Bus strip immediately (mixer context menu). Routes the currently
@@ -710,13 +760,28 @@ impl StudioLayout {
     }
 
     pub(super) fn reset_selected_track_pan(&mut self, cx: &mut Context<Self>) {
-        self.mark_dirty();
-        let _ = self.timeline.update(cx, |timeline, cx| {
-            if let Some(id) = timeline.state.selection.selected_track_id.clone() {
-                timeline.state.set_track_pan(&id, 0.0);
+        self.mark_dirty_view_only();
+        let ids: Vec<String> = self.timeline.update(cx, |timeline, cx| {
+            let mut ids = timeline.state.selection.selected_track_ids.clone();
+            if ids.is_empty() {
+                if let Some(primary) = timeline.state.selection.selected_track_id.clone() {
+                    ids.push(primary);
+                }
+            }
+            for id in &ids {
+                timeline.state.set_track_pan(id, 0.0);
+            }
+            if !ids.is_empty() {
                 cx.notify();
             }
+            ids
         });
+        if let Some(engine) = self.audio_bridge.engine.as_ref() {
+            for id in &ids {
+                let _ = engine.update_track_param(id, "pan", 0.0);
+            }
+        }
+        self.push_mixer_snapshot_to_window(cx);
     }
 
     pub(super) fn set_context_track_height_preset(


### PR DESCRIPTION
## Summary
- Stop PDC on main→bus feeders so bus-routed audio is not delayed twice relative to longer direct-to-master paths.
- Mixer Ctrl/Cmd+click and Shift+click multi-select with shared highlight; mute/solo/delete/color/reset vol-pan apply across the selection.
- Harden PDC ring write-pos (reset only on grow) and pre-size bridge insert scratch off the audio thread.

## Test plan
- [ ] `cargo test -p sphere_directaudioengine --lib latency_graph`
- [ ] `cargo check -p sphere_ui_components -p futureboard_native`
- [ ] Route a dry track through a bus while another track has longer insert latency; confirm bus and direct paths stay aligned (no extra bus delay)
- [ ] Mixer: Ctrl+click several strips, then mute/solo — all selected update in UI and audio
- [ ] Mixer: multi-select then Reset Volume/Pan, Track Color, Delete Track from context menu
- [ ] Right-click an already multi-selected strip — selection stays intact


Made with [Cursor](https://cursor.com)