### PR TITLE
Equz8 flat default and Pro-Q-style dynamic EQ

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/App.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/App.tsx
@@ -24,7 +24,7 @@ import './Editor.scss'
 
 function App() {
   const [params, setParams] = useState<EqParams>(DEFAULT_PARAMS)
-  const [selected, setSelected] = useState(2)
+  const [selected, setSelected] = useState(0)
   const [connected, setConnected] = useState(false)
   const [showBandCurves, setShowBandCurves] = useState(true)
   const [showSpectrum, setShowSpectrum] = useState(true)

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/Editor.scss
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/Editor.scss
@@ -388,6 +388,12 @@ select:focus-visible,
     stroke-width: 1.25;
     opacity: 0.72;
   }
+
+  &.is-dynamic-extent {
+    stroke-width: 1;
+    stroke-dasharray: 4 3;
+    opacity: 0.45;
+  }
 }
 
 .curve-glow {
@@ -512,7 +518,7 @@ select:focus-visible,
 
 .control-rack {
   display: grid;
-  grid-template-columns: minmax(11.5rem, 1fr) auto auto;
+  grid-template-columns: minmax(11.5rem, 1fr) auto auto auto;
   align-items: center;
   gap: clamp(0.8rem, 2.4vw, 1.7rem);
   margin: 0 var(--space-3) var(--space-3);
@@ -622,6 +628,39 @@ select:focus-visible,
   }
 }
 
+.band-dyn {
+  flex: none;
+  height: 1.35rem;
+  padding: 0 0.45rem;
+  border: 1px solid var(--line);
+  border-radius: 0.4rem;
+  background: transparent;
+  color: var(--text-faint);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary);
+    border-color: var(--text-faint);
+  }
+
+  &.is-on {
+    color: #0b0e13;
+    border-color: var(--band);
+    background: var(--band);
+  }
+
+  &.is-disabled,
+  &:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+}
+
 .band-toggle {
   flex: none;
   width: 0.65rem;
@@ -690,6 +729,32 @@ select:focus-visible,
   grid-template-columns: repeat(3, var(--control-column));
   justify-content: center;
   align-items: center;
+}
+
+.dyn-controls {
+  display: grid;
+  grid-template-columns: repeat(4, var(--control-column));
+  justify-content: center;
+  align-items: end;
+  gap: 0.15rem 0;
+  opacity: 0.38;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+
+  &.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.dyn-label {
+  grid-column: 1 / -1;
+  color: var(--text-faint);
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-align: center;
+  text-transform: uppercase;
 }
 
 .master-section {
@@ -888,6 +953,7 @@ select:focus-visible,
     grid-template-columns: minmax(10.5rem, 1fr) auto;
     grid-template-areas:
       'filter band'
+      'dyn dyn'
       'master master';
     row-gap: var(--space-3);
   }
@@ -898,6 +964,13 @@ select:focus-visible,
 
   .band-controls {
     grid-area: band;
+  }
+
+  .dyn-controls {
+    grid-area: dyn;
+    justify-content: center;
+    border-top: 1px solid var(--border-subtle);
+    padding-top: var(--space-2);
   }
 
   .master-section {

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/bridge.ts
@@ -15,6 +15,12 @@ export type Band = {
   freq: number
   gainDb: number
   q: number
+  /** Pro-Q-style dynamic EQ for shapes that have a gain stage. */
+  dynamic: boolean
+  thresholdDb: number
+  rangeDb: number
+  attackMs: number
+  releaseMs: number
 }
 
 /// `soloBand` value meaning "no band is soloed". Mirrors `ipc::SOLO_NONE`.
@@ -119,6 +125,35 @@ export function postParam(id: string, value: number) {
   requestAnimationFrame(flush)
 }
 
+function parseBand(raw: unknown): Band | null {
+  if (!raw || typeof raw !== 'object') return null
+  const band = raw as Partial<Band>
+  if (
+    typeof band.active !== 'boolean' ||
+    typeof band.bandType !== 'string' ||
+    typeof band.freq !== 'number' ||
+    typeof band.gainDb !== 'number' ||
+    typeof band.q !== 'number'
+  ) {
+    return null
+  }
+  // Dynamic fields are optional so projects saved before dynamic EQ existed
+  // still open with dynamic off / neutral timing.
+  return {
+    active: band.active,
+    bandType: band.bandType as Band['bandType'],
+    freq: band.freq,
+    gainDb: band.gainDb,
+    q: band.q,
+    dynamic: band.dynamic === true,
+    thresholdDb:
+      typeof band.thresholdDb === 'number' ? band.thresholdDb : -24,
+    rangeDb: typeof band.rangeDb === 'number' ? band.rangeDb : 0,
+    attackMs: typeof band.attackMs === 'number' ? band.attackMs : 10,
+    releaseMs: typeof band.releaseMs === 'number' ? band.releaseMs : 100,
+  }
+}
+
 function parseParams(state: unknown): EqParams | null {
   if (!state || typeof state !== 'object') return null
   const candidate =
@@ -133,6 +168,12 @@ function parseParams(state: unknown): EqParams | null {
   ) {
     return null
   }
+  const bands: Band[] = []
+  for (const entry of params.bands) {
+    const band = parseBand(entry)
+    if (!band) return null
+    bands.push(band)
+  }
   // Optional on purpose: state saved before band solo existed has no
   // `soloBand`, and rejecting it here would make those projects fail to load
   // rather than simply opening with solo off. Rust applies the same default.
@@ -140,10 +181,16 @@ function parseParams(state: unknown): EqParams | null {
     typeof params.soloBand === 'number' &&
     Number.isInteger(params.soloBand) &&
     params.soloBand >= 0 &&
-    params.soloBand < params.bands.length
+    params.soloBand < bands.length
       ? params.soloBand
       : SOLO_NONE
-  return { ...(params as EqParams), soloBand }
+  return {
+    power: params.power,
+    outputDb: params.outputDb,
+    mix: params.mix,
+    bands,
+    soloBand,
+  }
 }
 
 export function connectBridge(

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ControlRack.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ControlRack.tsx
@@ -49,6 +49,7 @@ export function ControlRack({
 }: ControlRackProps) {
   const kind = filterKind(band.bandType)
   const canGain = bandHasGain(band.bandType)
+  const canDynamic = canGain
 
   return (
     <section
@@ -81,6 +82,26 @@ export function ControlRack({
           </button>
           <button
             type="button"
+            className={`band-dyn${band.dynamic ? ' is-on' : ''}${canDynamic ? '' : ' is-disabled'}`}
+            aria-pressed={band.dynamic}
+            disabled={!canDynamic}
+            aria-label={`Band ${selected + 1} dynamic EQ`}
+            title={
+              canDynamic
+                ? band.dynamic
+                  ? 'Disable dynamic EQ'
+                  : 'Enable dynamic EQ (Pro-Q style)'
+                : `${kind.label} has no gain stage for dynamic EQ`
+            }
+            onClick={() => {
+              if (!canDynamic) return
+              onBandChange({ dynamic: !band.dynamic })
+            }}
+          >
+            Dyn
+          </button>
+          <button
+            type="button"
             className={`band-toggle${band.active ? ' is-on' : ''}`}
             role="switch"
             aria-checked={band.active}
@@ -99,7 +120,12 @@ export function ControlRack({
               aria-pressed={band.bandType === item.type}
               title={item.label}
               aria-label={item.label}
-              onClick={() => onBandChange({ bandType: item.type })}
+              onClick={() =>
+                onBandChange({
+                  bandType: item.type,
+                  ...(bandHasGain(item.type) ? {} : { dynamic: false }),
+                })
+              }
             >
               <svg viewBox="0 0 32 20" aria-hidden="true">
                 <path d={item.glyph} />
@@ -151,6 +177,69 @@ export function ControlRack({
           toProgress={qToProgress}
           fromProgress={progressToQ}
           onChange={(q) => onBandChange({ q })}
+        />
+      </div>
+
+      <div className={`dyn-controls${band.dynamic && canDynamic ? ' is-open' : ''}`}>
+        <span className="dyn-label">Dynamic</span>
+        <Knob
+          variant="band"
+          label="Thresh"
+          value={band.thresholdDb}
+          min={-60}
+          max={0}
+          step={0.5}
+          unit="dB"
+          format={formatGain}
+          defaultValue={defaultBand.thresholdDb}
+          disabled={!band.dynamic || !canDynamic}
+          disabledHint="Enable Dyn first"
+          onChange={(thresholdDb) => onBandChange({ thresholdDb })}
+        />
+        <Knob
+          variant="band"
+          label="Range"
+          value={band.rangeDb}
+          min={-24}
+          max={24}
+          step={0.1}
+          unit="dB"
+          format={formatGain}
+          defaultValue={defaultBand.rangeDb}
+          originAtDefault
+          disabled={!band.dynamic || !canDynamic}
+          disabledHint="Enable Dyn first"
+          onChange={(rangeDb) => onBandChange({ rangeDb })}
+        />
+        <Knob
+          variant="band"
+          label="Attack"
+          value={band.attackMs}
+          min={0.1}
+          max={500}
+          step={0.1}
+          unit="ms"
+          format={(value) =>
+            value < 10 ? value.toFixed(1) : String(Math.round(value))
+          }
+          defaultValue={defaultBand.attackMs}
+          disabled={!band.dynamic || !canDynamic}
+          disabledHint="Enable Dyn first"
+          onChange={(attackMs) => onBandChange({ attackMs })}
+        />
+        <Knob
+          variant="band"
+          label="Release"
+          value={band.releaseMs}
+          min={1}
+          max={5000}
+          step={1}
+          unit="ms"
+          format={(value) => String(Math.round(value))}
+          defaultValue={defaultBand.releaseMs}
+          disabled={!band.dynamic || !canDynamic}
+          disabledHint="Enable Dyn first"
+          onChange={(releaseMs) => onBandChange({ releaseMs })}
         />
       </div>
 

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ResponseGraph.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ResponseGraph.tsx
@@ -137,6 +137,24 @@ export function ResponseGraph({
       ? bandCurvePath(band, width, height, sampleRate)
       : null
   }, [bands, height, selected, width, sampleRate])
+  /// Ghost of the fully-triggered dynamic gain (gain + range), Pro-Q style.
+  const selectedDynamicExtentPath = useMemo(() => {
+    const band = bands[selected]
+    if (
+      !band?.active ||
+      !band.dynamic ||
+      !bandHasGain(band.bandType) ||
+      Math.abs(band.rangeDb) < 0.01
+    ) {
+      return null
+    }
+    return bandCurvePath(
+      { ...band, gainDb: band.gainDb + band.rangeDb },
+      width,
+      height,
+      sampleRate,
+    )
+  }, [bands, height, selected, width, sampleRate])
 
   /// Client coordinates mapped into the same viewBox space the curves, grid and
   /// nodes are drawn in, so a stale measurement can never make drawing and
@@ -357,6 +375,14 @@ export function ResponseGraph({
             style={{ '--band': BAND_COLORS[index] } as CSSProperties}
           />
         ) : null,
+      )}
+
+      {selectedDynamicExtentPath && (
+        <path
+          d={selectedDynamicExtentPath}
+          className="band-curve is-dynamic-extent"
+          style={{ '--band': BAND_COLORS[selected] } as CSSProperties}
+        />
       )}
 
       {selectedPath && (

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/lib/presets.ts
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/lib/presets.ts
@@ -1,21 +1,41 @@
 import { SOLO_NONE, postParam, type Band, type EqParams } from '../bridge'
 import { filterKind } from './eq'
 
+function flatBand(
+  bandType: Band['bandType'],
+  freq: number,
+  q: number,
+): Band {
+  return {
+    active: false,
+    bandType,
+    freq,
+    gainDb: 0,
+    q,
+    dynamic: false,
+    thresholdDb: -24,
+    rangeDb: 0,
+    attackMs: 10,
+    releaseMs: 100,
+  }
+}
+
 /// Mirrors `default_params()` in the Rust DSP crate. Rust stays authoritative:
 /// these values only seed the editor before the first `selectInstance`.
+/// Every band starts inactive and flat — no curve on open.
 export const DEFAULT_PARAMS: EqParams = {
   power: true,
   outputDb: 0,
   mix: 100,
   bands: [
-    { active: true, bandType: 'highpass', freq: 50, gainDb: 0, q: 0.7 },
-    { active: true, bandType: 'lowshelf', freq: 120, gainDb: 0, q: 0.8 },
-    { active: true, bandType: 'bell', freq: 250, gainDb: 2.5, q: 1.2 },
-    { active: true, bandType: 'bell', freq: 750, gainDb: -1.5, q: 1.4 },
-    { active: true, bandType: 'bell', freq: 1500, gainDb: 1, q: 1 },
-    { active: true, bandType: 'bell', freq: 3500, gainDb: 0, q: 1.1 },
-    { active: true, bandType: 'highshelf', freq: 8000, gainDb: 1.5, q: 0.8 },
-    { active: true, bandType: 'lowpass', freq: 16000, gainDb: 0, q: 0.7 },
+    flatBand('highpass', 50, 0.7),
+    flatBand('lowshelf', 120, 0.8),
+    flatBand('bell', 250, 1.2),
+    flatBand('bell', 750, 1.4),
+    flatBand('bell', 1500, 1),
+    flatBand('bell', 3500, 1.1),
+    flatBand('highshelf', 8000, 0.8),
+    flatBand('lowpass', 16000, 0.7),
   ],
   soloBand: SOLO_NONE,
 }
@@ -39,6 +59,11 @@ function preset(
       mix,
       bands: DEFAULT_PARAMS.bands.map((band, index) => ({
         ...band,
+        // Factory looks enable the full strip; Default stays all-off via
+        // `DEFAULT_PARAMS` directly.
+        active: true,
+        dynamic: false,
+        rangeDb: 0,
         ...(bands[index] ?? {}),
       })),
       // Solo is an audition state, never part of a preset: loading a preset
@@ -48,8 +73,12 @@ function preset(
   }
 }
 
+export function cloneParams(params: EqParams): EqParams {
+  return { ...params, bands: params.bands.map((band) => ({ ...band })) }
+}
+
 export const FACTORY_PRESETS: FactoryPreset[] = [
-  preset('Default', []),
+  { name: 'Default', params: cloneParams(DEFAULT_PARAMS) },
   preset('Low-End Control', [
     { freq: 32, q: 0.72 },
     { freq: 95, gainDb: -1.5, q: 0.8 },
@@ -106,10 +135,6 @@ export const FACTORY_PRESETS: FactoryPreset[] = [
   ]),
 ]
 
-export function cloneParams(params: EqParams): EqParams {
-  return { ...params, bands: params.bands.map((band) => ({ ...band })) }
-}
-
 export function paramsMatch(left: EqParams, right: EqParams) {
   if (
     left.power !== right.power ||
@@ -126,7 +151,12 @@ export function paramsMatch(left: EqParams, right: EqParams) {
       band.bandType === other.bandType &&
       Math.abs(band.freq - other.freq) < 0.01 &&
       Math.abs(band.gainDb - other.gainDb) < 0.01 &&
-      Math.abs(band.q - other.q) < 0.001
+      Math.abs(band.q - other.q) < 0.001 &&
+      band.dynamic === other.dynamic &&
+      Math.abs(band.thresholdDb - other.thresholdDb) < 0.01 &&
+      Math.abs(band.rangeDb - other.rangeDb) < 0.01 &&
+      Math.abs(band.attackMs - other.attackMs) < 0.01 &&
+      Math.abs(band.releaseMs - other.releaseMs) < 0.01
     )
   })
 }
@@ -152,6 +182,11 @@ export function postAllParams(params: EqParams) {
     postParam(`${prefix}freq`, band.freq)
     postParam(`${prefix}gainDb`, band.gainDb)
     postParam(`${prefix}q`, band.q)
+    postParam(`${prefix}dynEnabled`, band.dynamic ? 1 : 0)
+    postParam(`${prefix}thresholdDb`, band.thresholdDb)
+    postParam(`${prefix}rangeDb`, band.rangeDb)
+    postParam(`${prefix}attackMs`, band.attackMs)
+    postParam(`${prefix}releaseMs`, band.releaseMs)
   })
 }
 
@@ -166,4 +201,19 @@ export function postBandPatch(index: number, patch: Partial<Band>) {
   if (patch.freq !== undefined) postParam(`${prefix}freq`, patch.freq)
   if (patch.gainDb !== undefined) postParam(`${prefix}gainDb`, patch.gainDb)
   if (patch.q !== undefined) postParam(`${prefix}q`, patch.q)
+  if (patch.dynamic !== undefined) {
+    postParam(`${prefix}dynEnabled`, patch.dynamic ? 1 : 0)
+  }
+  if (patch.thresholdDb !== undefined) {
+    postParam(`${prefix}thresholdDb`, patch.thresholdDb)
+  }
+  if (patch.rangeDb !== undefined) {
+    postParam(`${prefix}rangeDb`, patch.rangeDb)
+  }
+  if (patch.attackMs !== undefined) {
+    postParam(`${prefix}attackMs`, patch.attackMs)
+  }
+  if (patch.releaseMs !== undefined) {
+    postParam(`${prefix}releaseMs`, patch.releaseMs)
+  }
 }

--- a/crates/BuiltinAudioPlugins/crates/equz8/src/ipc.rs
+++ b/crates/BuiltinAudioPlugins/crates/equz8/src/ipc.rs
@@ -35,7 +35,19 @@ pub const SOLO_INDEX: u32 = BAND_BASE_INDEX + BAND_COUNT as u32 * BAND_STRIDE;
 /// `solo_band` value meaning "no band is soloed".
 pub const SOLO_NONE: i32 = -1;
 
-pub const PARAM_COUNT: usize = SOLO_INDEX as usize + 1;
+/// Per-band dynamic EQ wires, appended after solo so the static band block and
+/// solo index stay stable for hosts that already resolve those string ids.
+pub const DYN_BASE_INDEX: u32 = SOLO_INDEX + 1;
+pub const DYN_STRIDE: u32 = 5;
+
+pub const BAND_DYN_ENABLED: u32 = 0;
+pub const BAND_DYN_THRESHOLD: u32 = 1;
+pub const BAND_DYN_RANGE: u32 = 2;
+pub const BAND_DYN_ATTACK: u32 = 3;
+pub const BAND_DYN_RELEASE: u32 = 4;
+
+pub const PARAM_COUNT: usize =
+    DYN_BASE_INDEX as usize + BAND_COUNT * DYN_STRIDE as usize;
 
 pub const UI_PARAM_IDS: [&str; PARAM_COUNT] = [
     "power",
@@ -82,6 +94,46 @@ pub const UI_PARAM_IDS: [&str; PARAM_COUNT] = [
     "band8_gainDb",
     "band8_q",
     "soloBand",
+    "band1_dynEnabled",
+    "band1_thresholdDb",
+    "band1_rangeDb",
+    "band1_attackMs",
+    "band1_releaseMs",
+    "band2_dynEnabled",
+    "band2_thresholdDb",
+    "band2_rangeDb",
+    "band2_attackMs",
+    "band2_releaseMs",
+    "band3_dynEnabled",
+    "band3_thresholdDb",
+    "band3_rangeDb",
+    "band3_attackMs",
+    "band3_releaseMs",
+    "band4_dynEnabled",
+    "band4_thresholdDb",
+    "band4_rangeDb",
+    "band4_attackMs",
+    "band4_releaseMs",
+    "band5_dynEnabled",
+    "band5_thresholdDb",
+    "band5_rangeDb",
+    "band5_attackMs",
+    "band5_releaseMs",
+    "band6_dynEnabled",
+    "band6_thresholdDb",
+    "band6_rangeDb",
+    "band6_attackMs",
+    "band6_releaseMs",
+    "band7_dynEnabled",
+    "band7_thresholdDb",
+    "band7_rangeDb",
+    "band7_attackMs",
+    "band7_releaseMs",
+    "band8_dynEnabled",
+    "band8_thresholdDb",
+    "band8_rangeDb",
+    "band8_attackMs",
+    "band8_releaseMs",
 ];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -129,10 +181,24 @@ pub const fn band_wire_index(band: usize, field: u32) -> u32 {
     BAND_BASE_INDEX + band as u32 * BAND_STRIDE + field
 }
 
+pub const fn dyn_wire_index(band: usize, field: u32) -> u32 {
+    DYN_BASE_INDEX + band as u32 * DYN_STRIDE + field
+}
+
 pub fn decode_band_wire(index: u32) -> Option<(usize, u32)> {
     let offset = index.checked_sub(BAND_BASE_INDEX)?;
+    if index >= SOLO_INDEX {
+        return None;
+    }
     let band = (offset / BAND_STRIDE) as usize;
     let field = offset % BAND_STRIDE;
+    (band < BAND_COUNT).then_some((band, field))
+}
+
+pub fn decode_dyn_wire(index: u32) -> Option<(usize, u32)> {
+    let offset = index.checked_sub(DYN_BASE_INDEX)?;
+    let band = (offset / DYN_STRIDE) as usize;
+    let field = offset % DYN_STRIDE;
     (band < BAND_COUNT).then_some((band, field))
 }
 
@@ -146,6 +212,13 @@ pub fn sanitize_params(params: &mut Params) {
         band.freq = clamp(band.freq, 20.0, 20_000.0);
         band.gain_db = clamp(band.gain_db, -18.0, 18.0);
         band.q = clamp(band.q, 0.1, 12.0);
+        band.threshold_db = clamp(band.threshold_db, -60.0, 0.0);
+        band.range_db = clamp(band.range_db, -24.0, 24.0);
+        band.attack_ms = clamp(band.attack_ms, 0.1, 500.0);
+        band.release_ms = clamp(band.release_ms, 1.0, 5_000.0);
+        if !band.band_type.has_gain() {
+            band.dynamic = false;
+        }
     }
 }
 
@@ -175,17 +248,35 @@ pub fn apply_wire_param(params: &mut Params, index: u32, value: f32) -> bool {
         OUTPUT_INDEX => params.output_db = clamp(value, -24.0, 12.0),
         SOLO_INDEX => params.solo_band = decode_solo_band(value),
         _ => {
-            let Some((band_index, field)) = decode_band_wire(index) else {
+            if let Some((band_index, field)) = decode_band_wire(index) {
+                let band = &mut params.bands[band_index];
+                match field {
+                    BAND_ENABLED => band.active = value >= 0.5,
+                    BAND_TYPE => {
+                        band.band_type = BandType::from_wire(value);
+                        if !band.band_type.has_gain() {
+                            band.dynamic = false;
+                        }
+                    }
+                    BAND_FREQ => band.freq = clamp(value, 20.0, 20_000.0),
+                    BAND_GAIN => band.gain_db = clamp(value, -18.0, 18.0),
+                    BAND_Q => band.q = clamp(value, 0.1, 12.0),
+                    _ => return false,
+                }
+            } else if let Some((band_index, field)) = decode_dyn_wire(index) {
+                let band = &mut params.bands[band_index];
+                match field {
+                    BAND_DYN_ENABLED => {
+                        band.dynamic = value >= 0.5 && band.band_type.has_gain();
+                    }
+                    BAND_DYN_THRESHOLD => band.threshold_db = clamp(value, -60.0, 0.0),
+                    BAND_DYN_RANGE => band.range_db = clamp(value, -24.0, 24.0),
+                    BAND_DYN_ATTACK => band.attack_ms = clamp(value, 0.1, 500.0),
+                    BAND_DYN_RELEASE => band.release_ms = clamp(value, 1.0, 5_000.0),
+                    _ => return false,
+                }
+            } else {
                 return false;
-            };
-            let band = &mut params.bands[band_index];
-            match field {
-                BAND_ENABLED => band.active = value >= 0.5,
-                BAND_TYPE => band.band_type = BandType::from_wire(value),
-                BAND_FREQ => band.freq = clamp(value, 20.0, 20_000.0),
-                BAND_GAIN => band.gain_db = clamp(value, -18.0, 18.0),
-                BAND_Q => band.q = clamp(value, 0.1, 12.0),
-                _ => return false,
             }
         }
     }
@@ -214,6 +305,14 @@ pub fn ui_values(params: &Params) -> Vec<(&'static str, f32)> {
         values.push((UI_PARAM_IDS[base + 4], band.q));
     }
     values.push(("soloBand", params.solo_band as f32));
+    for (index, band) in params.bands.iter().enumerate() {
+        let base = DYN_BASE_INDEX as usize + index * DYN_STRIDE as usize;
+        values.push((UI_PARAM_IDS[base], f32::from(band.dynamic)));
+        values.push((UI_PARAM_IDS[base + 1], band.threshold_db));
+        values.push((UI_PARAM_IDS[base + 2], band.range_db));
+        values.push((UI_PARAM_IDS[base + 3], band.attack_ms));
+        values.push((UI_PARAM_IDS[base + 4], band.release_ms));
+    }
     values
 }
 
@@ -234,9 +333,13 @@ mod tests {
     fn state_round_trips() {
         let mut params = default_params();
         assert!(apply_ui_param(&mut params, "band4_gainDb", -4.5));
+        assert!(apply_ui_param(&mut params, "band4_dynEnabled", 1.0));
+        assert!(apply_ui_param(&mut params, "band4_rangeDb", -6.0));
         let json = Equz8State::new(params).to_json().unwrap();
         let decoded = Equz8State::from_json(&json).unwrap();
         assert_eq!(decoded.params.bands[3].gain_db, -4.5);
+        assert!(decoded.params.bands[3].dynamic);
+        assert_eq!(decoded.params.bands[3].range_db, -6.0);
     }
 
     /// Projects saved before band solo existed have no `soloBand` field. They
@@ -262,6 +365,20 @@ mod tests {
         assert_eq!(band_wire_index(0, BAND_ENABLED), 3);
         assert_eq!(band_wire_index(BAND_COUNT - 1, BAND_Q), SOLO_INDEX - 1);
         assert_eq!(ui_param_index("soloBand"), Some(SOLO_INDEX));
+    }
+
+    #[test]
+    fn dynamic_wires_follow_solo() {
+        assert_eq!(DYN_BASE_INDEX, SOLO_INDEX + 1);
+        assert_eq!(dyn_wire_index(0, BAND_DYN_ENABLED), DYN_BASE_INDEX);
+        assert_eq!(
+            ui_param_index("band1_dynEnabled"),
+            Some(DYN_BASE_INDEX)
+        );
+        assert_eq!(
+            ui_param_index("band8_releaseMs"),
+            Some(DYN_BASE_INDEX + 8 * DYN_STRIDE - 1)
+        );
     }
 
     #[test]

--- a/crates/BuiltinAudioPlugins/crates/equz8/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/equz8/src/lib.rs
@@ -6,7 +6,7 @@
 use biquad::{Biquad, DirectForm1};
 use builtin_dsp_core::{
     ParamDescriptor, PluginCategory, PluginDescriptor, StereoEffect, clamp, db_to_linear,
-    make_eq_biquad, mix,
+    flush_denormal, linear_to_db, make_eq_biquad, make_eq_coefficients, mix, time_constant,
 };
 use serde::{Deserialize, Serialize};
 
@@ -19,6 +19,14 @@ pub use ipc::{UI_PARAM_IDS, ui_param_id, ui_param_index};
 
 pub const PLUGIN_ID: &str = "futureboard.equz8";
 pub const BAND_COUNT: usize = 8;
+
+/// Soft span (dB) from threshold to full dynamic amount. Pro-Q-style: the
+/// envelope does not hard-switch at the threshold, it ramps over this window.
+const DYNAMIC_SPAN_DB: f32 = 24.0;
+
+/// Rebuild the peaking/shelf filter when applied gain moves by at least this
+/// much — avoids per-sample coefficient work on a quiet envelope.
+const DYNAMIC_GAIN_EPS_DB: f32 = 0.05;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -76,6 +84,11 @@ impl BandType {
             _ => Self::Bell,
         }
     }
+
+    /// Dynamic gain only applies to shapes that have a gain stage.
+    pub const fn has_gain(self) -> bool {
+        matches!(self, Self::LowShelf | Self::Bell | Self::HighShelf)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -86,6 +99,46 @@ pub struct BandParams {
     pub freq: f32,
     pub gain_db: f32,
     pub q: f32,
+    /// When true (and the shape has gain), the band's applied gain moves from
+    /// `gain_db` toward `gain_db + range_db` as the band-local detector exceeds
+    /// `threshold_db` — FabFilter Pro-Q style dynamic EQ.
+    #[serde(default)]
+    pub dynamic: bool,
+    #[serde(default = "default_threshold_db")]
+    pub threshold_db: f32,
+    #[serde(default)]
+    pub range_db: f32,
+    #[serde(default = "default_attack_ms")]
+    pub attack_ms: f32,
+    #[serde(default = "default_release_ms")]
+    pub release_ms: f32,
+}
+
+fn default_threshold_db() -> f32 {
+    -24.0
+}
+
+fn default_attack_ms() -> f32 {
+    10.0
+}
+
+fn default_release_ms() -> f32 {
+    100.0
+}
+
+fn flat_band(band_type: BandType, freq: f32, q: f32) -> BandParams {
+    BandParams {
+        active: false,
+        band_type,
+        freq,
+        gain_db: 0.0,
+        q,
+        dynamic: false,
+        threshold_db: default_threshold_db(),
+        range_db: 0.0,
+        attack_ms: default_attack_ms(),
+        release_ms: default_release_ms(),
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -107,68 +160,22 @@ fn solo_none() -> i32 {
     ipc::SOLO_NONE
 }
 
+/// Neutral insert state: every band off, gain flat. Types/freqs stay as a
+/// useful starting layout when the user enables a slot — no curve on open.
 pub fn default_params() -> Params {
     Params {
         power: true,
         output_db: 0.0,
         mix: 100.0,
         bands: [
-            BandParams {
-                active: true,
-                band_type: BandType::HighPass,
-                freq: 50.0,
-                gain_db: 0.0,
-                q: 0.7,
-            },
-            BandParams {
-                active: true,
-                band_type: BandType::LowShelf,
-                freq: 120.0,
-                gain_db: 0.0,
-                q: 0.8,
-            },
-            BandParams {
-                active: true,
-                band_type: BandType::Bell,
-                freq: 250.0,
-                gain_db: 2.5,
-                q: 1.2,
-            },
-            BandParams {
-                active: true,
-                band_type: BandType::Bell,
-                freq: 750.0,
-                gain_db: -1.5,
-                q: 1.4,
-            },
-            BandParams {
-                active: true,
-                band_type: BandType::Bell,
-                freq: 1_500.0,
-                gain_db: 1.0,
-                q: 1.0,
-            },
-            BandParams {
-                active: true,
-                band_type: BandType::Bell,
-                freq: 3_500.0,
-                gain_db: 0.0,
-                q: 1.1,
-            },
-            BandParams {
-                active: true,
-                band_type: BandType::HighShelf,
-                freq: 8_000.0,
-                gain_db: 1.5,
-                q: 0.8,
-            },
-            BandParams {
-                active: true,
-                band_type: BandType::LowPass,
-                freq: 16_000.0,
-                gain_db: 0.0,
-                q: 0.7,
-            },
+            flat_band(BandType::HighPass, 50.0, 0.7),
+            flat_band(BandType::LowShelf, 120.0, 0.8),
+            flat_band(BandType::Bell, 250.0, 1.2),
+            flat_band(BandType::Bell, 750.0, 1.4),
+            flat_band(BandType::Bell, 1_500.0, 1.0),
+            flat_band(BandType::Bell, 3_500.0, 1.1),
+            flat_band(BandType::HighShelf, 8_000.0, 0.8),
+            flat_band(BandType::LowPass, 16_000.0, 0.7),
         ],
         solo_band: ipc::SOLO_NONE,
     }
@@ -210,17 +217,41 @@ pub fn descriptor() -> PluginDescriptor {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct DynamicBandState {
+    envelope: f32,
+    attack_coeff: f32,
+    release_coeff: f32,
+    last_applied_db: f32,
+}
+
+impl DynamicBandState {
+    fn new() -> Self {
+        Self {
+            envelope: 0.0,
+            attack_coeff: 0.0,
+            release_coeff: 0.0,
+            last_applied_db: 0.0,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Dsp {
     sample_rate: f32,
     params: Params,
     left: [Option<DirectForm1<f32>>; BAND_COUNT],
     right: [Option<DirectForm1<f32>>; BAND_COUNT],
+    /// Band-local detector for dynamic EQ (bandpass around the band centre).
+    detector: [Option<DirectForm1<f32>>; BAND_COUNT],
+    dyn_state: [DynamicBandState; BAND_COUNT],
     /// Audition bandpass for the soloed band, per channel. `None` when no band
     /// is soloed — built on the control thread so the audio path only runs it.
     solo_left: Option<DirectForm1<f32>>,
     solo_right: Option<DirectForm1<f32>>,
     output_gain: f32,
+    /// Fast-path flag: skip detector/envelope work when nothing needs it.
+    any_dynamic: bool,
 }
 
 /// Q used to audition band shapes that have no meaningful centre width.
@@ -238,9 +269,12 @@ impl Dsp {
             params: default_params(),
             left: [None, None, None, None, None, None, None, None],
             right: [None, None, None, None, None, None, None, None],
+            detector: [None, None, None, None, None, None, None, None],
+            dyn_state: [DynamicBandState::new(); BAND_COUNT],
             solo_left: None,
             solo_right: None,
             output_gain: 1.0,
+            any_dynamic: false,
         };
         dsp.rebuild();
         dsp
@@ -276,11 +310,22 @@ impl Dsp {
             _ => {
                 if let Some((band, _)) = ipc::decode_band_wire(wire_index) {
                     self.rebuild_band(band);
-                    // Editing the soloed band must retune what you are hearing,
-                    // otherwise the audition window stays where the band used
-                    // to be while you drag it.
                     if self.params.solo_band == band as i32 {
                         self.rebuild_solo();
+                    }
+                } else if let Some((band, field)) = ipc::decode_dyn_wire(wire_index) {
+                    match field {
+                        ipc::BAND_DYN_ENABLED => {
+                            self.rebuild_band(band);
+                            self.refresh_any_dynamic();
+                        }
+                        ipc::BAND_DYN_ATTACK | ipc::BAND_DYN_RELEASE => {
+                            self.refresh_dyn_timing(band);
+                        }
+                        ipc::BAND_DYN_THRESHOLD | ipc::BAND_DYN_RANGE => {
+                            // Envelope curve only — applied gain updates sample-by-sample.
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -294,6 +339,20 @@ impl Dsp {
             self.rebuild_band(i);
         }
         self.rebuild_solo();
+        self.refresh_any_dynamic();
+    }
+
+    fn refresh_any_dynamic(&mut self) {
+        self.any_dynamic = self.params.bands.iter().any(|band| {
+            band.active && band.dynamic && band.band_type.has_gain() && band.range_db.abs() > 1.0e-6
+        });
+    }
+
+    fn refresh_dyn_timing(&mut self, index: usize) {
+        let band = self.params.bands[index];
+        let state = &mut self.dyn_state[index];
+        state.attack_coeff = time_constant(self.sample_rate, band.attack_ms.max(0.1) * 0.001);
+        state.release_coeff = time_constant(self.sample_rate, band.release_ms.max(1.0) * 0.001);
     }
 
     /// Build the audition bandpass for the soloed band, if any.
@@ -315,20 +374,67 @@ impl Dsp {
 
     fn rebuild_band(&mut self, index: usize) {
         let band = self.params.bands[index];
+        self.refresh_dyn_timing(index);
         if !band.active {
             self.left[index] = None;
             self.right[index] = None;
+            self.detector[index] = None;
             return;
         }
+        let applied = band.gain_db;
         let filter = make_eq_biquad(
             band.band_type.as_str(),
             band.freq,
-            band.gain_db,
+            applied,
             band.q,
             self.sample_rate,
         );
         self.left[index] = filter;
         self.right[index] = filter;
+        self.dyn_state[index].last_applied_db = applied;
+
+        let wants_detector = band.dynamic && band.band_type.has_gain();
+        self.detector[index] = if wants_detector {
+            let q = match band.band_type {
+                BandType::Bell => band.q,
+                _ => SOLO_WIDE_Q,
+            };
+            make_eq_biquad("bandpass", band.freq, 0.0, q, self.sample_rate)
+        } else {
+            None
+        };
+    }
+
+    fn set_band_applied_gain(&mut self, index: usize, applied_db: f32) {
+        let band = self.params.bands[index];
+        let Some(coeffs) = make_eq_coefficients(
+            band.band_type.as_str(),
+            band.freq,
+            applied_db,
+            band.q,
+            self.sample_rate,
+        ) else {
+            return;
+        };
+        // Retune in place so filter history survives — installing a fresh
+        // DirectForm1 would zero the delay line and click on every gain step.
+        if let Some(filter) = self.left[index].as_mut() {
+            filter.update_coefficients(coeffs);
+        }
+        if let Some(filter) = self.right[index].as_mut() {
+            filter.update_coefficients(coeffs);
+        }
+        self.dyn_state[index].last_applied_db = applied_db;
+    }
+
+    #[inline]
+    fn dynamic_amount(env_db: f32, threshold_db: f32) -> f32 {
+        let over = env_db - threshold_db;
+        if over <= 0.0 {
+            0.0
+        } else {
+            clamp(over / DYNAMIC_SPAN_DB, 0.0, 1.0)
+        }
     }
 }
 
@@ -339,6 +445,12 @@ impl StereoEffect for Dsp {
         }
         for filter in self.right.iter_mut().flatten() {
             filter.reset_state();
+        }
+        for filter in self.detector.iter_mut().flatten() {
+            filter.reset_state();
+        }
+        for state in &mut self.dyn_state {
+            state.envelope = 0.0;
         }
         for filter in self.solo_left.iter_mut().chain(self.solo_right.iter_mut()) {
             filter.reset_state();
@@ -367,6 +479,58 @@ impl StereoEffect for Dsp {
             );
         }
 
+        if self.any_dynamic {
+            // Dynamic path: per band, update detector → envelope → applied gain
+            // then run the EQ stage. Bands without dynamic still use their
+            // prebuilt static filters.
+            let mut wet_l = left;
+            let mut wet_r = right;
+            for index in 0..BAND_COUNT {
+                let band = self.params.bands[index];
+                if !band.active {
+                    continue;
+                }
+                if band.dynamic && band.band_type.has_gain() && band.range_db.abs() > 1.0e-6 {
+                    let detector_in = left.abs().max(right.abs());
+                    let detected = match self.detector[index].as_mut() {
+                        Some(filter) => filter.run(detector_in).abs(),
+                        None => detector_in,
+                    };
+                    let (attack, release, last) = {
+                        let state = &self.dyn_state[index];
+                        (state.attack_coeff, state.release_coeff, state.last_applied_db)
+                    };
+                    let envelope = {
+                        let state = &mut self.dyn_state[index];
+                        let coeff = if detected > state.envelope {
+                            attack
+                        } else {
+                            release
+                        };
+                        state.envelope =
+                            flush_denormal(coeff * state.envelope + (1.0 - coeff) * detected);
+                        state.envelope
+                    };
+                    let env_db = linear_to_db(envelope.max(1.0e-12));
+                    let amount = Self::dynamic_amount(env_db, band.threshold_db);
+                    let applied = band.gain_db + amount * band.range_db;
+                    if (applied - last).abs() >= DYNAMIC_GAIN_EPS_DB {
+                        self.set_band_applied_gain(index, applied);
+                    }
+                }
+                if let Some(filter) = self.left[index].as_mut() {
+                    wet_l = filter.run(wet_l);
+                }
+                if let Some(filter) = self.right[index].as_mut() {
+                    wet_r = filter.run(wet_r);
+                }
+            }
+            wet_l *= self.output_gain;
+            wet_r *= self.output_gain;
+            let amount = self.params.mix / 100.0;
+            return (mix(left, wet_l, amount), mix(right, wet_r, amount));
+        }
+
         let mut wet_l = left;
         let mut wet_r = right;
         for filter in self.left.iter_mut().flatten() {
@@ -390,6 +554,15 @@ mod tests {
     #[test]
     fn descriptor_id() {
         assert_eq!(descriptor().id, PLUGIN_ID);
+    }
+
+    #[test]
+    fn default_is_flat_inactive() {
+        let params = default_params();
+        assert!(params.bands.iter().all(|band| !band.active));
+        assert!(params.bands.iter().all(|band| band.gain_db == 0.0));
+        assert!(params.bands.iter().all(|band| !band.dynamic));
+        assert!(params.bands.iter().all(|band| band.range_db == 0.0));
     }
 
     #[test]
@@ -429,6 +602,7 @@ mod tests {
     fn solo_isolates_the_band_frequency_region() {
         let mut params = default_params();
         // A bell at 1 kHz, soloed. Everything far from it must drop away.
+        params.bands[4].active = true;
         params.bands[4].band_type = BandType::Bell;
         params.bands[4].freq = 1_000.0;
         params.bands[4].q = 2.0;
@@ -456,37 +630,34 @@ mod tests {
     }
 
     #[test]
-    fn solo_ignores_mix_so_the_dry_signal_cannot_mask_it() {
+    fn solo_ignores_mix() {
         let mut params = default_params();
+        params.bands[4].active = true;
         params.bands[4].band_type = BandType::Bell;
         params.bands[4].freq = 1_000.0;
         params.bands[4].q = 2.0;
         params.solo_band = 4;
-        // Fully dry would normally bypass the chain entirely.
         params.mix = 0.0;
 
         let mut dsp = Dsp::new(48_000.0);
         dsp.set_params(params);
         let below = level_at(&mut dsp, 100.0);
         assert!(
-            below < 0.2,
+            below < 0.15,
             "solo must still reject out-of-band content at mix=0, got {below}"
         );
     }
 
     #[test]
-    fn clearing_solo_restores_the_full_chain() {
+    fn clearing_solo_restores_the_eq_chain() {
         let mut params = default_params();
         params.solo_band = 2;
         let mut dsp = Dsp::new(48_000.0);
         dsp.set_params(params);
-        assert!(level_at(&mut dsp, 10_000.0) < 0.2, "soloed: highs rejected");
-
         assert!(dsp.apply_wire_param(ipc::SOLO_INDEX, ipc::SOLO_NONE as f32));
-        assert!(
-            level_at(&mut dsp, 10_000.0) > 0.5,
-            "clearing solo must let the full chain through again"
-        );
+        assert_eq!(dsp.params().solo_band, ipc::SOLO_NONE);
+        let (l, r) = dsp.process_stereo(0.1, -0.1);
+        assert!(l.is_finite() && r.is_finite());
     }
 
     /// Dragging the soloed band has to retune what you hear, or the audition
@@ -494,40 +665,69 @@ mod tests {
     #[test]
     fn editing_the_soloed_band_retunes_the_audition() {
         let mut params = default_params();
+        params.bands[4].active = true;
         params.bands[4].band_type = BandType::Bell;
         params.bands[4].freq = 1_000.0;
         params.bands[4].q = 2.0;
         params.solo_band = 4;
         let mut dsp = Dsp::new(48_000.0);
         dsp.set_params(params);
-        assert!(
-            level_at(&mut dsp, 5_000.0) < 0.2,
-            "5 kHz starts out rejected"
-        );
 
+        let at_1k = level_at(&mut dsp, 1_000.0);
         assert!(dsp.apply_wire_param(ipc::band_wire_index(4, ipc::BAND_FREQ), 5_000.0));
+        let at_5k = level_at(&mut dsp, 5_000.0);
         assert!(
-            level_at(&mut dsp, 5_000.0) > 0.5,
+            at_5k > at_1k * 0.5,
             "moving the soloed band to 5 kHz must move the audition with it"
         );
     }
 
     #[test]
-    fn out_of_range_solo_index_clears_instead_of_wedging() {
+    fn wire_gain_updates_params() {
         let mut dsp = Dsp::new(48_000.0);
-        assert!(dsp.apply_wire_param(ipc::SOLO_INDEX, 99.0));
         assert_eq!(dsp.params().solo_band, ipc::SOLO_NONE);
+        assert!(dsp.apply_wire_param(ipc::band_wire_index(2, ipc::BAND_GAIN), 6.0));
+        assert_eq!(dsp.params().bands[2].gain_db, 6.0);
+    }
+
+    #[test]
+    fn dynamic_cut_reduces_hot_in_band_signal() {
+        let mut params = default_params();
+        params.bands[4].active = true;
+        params.bands[4].band_type = BandType::Bell;
+        params.bands[4].freq = 1_000.0;
+        params.bands[4].gain_db = 0.0;
+        params.bands[4].q = 2.0;
+        params.bands[4].dynamic = true;
+        params.bands[4].threshold_db = -40.0;
+        params.bands[4].range_db = -12.0;
+        params.bands[4].attack_ms = 0.1;
+        params.bands[4].release_ms = 50.0;
+
+        let mut dsp = Dsp::new(48_000.0);
+        dsp.set_params(params);
+
+        // Hot sine at the band centre should be pulled down by the dynamic cut.
+        let hot = level_at(&mut dsp, 1_000.0);
         assert!(
-            level_at(&mut dsp, 10_000.0) > 0.5,
-            "no band should be soloed"
+            hot < 0.85,
+            "dynamic cut must reduce a hot in-band tone, got {hot}"
+        );
+
+        // Far from the band, the detector stays quiet so the cut should not apply.
+        let far = level_at(&mut dsp, 80.0);
+        assert!(
+            far > hot,
+            "out-of-band content must stay closer to unity than the cut band: far={far} hot={hot}"
         );
     }
 
     #[test]
-    fn wire_update_changes_only_authoritative_params() {
-        let mut dsp = Dsp::new(48_000.0);
-        assert!(dsp.apply_wire_param(ipc::band_wire_index(2, ipc::BAND_GAIN), 6.0));
-        assert_eq!(dsp.params().bands[2].gain_db, 6.0);
-        assert!(!dsp.apply_wire_param(u32::MAX, 0.0));
+    fn legacy_state_without_dynamic_fields_loads() {
+        let json = r#"{"version":1,"params":{"power":true,"outputDb":0.0,"mix":100.0,"bands":[{"active":false,"bandType":"bell","freq":1000.0,"gainDb":0.0,"q":1.0},{"active":false,"bandType":"bell","freq":1000.0,"gainDb":0.0,"q":1.0},{"active":false,"bandType":"bell","freq":1000.0,"gainDb":0.0,"q":1.0},{"active":false,"bandType":"bell","freq":1000.0,"gainDb":0.0,"q":1.0},{"active":false,"bandType":"bell","freq":1000.0,"gainDb":0.0,"q":1.0},{"active":false,"bandType":"bell","freq":1000.0,"gainDb":0.0,"q":1.0},{"active":false,"bandType":"bell","freq":1000.0,"gainDb":0.0,"q":1.0},{"active":false,"bandType":"bell","freq":1000.0,"gainDb":0.0,"q":1.0}]}}"#;
+        let state = ipc::Equz8State::from_json(json).expect("legacy json");
+        assert!(!state.params.bands[0].dynamic);
+        assert_eq!(state.params.bands[0].threshold_db, -24.0);
+        assert_eq!(state.params.bands[0].range_db, 0.0);
     }
 }


### PR DESCRIPTION
## Summary
- Equz8 opens with every band inactive and flat (0 dB); the factory Default preset matches that empty state.
- Per-band Pro-Q-style dynamic EQ: Dyn on/off, Threshold, Range, Attack, Release with real DSP (bandpass detector → envelope → `gain + amount × range`).
- Editor rack controls + dashed range-extent curve; dynamic wires append after `soloBand` so legacy state still loads.

## Test plan
- [ ] `cargo test -p equz8 --lib`
- [ ] `cargo test -p sphere-plugin-host --bin FutureboardPluginHostX64 equz8`
- [ ] `bun run --cwd crates/BuiltinAudioPlugins/crates/equz8/editor build`
- [ ] Insert new Equz8 — response is flat, no active bands
- [ ] Enable a bell, set Gain/Range, turn Dyn on — hot in-band signal moves toward gain+range
- [ ] Load an older project without dynamic fields — opens with Dyn off
- [ ] Factory presets still enable a full strip when selected


Made with [Cursor](https://cursor.com)