### PR TITLE
Add Transient built-in plugin (Svelte editor + Rust DSP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "fa2a",
  "fa76",
  "meowsyn",
+ "transient",
  "wrapsynth",
 ]
 
@@ -7477,6 +7478,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sphere_directaudioengine",
+ "transient",
  "verbspace",
  "windows 0.61.3",
  "wrapsynth",
@@ -7542,6 +7544,7 @@ dependencies = [
  "sphere-graphic-engine",
  "sphere-plugin-host",
  "sphere_directaudioengine",
+ "transient",
  "unicode-segmentation",
  "verbspace",
  "wgpu",
@@ -8617,6 +8620,16 @@ dependencies = [
  "rand_distr",
  "rustfft",
  "tract-nnef",
+]
+
+[[package]]
+name = "transient"
+version = "0.1.0"
+dependencies = [
+ "builtin_dsp_core",
+ "builtin_ui_embed",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "crates/BuiltinAudioPlugins/crates/fa76",
     "crates/BuiltinAudioPlugins/crates/burnLimit",
     "crates/BuiltinAudioPlugins/crates/67Clipper",
+    "crates/BuiltinAudioPlugins/crates/Transient",
     "crates/BuiltinAudioPlugins/crates/c1073",
     "crates/BuiltinAudioPlugins/crates/meowsyn",
     "crates/BuiltinAudioPlugins/crates/wrapsynth",
@@ -107,6 +108,7 @@ echospace = { path = "crates/BuiltinAudioPlugins/crates/echospace" }
 fa76 = { path = "crates/BuiltinAudioPlugins/crates/fa76" }
 burnlimit = { path = "crates/BuiltinAudioPlugins/crates/burnLimit" }
 clipper67 = { path = "crates/BuiltinAudioPlugins/crates/67Clipper" }
+transient = { path = "crates/BuiltinAudioPlugins/crates/Transient" }
 c1073 = { path = "crates/BuiltinAudioPlugins/crates/c1073" }
 meowsyn = { path = "crates/BuiltinAudioPlugins/crates/meowsyn" }
 wrapsynth = { path = "crates/BuiltinAudioPlugins/crates/wrapsynth" }

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,23 @@
         "vite-plugin-singlefile": "^2.3.3",
       },
     },
+    "crates/BuiltinAudioPlugins/crates/Transient/editorui": {
+      "name": "transient-editor",
+      "version": "0.0.0",
+      "dependencies": {
+        "svelte": "^5.51.0",
+      },
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^6.2.1",
+        "@tsconfig/svelte": "^5.0.5",
+        "@types/bun": "^1.3.14",
+        "@types/node": "^24",
+        "svelte-check": "^4.4.2",
+        "typescript": "^5.9.3",
+        "vite": "^7.1.14",
+        "vite-plugin-singlefile": "^2.3.3",
+      },
+    },
     "crates/BuiltinAudioPlugins/crates/burnLimit/editorui": {
       "name": "burnlimit-editor",
       "version": "0.0.0",
@@ -1225,6 +1242,8 @@
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "transient-editor": ["transient-editor@workspace:crates/BuiltinAudioPlugins/crates/Transient/editorui"],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 

--- a/crates/BuiltinAudioPlugins/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/Cargo.toml
@@ -23,6 +23,7 @@ echospace.workspace = true
 fa76.workspace = true
 burnlimit.workspace = true
 clipper67.workspace = true
+transient.workspace = true
 c1073.workspace = true
 meowsyn.workspace = true
 wrapsynth.workspace = true

--- a/crates/BuiltinAudioPlugins/crates/Transient/Cargo.toml
+++ b/crates/BuiltinAudioPlugins/crates/Transient/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "transient"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Transient — attack/sustain transient shaper DSP core"
+
+[lib]
+name = "transient"
+# `rlib` for the umbrella crate / tests; `cdylib` so it also compiles as a
+# Built-in Plugin dynamic library (C entry points are a later slice).
+crate-type = ["rlib", "cdylib"]
+
+[dependencies]
+builtin-dsp-core.workspace = true
+builtin-ui-embed.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[build-dependencies]
+# Build-time only: turns `editorui/dist` into the embedded asset table. Must
+# stay pointed at the dependency-free `builtin_ui_embed`, never at the
+# `BuiltinAudioPlugins` umbrella — see rodharerist's manifest for why.
+builtin-ui-embed = { workspace = true, features = ["generate"] }
+
+[lints]
+workspace = true

--- a/crates/BuiltinAudioPlugins/crates/Transient/build.rs
+++ b/crates/BuiltinAudioPlugins/crates/Transient/build.rs
@@ -1,0 +1,32 @@
+//! Embeds the compiled Svelte editor (`editorui/dist`) into the library.
+//!
+//! The generator enumerates `dist/` every build, so Vite's content-hashed
+//! filenames are never hard-coded. A missing or unbuilt `dist/` is not an
+//! error: an empty table is emitted and the crate still compiles, which keeps
+//! `cargo test -p transient` working for anyone who has not run
+//! `bun run build` in `editorui/`.
+
+use std::path::PathBuf;
+
+fn main() {
+    let out_dir =
+        PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is always set for build scripts"));
+    let dist = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("editorui/dist");
+
+    let options = builtin_ui_embed::generate::GenerateOptions::from_out_dir(dist, out_dir);
+    match builtin_ui_embed::generate::generate(&options) {
+        Ok(report) if report.dist_present => {
+            println!(
+                "cargo:rustc-env=TRANSIENT_UI_ASSET_COUNT={}",
+                report.asset_count
+            );
+        }
+        Ok(_) => {
+            println!(
+                "cargo:warning=transient: editorui/dist not built; the plugin editor \
+                 will have no UI assets (run `bun run build` in editorui/)"
+            );
+        }
+        Err(error) => panic!("transient: failed to embed editor UI: {error}"),
+    }
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/README.md
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/README.md
@@ -1,0 +1,39 @@
+# Transient editor
+
+Embedded editor UI for the `transient` built-in plugin. Svelte 5 + Vite,
+bundled to a single `dist/index.html` by `vite-plugin-singlefile`, then
+embedded into the library and served by the native CEF host at
+`mikoplugin://transient/index.html`.
+
+## Character
+
+Attack / sustain shaper stage: scrolling waveform with teal signal accent,
+floating control panel (Attack / Sustain / Speed), In/Out/Shape meters, and a
+footer for Mix + Stereo Link. Dark charcoal surfaces shared with 67Clipper /
+BurnLimit, distinct teal accent.
+
+## Wire contract
+
+Mirrors `crates/Transient/src/ipc.rs` exactly:
+
+```
+power, attack, sustain, speed, mix, stereoLink
+```
+
+`params.ts` and `rust.ts` keep the editor's copy pinned to the Rust source via
+`params.test.ts`.
+
+## Develop
+
+```bash
+bun install
+bun run dev
+bun run build
+bun test
+```
+
+After a production build:
+
+```bash
+cargo build -p transient
+```

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/index.html
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Transient</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/package.json
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "transient-editor",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "svelte-check --tsconfig ./tsconfig.json && vite build",
+    "build:fast": "vite build",
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "preview": "vite preview",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "svelte": "^5.51.0"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^6.2.1",
+    "@tsconfig/svelte": "^5.0.5",
+    "@types/bun": "^1.3.14",
+    "@types/node": "^24",
+    "svelte-check": "^4.4.2",
+    "typescript": "^5.9.3",
+    "vite": "^7.1.14",
+    "vite-plugin-singlefile": "^2.3.3"
+  }
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/App.svelte
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/App.svelte
@@ -1,0 +1,462 @@
+<script lang="ts">
+  import {
+    connectBridge,
+    postParam,
+    type TransientParams,
+    type MeterFrame,
+  } from './bridge'
+  import {
+    DEFAULT_PARAMS,
+    FACTORY_PRESETS,
+    matchingPresetIndex,
+    postAllParams,
+  } from './presets'
+  import { PARAMS, type ParamId } from './params'
+  import {
+    HISTORY_LENGTH,
+    grNorm,
+    linearToDb,
+    pushHistory,
+    shouldTagPeak,
+    silentSample,
+    type HistorySample,
+  } from './meter'
+  import FlatKnob from './lib/FlatKnob.svelte'
+  import LevelMeters from './lib/LevelMeters.svelte'
+  import PresetControl from './lib/PresetControl.svelte'
+  import WaveDisplay from './lib/WaveDisplay.svelte'
+  import logo from './assets/logo.svg'
+
+  /**
+   * Local view of the parameters. Rust is the authority: this starts at the
+   * schema defaults, is replaced wholesale by `selectInstance`, and is only
+   * moved locally to keep a drag responsive.
+   */
+  let params = $state<TransientParams>({ ...DEFAULT_PARAMS })
+  let connected = $state(false)
+  let preset = $state<number | null>(0)
+
+  /** Latest telemetry frame. `null` until the host sends one. */
+  let meters = $state<MeterFrame | null>(null)
+  let history = $state<HistorySample[]>(
+    Array.from({ length: 48 }, () => silentSample()),
+  )
+  let tags = $state<{ x: number; y: number; label: string }[]>([])
+  let previousGr = 0
+
+  $effect(() =>
+    connectBridge(
+      (next) => {
+        params = next
+        preset = matchingPresetIndex(next)
+      },
+      (isConnected) => {
+        connected = isConnected
+        if (!isConnected) {
+          meters = null
+          history = Array.from({ length: 48 }, () => silentSample())
+          tags = []
+          previousGr = 0
+        }
+      },
+      (frame) => {
+        meters = frame
+        const sample: HistorySample = {
+          inDb: linearToDb(frame.inPeak),
+          rmsDb: linearToDb(frame.inRms),
+          outDb: linearToDb(frame.outPeak),
+          grDb: frame.gainReductionDb,
+        }
+        history = pushHistory(history, sample, HISTORY_LENGTH)
+
+        if (shouldTagPeak(sample.grDb, previousGr)) {
+          const next = [
+            ...tags,
+            {
+              x: 0.92,
+              y: grNorm(sample.grDb) * 0.5,
+              label: `${sample.grDb.toFixed(1)} dB`,
+            },
+          ]
+          tags = next.slice(-4).map((tag, index, list) => ({
+            ...tag,
+            x: 0.58 + index * (0.32 / Math.max(list.length, 1)),
+          }))
+        }
+        previousGr = sample.grDb
+      },
+    ),
+  )
+
+  $effect(() => {
+    if (!connected) return
+    const id = setInterval(() => {
+      tags = tags
+        .map((tag) => ({ ...tag, x: tag.x - 1 / HISTORY_LENGTH }))
+        .filter((tag) => tag.x > 0.05)
+    }, 1000 / 30)
+    return () => clearInterval(id)
+  })
+
+  function set(id: ParamId, value: number) {
+    params[id] = value
+    postParam(id, value)
+    preset = null
+  }
+
+  function setFlag(id: 'power' | 'stereoLink', value: boolean) {
+    params[id] = value
+    postParam(id, value ? 1 : 0)
+    if (id !== 'power') preset = null
+  }
+
+  function loadPreset(index: number) {
+    const wrapped =
+      ((index % FACTORY_PRESETS.length) + FACTORY_PRESETS.length) %
+      FACTORY_PRESETS.length
+    const next = { ...FACTORY_PRESETS[wrapped]!.params }
+    params = next
+    preset = wrapped
+    postAllParams(next)
+  }
+
+  const shapeReadout = $derived(
+    connected && meters ? meters.gainReductionDb.toFixed(1) : '—',
+  )
+  const outReadout = $derived(
+    connected && meters ? linearToDb(meters.outPeak).toFixed(1) : '—',
+  )
+</script>
+
+<div class="unit">
+  <div class="panel">
+    <header class="chrome">
+      <div class="brand">
+        <img class="logo" src={logo} alt="Transient" />
+      </div>
+
+      <PresetControl
+        {preset}
+        names={FACTORY_PRESETS.map((entry) => entry.name)}
+        onchange={loadPreset}
+        onprevious={() => loadPreset((preset ?? 0) - 1)}
+        onnext={() => loadPreset((preset ?? -1) + 1)}
+      />
+
+      <div class="chrome-actions">
+        <div class="readout-chip">
+          <span class="rlabel">SHAPE</span>
+          <span class="rvalue shape">{shapeReadout}</span>
+        </div>
+        <div class="readout-chip">
+          <span class="rlabel">OUT</span>
+          <span class="rvalue">{outReadout}</span>
+        </div>
+        <button
+          type="button"
+          class="chip"
+          class:on={!params.power}
+          onclick={() => setFlag('power', !params.power)}
+        >
+          Bypass
+        </button>
+      </div>
+    </header>
+
+    <div class="stage">
+      <div class="wave-wrap">
+        <WaveDisplay
+          {history}
+          ceilingDb={0}
+          live={connected && meters !== null}
+          {tags}
+        />
+
+        <div class="control-panel">
+          <div class="knobs">
+            <svg class="curve" viewBox="0 0 240 62" aria-hidden="true">
+              <path
+                d="M16 44 C 48 12, 72 12, 100 28 C 128 44, 160 52, 224 36"
+              />
+            </svg>
+            <FlatKnob
+              spec={PARAMS.attack}
+              value={params.attack}
+              onchange={(v) => set('attack', v)}
+              size="var(--knob-lg)"
+              disabled={!params.power}
+            />
+            <FlatKnob
+              spec={PARAMS.sustain}
+              value={params.sustain}
+              onchange={(v) => set('sustain', v)}
+              size="var(--knob-lg)"
+              disabled={!params.power}
+            />
+            <FlatKnob
+              spec={PARAMS.speed}
+              value={params.speed}
+              onchange={(v) => set('speed', v)}
+              size="var(--knob-md)"
+              disabled={!params.power}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class="side">
+        <LevelMeters
+          inPeak={meters?.inPeak ?? 0}
+          outPeak={meters?.outPeak ?? 0}
+          gainReductionDb={meters?.gainReductionDb ?? 0}
+          live={connected && meters !== null}
+          inClip={meters?.inClip ?? false}
+          outClip={meters?.outClip ?? false}
+        />
+      </div>
+    </div>
+
+    <footer class="footer">
+      <FlatKnob
+        spec={PARAMS.mix}
+        value={params.mix}
+        onchange={(v) => set('mix', v)}
+        size="var(--knob-sm)"
+        disabled={!params.power}
+      />
+
+      <div class="toggles">
+        <button
+          type="button"
+          class="chip"
+          class:on={params.stereoLink}
+          onclick={() => setFlag('stereoLink', !params.stereoLink)}
+        >
+          Stereo Link
+        </button>
+      </div>
+    </footer>
+  </div>
+</div>
+
+<style>
+  .unit {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    padding: var(--s3);
+    background: var(--bg);
+  }
+
+  .panel {
+    display: grid;
+    grid-template-rows: var(--chrome-h) minmax(0, 1fr) auto;
+    gap: var(--s3);
+    width: 100%;
+    height: 100%;
+    max-width: 68rem;
+    max-height: 36rem;
+    margin: auto;
+    padding: var(--s3) var(--s4);
+    border: 1px solid var(--border-hi);
+    border-radius: calc(var(--r) + 0.15rem);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 28%),
+      var(--panel);
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
+  }
+
+  .chrome {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: var(--s3);
+    min-height: var(--chrome-h);
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .logo {
+    width: min(100%, 10.5rem);
+    height: auto;
+  }
+
+  .chrome-actions {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: var(--s2);
+  }
+
+  .readout-chip {
+    display: flex;
+    align-items: baseline;
+    gap: 0.3rem;
+    height: var(--chrome-h);
+    padding: 0 0.6rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--inset);
+  }
+
+  .rlabel {
+    color: var(--text-muted);
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+  }
+
+  .rvalue {
+    min-width: 2.6ch;
+    color: var(--text);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    text-align: right;
+  }
+
+  .rvalue.shape {
+    color: var(--amber);
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: var(--chrome-h);
+    padding: 0 0.75rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 0.65rem;
+    font-weight: 650;
+    letter-spacing: 0.04em;
+    background: var(--inset);
+    white-space: nowrap;
+  }
+
+  .chip:hover {
+    color: var(--text);
+    border-color: var(--border-hi);
+  }
+
+  .chip.on {
+    color: var(--text);
+    border-color: rgba(46, 196, 182, 0.5);
+    background: var(--accent-dim);
+  }
+
+  .stage {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 5.75rem;
+    min-height: 0;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    background: var(--stage);
+  }
+
+  .wave-wrap {
+    position: relative;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .side {
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .control-panel {
+    position: absolute;
+    bottom: var(--s3);
+    left: var(--s3);
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    gap: var(--s4);
+    padding: 0.75rem 1.1rem;
+    border: 1px solid var(--border-hi);
+    border-radius: var(--r);
+    background: var(--float);
+    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(8px);
+  }
+
+  .knobs {
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    gap: 1.35rem;
+  }
+
+  .curve {
+    position: absolute;
+    top: -0.35rem;
+    left: 0;
+    z-index: 0;
+    width: 100%;
+    height: 3.4rem;
+    pointer-events: none;
+  }
+
+  .curve path {
+    fill: none;
+    stroke: rgba(46, 196, 182, 0.32);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+  }
+
+  .footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--s4);
+    min-height: var(--footer-h);
+  }
+
+  .toggles {
+    display: flex;
+    align-items: center;
+    gap: var(--s2);
+  }
+
+  @media (max-width: 960px) {
+    .panel {
+      max-height: none;
+    }
+
+    .chrome {
+      grid-template-columns: 1fr;
+      justify-items: start;
+      gap: var(--s2);
+    }
+
+    .chrome-actions {
+      justify-content: flex-start;
+    }
+
+    .stage {
+      grid-template-columns: 1fr;
+    }
+
+    .side {
+      display: none;
+    }
+
+    .control-panel {
+      flex-wrap: wrap;
+      right: var(--s3);
+    }
+
+    .footer {
+      flex-direction: column;
+      align-items: stretch;
+    }
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/app.css
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/app.css
@@ -1,0 +1,102 @@
+/*
+ * Transient — attack / sustain shaper faceplate.
+ *
+ * Dark charcoal UI with a teal signal accent for the transient path and a soft
+ * amber reserved for sustain shaping. Flat surfaces, thin borders, tabular
+ * numerals — same family as 67Clipper / BurnLimit, distinct accent.
+ */
+
+:root {
+  --bg: #05080a;
+  --panel: #10161a;
+  --panel-hi: #182026;
+  --inset: #0a0e11;
+  --stage: #06090b;
+  --float: rgba(16, 22, 26, 0.92);
+
+  --border: rgba(255, 255, 255, 0.075);
+  --border-hi: rgba(255, 255, 255, 0.14);
+
+  --text: #eef4f7;
+  --text-muted: rgba(170, 190, 199, 0.58);
+  --readout: #eef4f7;
+
+  --accent: #2ec4b6;
+  --accent-soft: #3fd4c6;
+  --accent-dim: rgba(46, 196, 182, 0.16);
+  --red: #e8483a;
+  --red-soft: rgba(232, 72, 58, 0.7);
+  --amber: #e8a23a;
+
+  --signal: var(--accent);
+  --gr: var(--amber);
+  --clip: var(--red);
+
+  --r: 0.6rem;
+  --r-sm: 0.35rem;
+
+  --s1: 0.25rem;
+  --s2: 0.5rem;
+  --s3: 0.75rem;
+  --s4: 1rem;
+  --s5: 1.25rem;
+
+  --chrome-h: 2.35rem;
+  --footer-h: 3.5rem;
+
+  --knob-lg: clamp(3.6rem, 6.5vw, 4.5rem);
+  --knob-md: clamp(2.9rem, 5vw, 3.5rem);
+  --knob-sm: clamp(2.35rem, 4vw, 2.75rem);
+
+  --ease: 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
+
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  min-width: 860px;
+  height: 100%;
+  min-height: 460px;
+  margin: 0;
+  overflow: hidden;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'IBM Plex Sans', 'Segoe UI', Helvetica, Arial, sans-serif;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum' 1;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  -webkit-font-smoothing: antialiased;
+  user-select: none;
+  cursor: default;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition:
+    color var(--ease),
+    background-color var(--ease),
+    border-color var(--ease);
+}
+
+button:focus-visible,
+select:focus-visible {
+  outline: 1.5px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/assets/logo.svg
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/assets/logo.svg
@@ -1,0 +1,5 @@
+<svg width="220" height="26" viewBox="0 0 220 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <text x="0" y="19" font-family="'IBM Plex Sans', 'Segoe UI', Helvetica, Arial, sans-serif" font-size="19" font-weight="700" letter-spacing="0.5">
+    <tspan fill="#eef4f7">TRAN</tspan><tspan fill="#2ec4b6">SIENT</tspan>
+  </text>
+</svg>

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/bridge.ts
@@ -1,0 +1,195 @@
+/**
+ * Native bridge for the Transient editor.
+ *
+ * Same wire contract every built-in editor speaks, plus the telemetry the
+ * waveform stage and meters run on: the host pushes `futureboard.meters` at
+ * ~30 Hz for the bound instance, carrying the levels and the shaping amount
+ * the DSP is actually applying. Nothing on this page invents a meter
+ * reading.
+ */
+
+export const BRIDGE_PROTOCOL_VERSION = 1
+export const PLUGIN_ID = 'transient'
+
+/** The state blob `transient::ipc::TransientState` serializes. */
+export type TransientParams = {
+  power: boolean
+  attack: number
+  sustain: number
+  speed: number
+  mix: number
+  stereoLink: boolean
+}
+
+/**
+ * One telemetry frame from the plugin host, measured on this insert.
+ *
+ * `gainReductionDb` is the absolute magnitude of the applied dynamic gain
+ * change in dB. Levels are linear 0..1.
+ */
+export type MeterFrame = {
+  inPeak: number
+  inRms: number
+  outPeak: number
+  outRms: number
+  gainReductionDb: number
+  inClip: boolean
+  outClip: boolean
+}
+
+type Binding = {
+  pluginId: string
+  instanceId: string
+  bindingGeneration: number
+}
+
+type SelectInstanceMessage = {
+  type: 'futureboard.selectInstance'
+  protocolVersion: number
+  pluginId: string
+  instanceId: string
+  bindingGeneration: number
+  stateRevision: number
+  state: unknown
+}
+
+type InstanceRemovedMessage = {
+  type: 'futureboard.instanceRemoved'
+  protocolVersion: number
+  instanceId: string
+}
+
+type MetersMessage = MeterFrame & {
+  type: 'futureboard.meters'
+  protocolVersion: number
+  instanceId: string
+}
+
+let binding: Binding | null = null
+const pending = new Map<string, number>()
+let scheduled = false
+
+function post(body: unknown) {
+  if (window.location.protocol !== 'mikoplugin:') return
+  try {
+    void fetch('__bridge', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }).catch(() => {})
+  } catch {
+    // A standalone design preview intentionally has no native endpoint.
+  }
+}
+
+function flush() {
+  scheduled = false
+  if (!binding || pending.size === 0) {
+    pending.clear()
+    return
+  }
+  const params = Array.from(pending, ([id, value]) => ({ id, value }))
+  pending.clear()
+  post({
+    type: 'futureboard.setParams',
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    ...binding,
+    params,
+  })
+}
+
+export function postParam(id: string, value: number) {
+  pending.set(id, value)
+  if (scheduled) return
+  scheduled = true
+  requestAnimationFrame(flush)
+}
+
+const NUMERIC_KEYS = ['attack', 'sustain', 'speed', 'mix'] as const
+
+function parseParams(state: unknown): TransientParams | null {
+  if (!state || typeof state !== 'object') return null
+  const candidate =
+    'params' in state ? (state as { params?: unknown }).params : state
+  if (!candidate || typeof candidate !== 'object') return null
+  const params = candidate as Record<string, unknown>
+
+  if (typeof params.power !== 'boolean') return null
+  if (typeof params.stereoLink !== 'boolean') return null
+  for (const key of NUMERIC_KEYS) {
+    const value = params[key]
+    if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  }
+  return params as unknown as TransientParams
+}
+
+export function connectBridge(
+  onParams: (params: TransientParams) => void,
+  onConnection: (connected: boolean) => void,
+  onMeters?: (frame: MeterFrame) => void,
+) {
+  post({
+    type: 'futureboard.bridgeReady',
+    protocolVersion: BRIDGE_PROTOCOL_VERSION,
+    bridgeVersion: BRIDGE_PROTOCOL_VERSION,
+    pluginId: PLUGIN_ID,
+  })
+
+  const listener = (event: MessageEvent) => {
+    const message = event.data as
+      | SelectInstanceMessage
+      | InstanceRemovedMessage
+      | MetersMessage
+      | undefined
+    if (!message || typeof message !== 'object') return
+
+    // Highest-rate message by far (~30 Hz), so it is matched before the rest
+    // and never reaches the binding bookkeeping below.
+    if (message.type === 'futureboard.meters') {
+      if (!onMeters || binding?.instanceId !== message.instanceId) return
+      onMeters({
+        inPeak: message.inPeak,
+        inRms: message.inRms,
+        outPeak: message.outPeak,
+        outRms: message.outRms,
+        gainReductionDb: message.gainReductionDb,
+        inClip: message.inClip,
+        outClip: message.outClip,
+      })
+      return
+    }
+
+    if (message.type === 'futureboard.selectInstance') {
+      binding = {
+        pluginId: message.pluginId,
+        instanceId: message.instanceId,
+        bindingGeneration: message.bindingGeneration,
+      }
+      pending.clear()
+      const params = parseParams(message.state)
+      if (params) onParams(params)
+      onConnection(true)
+      post({
+        type: 'futureboard.instanceReady',
+        protocolVersion: BRIDGE_PROTOCOL_VERSION,
+        pluginId: message.pluginId,
+        instanceId: message.instanceId,
+        bindingGeneration: message.bindingGeneration,
+        stateRevision: message.stateRevision,
+      })
+    } else if (
+      message.type === 'futureboard.instanceRemoved' &&
+      binding?.instanceId === message.instanceId
+    ) {
+      binding = null
+      pending.clear()
+      onConnection(false)
+    }
+  }
+
+  window.addEventListener('message', listener)
+  return () => {
+    window.removeEventListener('message', listener)
+    binding = null
+    pending.clear()
+  }
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/lib/FlatKnob.svelte
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/lib/FlatKnob.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+  import { clamp, format, fromNorm, toNorm, type ParamSpec } from '../params'
+
+  type Props = {
+    spec: ParamSpec
+    value: number
+    onchange: (value: number) => void
+    /** CSS size; defaults to `--knob-lg`. */
+    size?: string
+    disabled?: boolean
+  }
+
+  const { spec, value, onchange, size, disabled = false }: Props = $props()
+
+  const norm = $derived(toNorm(spec, value))
+
+  let dragging = $state(false)
+  let dragStartY = 0
+  let dragStartNorm = 0
+
+  /** Full 0→1 sweep; Shift multiplies for fine control. */
+  const TRAVEL_PX = 380
+
+  const START_DEG = -135
+  const SWEEP_DEG = 270
+  const pointerAngle = $derived(START_DEG + SWEEP_DEG * norm)
+
+  function commit(nextNorm: number) {
+    if (disabled) return
+    onchange(fromNorm(spec, clamp(nextNorm, 0, 1)))
+  }
+
+  function onPointerDown(event: PointerEvent) {
+    if (disabled || event.button !== 0) return
+    dragging = true
+    dragStartY = event.clientY
+    dragStartNorm = norm
+    ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
+    event.preventDefault()
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    if (!dragging) return
+    const travel = event.shiftKey ? TRAVEL_PX * 4 : TRAVEL_PX
+    commit(dragStartNorm + (dragStartY - event.clientY) / travel)
+  }
+
+  function onPointerUp(event: PointerEvent) {
+    if (!dragging) return
+    dragging = false
+    ;(event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId)
+  }
+
+  function onWheel(event: WheelEvent) {
+    if (disabled) return
+    event.preventDefault()
+    const step = event.shiftKey ? spec.step * 0.25 : spec.step
+    onchange(
+      clamp(value + (event.deltaY < 0 ? step : -step), spec.min, spec.max),
+    )
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    if (disabled) return
+    const step = event.shiftKey ? spec.step * 0.25 : spec.step
+    if (event.key === 'ArrowUp' || event.key === 'ArrowRight') {
+      event.preventDefault()
+      onchange(clamp(value + step, spec.min, spec.max))
+    } else if (event.key === 'ArrowDown' || event.key === 'ArrowLeft') {
+      event.preventDefault()
+      onchange(clamp(value - step, spec.min, spec.max))
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      onchange(spec.max)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      onchange(spec.min)
+    }
+  }
+</script>
+
+<div
+  class="knob"
+  class:disabled
+  class:dragging
+  style={size ? `--knob: ${size}` : undefined}
+>
+  <div
+    class="cap"
+    role="slider"
+    tabindex={disabled ? -1 : 0}
+    aria-label={spec.label}
+    aria-valuemin={spec.min}
+    aria-valuemax={spec.max}
+    aria-valuenow={value}
+    aria-valuetext="{format(spec, value)} {spec.unit}"
+    aria-disabled={disabled}
+    title="{spec.label} — drag vertically, Shift for fine, double-click to reset"
+    onpointerdown={onPointerDown}
+    onpointermove={onPointerMove}
+    onpointerup={onPointerUp}
+    onpointercancel={onPointerUp}
+    onwheel={onWheel}
+    onkeydown={onKeyDown}
+    ondblclick={() => !disabled && onchange(spec.default)}
+  >
+    <svg viewBox="0 0 80 80" aria-hidden="true">
+      <circle
+        class="track"
+        cx="40"
+        cy="40"
+        r="30"
+        fill="none"
+        pathLength="100"
+        stroke-dasharray="75 25"
+        transform="rotate(135 40 40)"
+      />
+      <circle
+        class="fill"
+        cx="40"
+        cy="40"
+        r="30"
+        fill="none"
+        pathLength="100"
+        stroke-dasharray="{(norm * 75).toFixed(2)} 100"
+        transform="rotate(135 40 40)"
+      />
+      <circle cx="40" cy="40" r="22" class="body" />
+      <g style="transform: rotate({pointerAngle}deg); transform-origin: 40px 40px">
+        <rect class="pointer" x="39" y="14" width="2" height="10" rx="1" />
+      </g>
+    </svg>
+  </div>
+  <div class="plate">
+    <div class="value">{format(spec, value)}<small>{spec.unit}</small></div>
+    <div class="name">{spec.label}</div>
+  </div>
+</div>
+
+<style>
+  .knob {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+
+  .knob.disabled {
+    opacity: 0.35;
+    pointer-events: none;
+  }
+
+  .cap {
+    width: var(--knob, var(--knob-lg));
+    height: var(--knob, var(--knob-lg));
+    cursor: ns-resize;
+    touch-action: none;
+    outline: none;
+  }
+
+  svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .track {
+    stroke: rgba(255, 255, 255, 0.1);
+    stroke-width: 5;
+    stroke-linecap: round;
+  }
+
+  .fill {
+    stroke: var(--accent);
+    stroke-width: 5;
+    stroke-linecap: round;
+  }
+
+  .body {
+    fill: #14181f;
+    stroke: rgba(255, 255, 255, 0.08);
+    stroke-width: 1;
+  }
+
+  .pointer {
+    fill: #f5f7fa;
+  }
+
+  .knob.dragging .fill {
+    stroke: var(--accent-soft);
+  }
+
+  .knob.dragging .pointer {
+    fill: var(--accent-soft);
+  }
+
+  .plate {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.1rem;
+  }
+
+  .value {
+    color: var(--text);
+    font-size: 0.72rem;
+    font-weight: 650;
+    letter-spacing: -0.02em;
+  }
+
+  .value small {
+    margin-left: 0.12rem;
+    color: var(--text-muted);
+    font-size: 0.52rem;
+  }
+
+  .name {
+    color: var(--text-muted);
+    font-size: 0.55rem;
+    font-weight: 650;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/lib/LevelMeters.svelte
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/lib/LevelMeters.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+  import { advance, grNorm, levelNorm, linearToDb } from '../meter'
+  import { untrack } from 'svelte'
+
+  type Props = {
+    inPeak: number
+    outPeak: number
+    gainReductionDb: number
+    live: boolean
+    inClip: boolean
+    outClip: boolean
+  }
+
+  const { inPeak, outPeak, gainReductionDb, live, inClip, outClip }: Props =
+    $props()
+
+  const inTarget = $derived(live ? 1 - levelNorm(linearToDb(inPeak)) : 0)
+  const outTarget = $derived(live ? 1 - levelNorm(linearToDb(outPeak)) : 0)
+  const grTarget = $derived(live ? grNorm(gainReductionDb) : 0)
+
+  let inBar = $state(untrack(() => inTarget))
+  let outBar = $state(untrack(() => outTarget))
+  let grBar = $state(untrack(() => grTarget))
+
+  $effect(() => {
+    let raf = 0
+    let last = performance.now()
+    const step = (now: number) => {
+      const dt = Math.min((now - last) / 1000, 0.25)
+      last = now
+      inBar = advance(inBar, inTarget, dt)
+      outBar = advance(outBar, outTarget, dt)
+      grBar = advance(grBar, grTarget, dt, 0.05)
+      raf = requestAnimationFrame(step)
+    }
+    raf = requestAnimationFrame(step)
+    return () => cancelAnimationFrame(raf)
+  })
+
+  const grDb = $derived(live ? gainReductionDb : null)
+</script>
+
+<aside class="meters" aria-label="Level meters">
+  <div class="bars">
+    <div class="col">
+      <div class="bar" role="img" aria-label="Input">
+        <div class="fill in" style="height: {(inBar * 100).toFixed(2)}%"></div>
+        <div class="clip-led" class:on={live && inClip}></div>
+      </div>
+      <span class="label">In</span>
+    </div>
+    <div class="col">
+      <div class="bar" role="img" aria-label="Output">
+        <div class="fill out" style="height: {(outBar * 100).toFixed(2)}%"></div>
+        <div class="clip-led" class:on={live && outClip}></div>
+      </div>
+      <span class="label">Out</span>
+    </div>
+    <div class="col gr">
+      <div class="bar" role="img" aria-label="Gain reduction">
+        <div class="fill gr" style="height: {(grBar * 100).toFixed(2)}%"></div>
+      </div>
+      <span class="label">GR</span>
+    </div>
+  </div>
+
+  <div class="readout">
+    <span class="num">{grDb === null ? '—' : `-${grDb.toFixed(1)}`}</span>
+    <span class="unit">dB</span>
+  </div>
+</aside>
+
+<style>
+  .meters {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s3);
+    height: 100%;
+    padding: var(--s3) var(--s2) var(--s2);
+    background: rgba(255, 255, 255, 0.02);
+    border-left: 1px solid var(--border);
+  }
+
+  .bars {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1.15fr;
+    gap: 0.35rem;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 0;
+  }
+
+  .bar {
+    position: relative;
+    flex: 1;
+    width: 100%;
+    min-height: 0;
+    overflow: hidden;
+    border-radius: var(--r-sm);
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .fill {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border-radius: inherit;
+  }
+
+  .fill.in {
+    background: #2f6ea8;
+  }
+
+  .fill.out {
+    background: var(--accent);
+  }
+
+  .fill.gr {
+    background: var(--red);
+  }
+
+  .clip-led {
+    position: absolute;
+    top: 0.25rem;
+    left: 50%;
+    width: 0.3rem;
+    height: 0.3rem;
+    transform: translateX(-50%);
+    border-radius: 50%;
+    background: #2a3038;
+  }
+
+  .clip-led.on {
+    background: var(--clip);
+  }
+
+  .label {
+    color: var(--text-muted);
+    font-size: 0.5rem;
+    font-weight: 650;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .readout {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 0.2rem;
+    padding-top: var(--s1);
+    border-top: 1px solid var(--border);
+  }
+
+  .num {
+    color: var(--red);
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+  }
+
+  .unit {
+    color: var(--text-muted);
+    font-size: 0.55rem;
+    font-weight: 650;
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/lib/PresetControl.svelte
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/lib/PresetControl.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  type Props = {
+    preset: number | null
+    names: string[]
+    onchange: (index: number) => void
+    onprevious: () => void
+    onnext: () => void
+  }
+
+  const { preset, names, onchange, onprevious, onnext }: Props = $props()
+</script>
+
+<div class="preset">
+  <button type="button" class="step" aria-label="Previous preset" onclick={onprevious}>
+    ‹
+  </button>
+  <label class="select">
+    <span>{preset === null ? 'Custom' : names[preset]}</span>
+    <select
+      aria-label="Preset"
+      value={preset ?? 'custom'}
+      onchange={(event) => {
+        const value = (event.currentTarget as HTMLSelectElement).value
+        if (value !== 'custom') onchange(Number(value))
+      }}
+    >
+      {#if preset === null}
+        <option value="custom">Custom</option>
+      {/if}
+      {#each names as name, index (name)}
+        <option value={index}>{name}</option>
+      {/each}
+    </select>
+  </label>
+  <button type="button" class="step" aria-label="Next preset" onclick={onnext}>
+    ›
+  </button>
+</div>
+
+<style>
+  .preset {
+    display: grid;
+    grid-template-columns: 1.75rem minmax(0, 1fr) 1.75rem;
+    align-items: stretch;
+    width: min(100%, 13.5rem);
+    height: var(--chrome-h);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--inset);
+  }
+
+  .step {
+    color: var(--text-muted);
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .step:hover {
+    color: var(--text);
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .select {
+    position: relative;
+    display: grid;
+    place-items: center;
+    min-width: 0;
+    border-inline: 1px solid var(--border);
+  }
+
+  .select > span {
+    overflow: hidden;
+    width: 100%;
+    padding: 0 var(--s2);
+    color: var(--text);
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .select select {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    border: 0;
+    opacity: 0;
+    cursor: pointer;
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/lib/WaveDisplay.svelte
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/lib/WaveDisplay.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+  import {
+    STAGE_TICKS_DB,
+    grNorm,
+    levelNorm,
+    type HistorySample,
+  } from '../meter'
+
+  type PeakTag = {
+    x: number
+    y: number
+    label: string
+  }
+
+  type Props = {
+    history: HistorySample[]
+    ceilingDb: number
+    live: boolean
+    tags?: PeakTag[]
+  }
+
+  const { history, ceilingDb, live, tags = [] }: Props = $props()
+
+  let canvas: HTMLCanvasElement | undefined = $state()
+  let width = $state(0)
+  let height = $state(0)
+
+  $effect(() => {
+    const el = canvas
+    if (!el) return
+    const parent = el.parentElement
+    if (!parent) return
+    const ro = new ResizeObserver((entries) => {
+      const box = entries[0]?.contentRect
+      if (!box) return
+      width = Math.max(1, Math.floor(box.width * devicePixelRatio))
+      height = Math.max(1, Math.floor(box.height * devicePixelRatio))
+      el.width = width
+      el.height = height
+    })
+    ro.observe(parent)
+    return () => ro.disconnect()
+  })
+
+  $effect(() => {
+    const el = canvas
+    if (!el || width === 0 || height === 0) return
+    void history
+    void ceilingDb
+    void live
+    const ctx = el.getContext('2d')
+    if (!ctx) return
+    draw(ctx, width, height, history, ceilingDb, live)
+  })
+
+  function draw(
+    ctx: CanvasRenderingContext2D,
+    w: number,
+    h: number,
+    samples: HistorySample[],
+    ceiling: number,
+    isLive: boolean,
+  ) {
+    ctx.clearRect(0, 0, w, h)
+    ctx.fillStyle = '#060809'
+    ctx.fillRect(0, 0, w, h)
+
+    // Sparse horizontal rules
+    ctx.strokeStyle = 'rgba(255,255,255,0.035)'
+    ctx.lineWidth = 1
+    for (const tick of STAGE_TICKS_DB) {
+      if (tick === 0) continue
+      const y = levelNorm(tick) * h
+      ctx.beginPath()
+      ctx.moveTo(0, y)
+      ctx.lineTo(w, y)
+      ctx.stroke()
+    }
+
+    // 0 dB ceiling of the face
+    ctx.strokeStyle = 'rgba(255,255,255,0.1)'
+    ctx.beginPath()
+    ctx.moveTo(0, 0.5)
+    ctx.lineTo(w, 0.5)
+    ctx.stroke()
+
+    // Output ceiling guide
+    const ceilY = levelNorm(ceiling) * h
+    ctx.strokeStyle = 'rgba(74, 163, 255, 0.55)'
+    ctx.lineWidth = 1
+    ctx.setLineDash([5 * devicePixelRatio, 4 * devicePixelRatio])
+    ctx.beginPath()
+    ctx.moveTo(0, ceilY)
+    ctx.lineTo(w, ceilY)
+    ctx.stroke()
+    ctx.setLineDash([])
+
+    if (samples.length < 2) return
+    const col = w / Math.max(samples.length - 1, 1)
+
+    // Muted blue input body
+    ctx.beginPath()
+    ctx.moveTo(0, h)
+    for (let i = 0; i < samples.length; i++) {
+      ctx.lineTo(i * col, levelNorm(isLive ? samples[i]!.inDb : -48) * h)
+    }
+    ctx.lineTo((samples.length - 1) * col, h)
+    ctx.closePath()
+    const body = ctx.createLinearGradient(0, 0, 0, h)
+    body.addColorStop(0, 'rgba(120, 175, 230, 0.5)')
+    body.addColorStop(0.45, 'rgba(61, 110, 158, 0.26)')
+    body.addColorStop(1, 'rgba(20, 40, 62, 0.08)')
+    ctx.fillStyle = body
+    ctx.fill()
+
+    // RMS contour
+    ctx.beginPath()
+    for (let i = 0; i < samples.length; i++) {
+      const y = levelNorm(isLive ? samples[i]!.rmsDb : -48) * h
+      if (i === 0) ctx.moveTo(i * col, y)
+      else ctx.lineTo(i * col, y)
+    }
+    ctx.strokeStyle = 'rgba(74, 163, 255, 0.75)'
+    ctx.lineWidth = 1.15 * devicePixelRatio
+    ctx.stroke()
+
+    // Red GR / clip activity from the top — the signature
+    ctx.beginPath()
+    ctx.moveTo(0, 0)
+    for (let i = 0; i < samples.length; i++) {
+      ctx.lineTo(i * col, grNorm(isLive ? samples[i]!.grDb : 0) * h * 0.52)
+    }
+    ctx.lineTo((samples.length - 1) * col, 0)
+    ctx.closePath()
+    ctx.fillStyle = 'rgba(232, 72, 58, 0.7)'
+    ctx.fill()
+
+    ctx.beginPath()
+    for (let i = 0; i < samples.length; i++) {
+      const y = grNorm(isLive ? samples[i]!.grDb : 0) * h * 0.52
+      if (i === 0) ctx.moveTo(i * col, y)
+      else ctx.lineTo(i * col, y)
+    }
+    ctx.strokeStyle = '#ff6a5c'
+    ctx.lineWidth = 1.5 * devicePixelRatio
+    ctx.stroke()
+  }
+</script>
+
+<div class="wave" class:dark={!live}>
+  <canvas bind:this={canvas} aria-hidden="true"></canvas>
+  <div class="scale" aria-hidden="true">
+    {#each STAGE_TICKS_DB as tick}
+      <span style="top: {(levelNorm(tick) * 100).toFixed(2)}%">{tick}</span>
+    {/each}
+  </div>
+  {#each tags as tag (tag.x + tag.label)}
+    <div
+      class="tag"
+      style="left: {(tag.x * 100).toFixed(2)}%; top: {(tag.y * 100).toFixed(2)}%"
+    >
+      {tag.label}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .wave {
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    height: 100%;
+    background: var(--stage);
+  }
+
+  .wave.dark {
+    opacity: 0.5;
+  }
+
+  canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .scale {
+    position: absolute;
+    inset: 0.4rem 0.6rem 0.4rem auto;
+    width: 1.9rem;
+    pointer-events: none;
+  }
+
+  .scale span {
+    position: absolute;
+    right: 0;
+    transform: translateY(-50%);
+    color: rgba(200, 210, 225, 0.38);
+    font-size: 0.55rem;
+    font-weight: 600;
+  }
+
+  .tag {
+    position: absolute;
+    z-index: 2;
+    transform: translate(-50%, -120%);
+    padding: 0.14rem 0.42rem;
+    border-radius: 999px;
+    background: var(--red);
+    color: #180a08;
+    font-size: 0.58rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    pointer-events: none;
+    white-space: nowrap;
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/main.ts
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/main.ts
@@ -1,0 +1,9 @@
+import { mount } from 'svelte'
+
+import './app.css'
+import App from './App.svelte'
+
+const root = document.getElementById('root')
+if (!root) throw new Error('#root is missing from index.html')
+
+export default mount(App, { target: root })

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/meter.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/meter.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  GR_FULL_SCALE_DB,
+  HISTORY_LENGTH,
+  STAGE_CEIL_DB,
+  STAGE_FLOOR_DB,
+  STAGE_TICKS_DB,
+  advance,
+  grNorm,
+  levelNorm,
+  linearToDb,
+  pushHistory,
+  shouldTagPeak,
+  silentSample,
+} from './meter'
+
+describe('stage level scale', () => {
+  test('maps 0 dBFS to the top and the floor to the bottom', () => {
+    expect(levelNorm(STAGE_CEIL_DB)).toBe(0)
+    expect(levelNorm(STAGE_FLOOR_DB)).toBe(1)
+  })
+
+  test('is monotonic — louder is always higher on the face', () => {
+    let previous = -Infinity
+    for (let db = STAGE_FLOOR_DB; db <= STAGE_CEIL_DB; db += 1) {
+      const height = 1 - levelNorm(db)
+      expect(height).toBeGreaterThan(previous)
+      previous = height
+    }
+  })
+
+  test('clamps rather than running off the face', () => {
+    expect(levelNorm(12)).toBe(0)
+    expect(levelNorm(-96)).toBe(1)
+  })
+})
+
+describe('gain reduction / clip overlay', () => {
+  test('grows downward from the top as reduction increases', () => {
+    expect(grNorm(0)).toBe(0)
+    expect(grNorm(GR_FULL_SCALE_DB)).toBe(1)
+    expect(grNorm(GR_FULL_SCALE_DB / 2)).toBeCloseTo(0.5, 9)
+  })
+
+  test('clamps deep spikes', () => {
+    expect(grNorm(-1)).toBe(0)
+    expect(grNorm(100)).toBe(1)
+  })
+})
+
+describe('stage ticks', () => {
+  test('are inside the declared range and include the endpoints', () => {
+    expect(STAGE_TICKS_DB[0]).toBe(STAGE_CEIL_DB)
+    expect(STAGE_TICKS_DB.at(-1)).toBe(STAGE_FLOOR_DB)
+    for (const tick of STAGE_TICKS_DB) {
+      expect(tick).toBeLessThanOrEqual(STAGE_CEIL_DB)
+      expect(tick).toBeGreaterThanOrEqual(STAGE_FLOOR_DB)
+    }
+  })
+})
+
+describe('history ring', () => {
+  test('grows until capacity then drops the oldest', () => {
+    let history = [silentSample()]
+    for (let i = 0; i < HISTORY_LENGTH + 5; i++) {
+      history = pushHistory(history, {
+        inDb: -i,
+        rmsDb: -i,
+        outDb: -i,
+        grDb: i % 4,
+      })
+    }
+    expect(history.length).toBe(HISTORY_LENGTH)
+    expect(history.at(-1)?.inDb).toBe(-(HISTORY_LENGTH + 4))
+    expect(history[0]?.inDb).toBe(-5)
+  })
+
+  test('a silent sample rests at the stage floor with no reduction', () => {
+    const sample = silentSample()
+    expect(sample.inDb).toBe(STAGE_FLOOR_DB)
+    expect(sample.grDb).toBe(0)
+  })
+})
+
+describe('peak tags', () => {
+  test('only fire on rising GR above the threshold', () => {
+    expect(shouldTagPeak(0.1, 0)).toBe(false)
+    expect(shouldTagPeak(0.5, 0.2)).toBe(true)
+    expect(shouldTagPeak(0.5, 0.45)).toBe(false)
+  })
+})
+
+describe('meter ballistics', () => {
+  test('never overshoots and holds still without time or a target', () => {
+    expect(advance(0.5, 1, 0)).toBe(0.5)
+    expect(advance(0.5, Number.NaN, 0.1)).toBe(0.5)
+    let value = 0
+    for (let i = 0; i < 10_000; i++) value = advance(value, 1, 0.01)
+    expect(value).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('level conversion', () => {
+  test('unity is 0 dB and silence floors instead of returning -Infinity', () => {
+    expect(linearToDb(1)).toBeCloseTo(0, 9)
+    expect(linearToDb(0.5)).toBeCloseTo(-6.02, 2)
+    expect(Number.isFinite(linearToDb(0))).toBe(true)
+  })
+})

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/meter.ts
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/meter.ts
@@ -1,0 +1,100 @@
+/**
+ * Display mapping for 67Clipper's scrolling waveform stage.
+ *
+ * Numbers come from the host's `futureboard.meters` frames. This module only
+ * places those readings on the face and keeps a short rolling history so the
+ * scrolling stage can draw them. Nothing here invents levels.
+ */
+
+export function clamp(value: number, min: number, max: number): number {
+  return value < min ? min : value > max ? max : value
+}
+
+export function linearToDb(linear: number): number {
+  return 20 * Math.log10(Math.max(linear, 1e-6))
+}
+
+/** Bottom of the scrolling stage / vertical level meters, in dBFS. */
+export const STAGE_FLOOR_DB = -48
+
+/** Top of the level scale (0 dBFS). */
+export const STAGE_CEIL_DB = 0
+
+/** Full-scale gain reduction for meters and the red GR overlay. */
+export const GR_FULL_SCALE_DB = 24
+
+/** How many history columns the scrolling stage keeps. */
+export const HISTORY_LENGTH = 240
+
+export type HistorySample = {
+  /** Input peak, dBFS. */
+  inDb: number
+  /** Smoothed input RMS, dBFS. */
+  rmsDb: number
+  /** Output peak, dBFS. */
+  outDb: number
+  /** Positive gain reduction / clip depth in dB. */
+  grDb: number
+}
+
+/**
+ * Map a level in dBFS onto the stage: 0 at the top (0 dB), 1 at the floor.
+ * Used for both the scrolling fill and the vertical bar meters.
+ */
+export function levelNorm(db: number): number {
+  return clamp((STAGE_CEIL_DB - db) / (STAGE_CEIL_DB - STAGE_FLOOR_DB), 0, 1)
+}
+
+/**
+ * Gain reduction / clip depth as a fraction of the stage height growing
+ * downward from the top (0 dB line).
+ */
+export function grNorm(grDb: number): number {
+  return clamp(grDb / GR_FULL_SCALE_DB, 0, 1)
+}
+
+/** Major dB marks printed on the stage scale. */
+export const STAGE_TICKS_DB = [0, -3, -6, -9, -12, -18, -24, -36, -48] as const
+
+/**
+ * One-pole ballistics for meter fill. Fast enough to feel alive at ~30 Hz
+ * host telemetry without inventing peaks.
+ */
+export function advance(
+  current: number,
+  target: number,
+  dt: number,
+  tau = 0.04,
+): number {
+  if (!Number.isFinite(target)) return current
+  if (dt <= 0) return current
+  const alpha = 1 - Math.exp(-dt / Math.max(tau, 1e-4))
+  return current + (target - current) * alpha
+}
+
+/** Push one measured frame into a fixed-length ring (drops the oldest). */
+export function pushHistory(
+  history: readonly HistorySample[],
+  sample: HistorySample,
+  length = HISTORY_LENGTH,
+): HistorySample[] {
+  if (history.length >= length) {
+    return [...history.slice(history.length - length + 1), sample]
+  }
+  return [...history, sample]
+}
+
+/** Empty history column used until the host starts sending meters. */
+export function silentSample(): HistorySample {
+  return {
+    inDb: STAGE_FLOOR_DB,
+    rmsDb: STAGE_FLOOR_DB,
+    outDb: STAGE_FLOOR_DB,
+    grDb: 0,
+  }
+}
+
+/** Whether a GR/clip spike is worth tagging on the stage. */
+export function shouldTagPeak(grDb: number, previousGrDb: number): boolean {
+  return grDb >= 0.3 && grDb > previousGrDb + 0.15
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/params.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/params.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test'
+
+import { PARAMS, format, fromNorm, toNorm, type ParamId } from './params'
+import { IPC_RS, rustRanges, rustStringArray } from './rust'
+
+const rustIds = rustStringArray(IPC_RS, 'UI_PARAM_IDS')
+const rustRangeTable = rustRanges('RANGES')
+
+describe('the schema mirrors transient::ipc', () => {
+  test('every editor param id exists in the Rust wire table', () => {
+    for (const id of Object.keys(PARAMS) as ParamId[]) {
+      expect(rustIds).toContain(id)
+    }
+  })
+
+  test('ranges match the Rust ranges exactly', () => {
+    for (const id of Object.keys(PARAMS) as ParamId[]) {
+      const spec = PARAMS[id]
+      const index = rustIds.indexOf(id)
+      const range = rustRangeTable[index]
+      expect(range, `no Rust range for ${id}`).toBeDefined()
+      expect([id, spec.min, spec.max]).toEqual([id, range![0], range![1]])
+      expect(spec.default).toBeGreaterThanOrEqual(spec.min)
+      expect(spec.default).toBeLessThanOrEqual(spec.max)
+    }
+  })
+
+  test('only the discrete controls are missing from the knob table', () => {
+    const missing = rustIds.filter((id) => !(id in PARAMS))
+    expect(missing.sort()).toEqual(['power', 'stereoLink'])
+  })
+})
+
+describe('control tapers', () => {
+  test('every taper round-trips across its whole range', () => {
+    for (const id of Object.keys(PARAMS) as ParamId[]) {
+      const spec = PARAMS[id]
+      for (const t of [0, 0.13, 0.5, 0.87, 1]) {
+        const value = fromNorm(spec, t)
+        expect(value).toBeGreaterThanOrEqual(spec.min - 1e-6)
+        expect(value).toBeLessThanOrEqual(spec.max + 1e-6)
+        expect(toNorm(spec, value)).toBeCloseTo(t, 5)
+      }
+    }
+  })
+
+  test('the endpoints are exact, not a few ulps short', () => {
+    for (const id of Object.keys(PARAMS) as ParamId[]) {
+      expect(fromNorm(PARAMS[id], 0)).toBe(PARAMS[id].min)
+      expect(fromNorm(PARAMS[id], 1)).toBe(PARAMS[id].max)
+    }
+  })
+})
+
+describe('readouts', () => {
+  test('bipolar percentages carry a sign and plain ones stay plain', () => {
+    expect(format(PARAMS.attack, 40)).toBe('+40')
+    expect(format(PARAMS.attack, -25)).toBe('-25')
+    expect(format(PARAMS.sustain, 0)).toBe('0')
+    expect(format(PARAMS.mix, 100)).toBe('100')
+    expect(format(PARAMS.speed, 50)).toBe('50')
+  })
+
+  test('a value outside the range is displayed clamped, never as NaN', () => {
+    expect(format(PARAMS.mix, 1e9)).toBe('100')
+    expect(format(PARAMS.mix, -50)).toBe('0')
+    expect(format(PARAMS.attack, 200)).toBe('+100')
+  })
+})

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/params.ts
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/params.ts
@@ -1,0 +1,104 @@
+/**
+ * Editor-side mirror of Transient's parameter contract.
+ *
+ * Rust owns the authority: `src/ipc.rs` defines the ids and their ranges, and
+ * clamps every incoming value again. This table exists so the UI can lay out
+ * a control, choose a taper, and format a readout — never to decide what a
+ * value means. `params.test.ts` pins the ids and ranges against the Rust
+ * source.
+ */
+
+export type ParamId = 'attack' | 'sustain' | 'speed' | 'mix'
+
+type Taper = 'lin' | 'exp' | number
+
+export type ParamSpec = {
+  id: ParamId
+  label: string
+  min: number
+  max: number
+  default: number
+  unit: string
+  taper: Taper
+  digits: number
+  step: number
+  /** Value the dial/arc fills out from. Defaults to `min`. */
+  origin?: number
+}
+
+const spec = (
+  id: ParamId,
+  label: string,
+  min: number,
+  max: number,
+  def: number,
+  unit: string,
+  taper: Taper,
+  digits: number,
+  step: number,
+  origin?: number,
+): ParamSpec => ({
+  id,
+  label,
+  min,
+  max,
+  default: def,
+  unit,
+  taper,
+  digits,
+  step,
+  origin,
+})
+
+export const PARAMS: Record<ParamId, ParamSpec> = {
+  attack: spec('attack', 'Attack', -100, 100, 0, '%', 'lin', 0, 1, 0),
+  sustain: spec('sustain', 'Sustain', -100, 100, 0, '%', 'lin', 0, 1, 0),
+  speed: spec('speed', 'Speed', 0, 100, 50, '%', 'lin', 0, 1),
+  mix: spec('mix', 'Mix', 0, 100, 100, '%', 'lin', 0, 1),
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return value < min ? min : value > max ? max : value
+}
+
+/** Value -> 0..1 control travel. */
+export function toNorm(spec: ParamSpec, value: number): number {
+  const v = clamp(value, spec.min, spec.max)
+  if (spec.taper === 'exp') {
+    const lo = Math.log(Math.max(spec.min, 1e-6))
+    return (Math.log(Math.max(v, 1e-6)) - lo) / (Math.log(spec.max) - lo)
+  }
+  const t = (v - spec.min) / (spec.max - spec.min)
+  return spec.taper === 'lin' ? t : Math.pow(t, 1 / spec.taper)
+}
+
+/**
+ * 0..1 control travel -> value.
+ *
+ * The endpoints return `min`/`max` exactly rather than evaluating the taper:
+ * `exp(log(max))` lands a few ulps short, so a knob at full travel would
+ * never quite reach its own maximum.
+ */
+export function fromNorm(spec: ParamSpec, norm: number): number {
+  const t = clamp(norm, 0, 1)
+  if (t <= 0) return spec.min
+  if (t >= 1) return spec.max
+  if (spec.taper === 'exp') {
+    const lo = Math.log(Math.max(spec.min, 1e-6))
+    return clamp(
+      Math.exp(lo + t * (Math.log(spec.max) - lo)),
+      spec.min,
+      spec.max,
+    )
+  }
+  const shaped = spec.taper === 'lin' ? t : Math.pow(t, spec.taper)
+  return clamp(spec.min + shaped * (spec.max - spec.min), spec.min, spec.max)
+}
+
+export function format(spec: ParamSpec, value: number): string {
+  const v = clamp(value, spec.min, spec.max)
+  if ((spec.unit === 'dB' || spec.origin === 0) && v > 0) {
+    return `+${v.toFixed(spec.digits)}`
+  }
+  return v.toFixed(spec.digits)
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/presets.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/presets.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  DEFAULT_PARAMS,
+  FACTORY_PRESETS,
+  matchingPresetIndex,
+  paramsMatch,
+} from './presets'
+import { PARAMS } from './params'
+
+describe('factory presets', () => {
+  test('Default mirrors the schema defaults', () => {
+    expect(FACTORY_PRESETS[0]?.name).toBe('Default')
+    expect(paramsMatch(FACTORY_PRESETS[0]!.params, DEFAULT_PARAMS)).toBe(true)
+    for (const id of Object.keys(PARAMS) as (keyof typeof PARAMS)[]) {
+      expect(DEFAULT_PARAMS[id]).toBe(PARAMS[id].default)
+    }
+  })
+
+  test('every preset stays inside the schema ranges', () => {
+    for (const entry of FACTORY_PRESETS) {
+      for (const id of Object.keys(PARAMS) as (keyof typeof PARAMS)[]) {
+        const spec = PARAMS[id]
+        const value = entry.params[id]
+        expect(value).toBeGreaterThanOrEqual(spec.min)
+        expect(value).toBeLessThanOrEqual(spec.max)
+      }
+      expect(entry.params.power).toBe(true)
+      expect(typeof entry.params.stereoLink).toBe('boolean')
+    }
+  })
+
+  test('matchingPresetIndex recognizes Default and rejects edits', () => {
+    expect(matchingPresetIndex(DEFAULT_PARAMS)).toBe(0)
+    expect(
+      matchingPresetIndex({ ...DEFAULT_PARAMS, mix: DEFAULT_PARAMS.mix + 1 }),
+    ).toBeNull()
+  })
+
+  test('preset names are unique', () => {
+    const names = FACTORY_PRESETS.map((entry) => entry.name)
+    expect(new Set(names).size).toBe(names.length)
+  })
+})

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/presets.ts
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/presets.ts
@@ -1,0 +1,91 @@
+/**
+ * Factory presets for Transient.
+ *
+ * These are editor-side starting points that push real parameter values
+ * through the existing bridge. Rust still clamps and owns DSP state —
+ * presets never invent controls or bypass the wire contract.
+ */
+
+import { postParam, type TransientParams } from './bridge'
+import { PARAMS, type ParamId } from './params'
+
+export const DEFAULT_PARAMS: TransientParams = {
+  power: true,
+  attack: PARAMS.attack.default,
+  sustain: PARAMS.sustain.default,
+  speed: PARAMS.speed.default,
+  mix: PARAMS.mix.default,
+  stereoLink: true,
+}
+
+export type FactoryPreset = {
+  name: string
+  params: TransientParams
+}
+
+function preset(
+  name: string,
+  patch: Partial<TransientParams>,
+): FactoryPreset {
+  return {
+    name,
+    params: { ...DEFAULT_PARAMS, ...patch, power: true },
+  }
+}
+
+export const FACTORY_PRESETS: FactoryPreset[] = [
+  preset('Default', {}),
+  preset('Punch Up', {
+    attack: 55,
+    sustain: -15,
+    speed: 60,
+    mix: 100,
+    stereoLink: true,
+  }),
+  preset('Snap Cut', {
+    attack: -45,
+    sustain: 20,
+    speed: 70,
+    mix: 100,
+    stereoLink: true,
+  }),
+  preset('Body Boost', {
+    attack: 10,
+    sustain: 50,
+    speed: 40,
+    mix: 100,
+    stereoLink: true,
+  }),
+  preset('Drum Gate', {
+    attack: 35,
+    sustain: -70,
+    speed: 80,
+    mix: 100,
+    stereoLink: true,
+  }),
+]
+
+const NUMERIC_IDS = Object.keys(PARAMS) as ParamId[]
+
+export function paramsMatch(left: TransientParams, right: TransientParams) {
+  if (left.power !== right.power || left.stereoLink !== right.stereoLink) {
+    return false
+  }
+  return NUMERIC_IDS.every((id) => Math.abs(left[id] - right[id]) < 0.05)
+}
+
+export function matchingPresetIndex(params: TransientParams) {
+  const index = FACTORY_PRESETS.findIndex((entry) =>
+    paramsMatch(params, entry.params),
+  )
+  return index >= 0 ? index : null
+}
+
+/** Whole-state push; the bridge coalesces into one `setParams` per frame. */
+export function postAllParams(params: TransientParams) {
+  postParam('power', params.power ? 1 : 0)
+  for (const id of NUMERIC_IDS) {
+    postParam(id, params[id])
+  }
+  postParam('stereoLink', params.stereoLink ? 1 : 0)
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/rust.ts
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/src/rust.ts
@@ -1,0 +1,70 @@
+/**
+ * Test-only readers for the Rust source of truth.
+ *
+ * The editor duplicates a handful of Rust constants — parameter ids and
+ * ranges. Duplication is unavoidable (the editor is a separate bundle), so
+ * the tests parse the real `.rs` files and compare, which turns a silent
+ * drift into a failing check.
+ *
+ * Not imported by the app; kept out of the bundle by having no runtime
+ * caller.
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const read = (relative: string) =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8')
+
+export const LIB_RS = read('../../src/lib.rs')
+export const IPC_RS = read('../../src/ipc.rs')
+
+/** Rust float literals allow `_` separators; JS `Number` does not. */
+function num(literal: string): number {
+  return Number(literal.replace(/_/g, ''))
+}
+
+/** The body of `<name>: <type> = [ ... ];`. */
+function arrayBody(source: string, name: string): string {
+  const match = new RegExp(
+    `(?:pub )?const ${name}\\s*:[^=]+=\\s*\\[([\\s\\S]*?)\\];`,
+  ).exec(source)
+  if (!match?.[1]) throw new Error(`${name} not found in Rust source`)
+  return match[1]
+}
+
+/** `pub const NAME: f32 = 500.0;` */
+export function rustScalar(source: string, name: string): number {
+  const match = new RegExp(
+    `(?:pub )?const ${name}\\s*:\\s*f32\\s*=\\s*([0-9_.]+)\\s*;`,
+  ).exec(source)
+  if (!match?.[1]) throw new Error(`${name} not found in Rust source`)
+  return num(match[1])
+}
+
+export function rustFloatArray(source: string, name: string): number[] {
+  return arrayBody(source, name)
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map(num)
+}
+
+/** `UI_PARAM_IDS` — the quoted strings, in order. */
+export function rustStringArray(source: string, name: string): string[] {
+  return Array.from(arrayBody(source, name).matchAll(/"([^"]*)"/g), (m) => m[1]!)
+}
+
+/**
+ * `RANGES` — `(min, max), // comment` tuples, in order. Identifiers are
+ * resolved against `lib.rs` scalars, so a named constant reads as its
+ * numeric value.
+ */
+export function rustRanges(name: string): [number, number][] {
+  const resolve = (token: string) =>
+    /^[-0-9]/.test(token) ? num(token) : rustScalar(LIB_RS, token)
+  return Array.from(
+    arrayBody(IPC_RS, name).matchAll(/\(\s*([^,\s]+)\s*,\s*([^)\s]+)\s*\)/g),
+    (m) => [resolve(m[1]!), resolve(m[2]!)] as [number, number],
+  )
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/svelte.config.js
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+export default {
+  preprocess: vitePreprocess(),
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/tsconfig.json
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "types": ["bun", "svelte", "vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "vite.config.ts"]
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/editorui/vite.config.ts
+++ b/crates/BuiltinAudioPlugins/crates/Transient/editorui/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { viteSingleFile } from 'vite-plugin-singlefile'
+import { fileURLToPath } from 'node:url'
+
+// The editor is embedded into the plugin library as a single, fully
+// self-contained `index.html` (JS/CSS inlined). It is served to CEF through the
+// `mikoplugin://transient/index.html` custom scheme, so there must be no
+// sibling asset requests and no network fetch at runtime.
+export default defineConfig({
+  // Pin the root to this config's own URL: the checkout may be reached through
+  // more than one path, and a relative root makes Vite emit index.html as an
+  // absolute asset reference the custom scheme cannot resolve.
+  root: fileURLToPath(new URL('.', import.meta.url)),
+  plugins: [svelte(), viteSingleFile()],
+  build: {
+    target: 'chrome120',
+    assetsInlineLimit: Infinity,
+    cssCodeSplit: false,
+  },
+})

--- a/crates/BuiltinAudioPlugins/crates/Transient/src/ipc.rs
+++ b/crates/BuiltinAudioPlugins/crates/Transient/src/ipc.rs
@@ -1,0 +1,213 @@
+//! Stable editor/DSP parameter wire contract for Transient.
+//!
+//! String ids live at the UI/control boundary only. The native host resolves
+//! them to compact indices before publishing edits to an audio-side bounded
+//! queue; [`Dsp::apply_wire_param`](crate::Dsp::apply_wire_param) consumes the
+//! numeric form without allocation, serialization, locking, or string lookup.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Params, clamp, default_params};
+
+pub const PROTOCOL_VERSION: u32 = 1;
+pub const STATE_VERSION: u32 = 1;
+
+pub const POWER_INDEX: u32 = 0;
+pub const ATTACK_INDEX: u32 = 1;
+pub const SUSTAIN_INDEX: u32 = 2;
+pub const SPEED_INDEX: u32 = 3;
+pub const MIX_INDEX: u32 = 4;
+pub const STEREO_LINK_INDEX: u32 = 5;
+
+pub const PARAM_COUNT: usize = 6;
+
+/// Wire index *is* the position in this table; the editor and the host both
+/// resolve through it, so the order is part of the persisted contract. Append
+/// only.
+pub const UI_PARAM_IDS: [&str; PARAM_COUNT] = [
+    "power",
+    "attack",
+    "sustain",
+    "speed",
+    "mix",
+    "stereoLink",
+];
+
+/// Inclusive `(min, max)` for every continuous parameter, indexed by wire
+/// index. Booleans carry `(0, 0)` and are handled by their own arms in
+/// [`apply_wire_param`]. Single source of truth for clamping, so
+/// [`sanitize_params`] and the wire path cannot drift apart.
+const RANGES: [(f32, f32); PARAM_COUNT] = [
+    (0.0, 0.0),     // power
+    (-100.0, 100.0), // attack
+    (-100.0, 100.0), // sustain
+    (0.0, 100.0),   // speed
+    (0.0, 100.0),   // mix
+    (0.0, 0.0),     // stereoLink
+];
+
+#[inline]
+fn clamp_wire(index: u32, value: f32) -> f32 {
+    let (min, max) = RANGES[index as usize];
+    clamp(value, min, max)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransientState {
+    pub version: u32,
+    pub params: Params,
+}
+
+impl TransientState {
+    pub fn new(params: Params) -> Self {
+        Self {
+            version: STATE_VERSION,
+            params,
+        }
+    }
+
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+}
+
+impl Default for TransientState {
+    fn default() -> Self {
+        Self::new(default_params())
+    }
+}
+
+pub fn ui_param_index(id: &str) -> Option<u32> {
+    UI_PARAM_IDS
+        .iter()
+        .position(|candidate| *candidate == id)
+        .map(|index| index as u32)
+}
+
+pub fn ui_param_id(index: u32) -> Option<&'static str> {
+    UI_PARAM_IDS.get(index as usize).copied()
+}
+
+/// Clamp a whole `Params` into range. Used after deserializing a project blob,
+/// which may predate a range change or have been edited by hand.
+pub fn sanitize_params(params: &mut Params) {
+    params.attack = clamp_wire(ATTACK_INDEX, params.attack);
+    params.sustain = clamp_wire(SUSTAIN_INDEX, params.sustain);
+    params.speed = clamp_wire(SPEED_INDEX, params.speed);
+    params.mix = clamp_wire(MIX_INDEX, params.mix);
+}
+
+/// Apply one compact UI/control update. Allocation-free and total: invalid
+/// indices are rejected, non-finite values are rejected, and every continuous
+/// value is clamped to its declared range.
+pub fn apply_wire_param(params: &mut Params, index: u32, value: f32) -> bool {
+    if !value.is_finite() || index as usize >= PARAM_COUNT {
+        return false;
+    }
+    match index {
+        POWER_INDEX => params.power = value >= 0.5,
+        ATTACK_INDEX => params.attack = clamp_wire(index, value),
+        SUSTAIN_INDEX => params.sustain = clamp_wire(index, value),
+        SPEED_INDEX => params.speed = clamp_wire(index, value),
+        MIX_INDEX => params.mix = clamp_wire(index, value),
+        STEREO_LINK_INDEX => params.stereo_link = value >= 0.5,
+        _ => return false,
+    }
+    true
+}
+
+/// Resolve a string id off the realtime path and apply it to a state mirror.
+pub fn apply_ui_param(params: &mut Params, id: &str, value: f32) -> bool {
+    let Some(index) = ui_param_index(id) else {
+        return false;
+    };
+    apply_wire_param(params, index, value)
+}
+
+/// Every parameter as `(id, raw value)`, in wire order. Drives project replay
+/// and the descriptor-vs-defaults check.
+pub fn ui_values(params: &Params) -> Vec<(&'static str, f32)> {
+    vec![
+        ("power", f32::from(params.power)),
+        ("attack", params.attack),
+        ("sustain", params.sustain),
+        ("speed", params.speed),
+        ("mix", params.mix),
+        ("stereoLink", f32::from(params.stereo_link)),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_round_trip_to_wire_indices() {
+        assert_eq!(UI_PARAM_IDS.len(), PARAM_COUNT);
+        for (index, id) in UI_PARAM_IDS.iter().enumerate() {
+            assert_eq!(ui_param_index(id), Some(index as u32));
+            assert_eq!(ui_param_id(index as u32), Some(*id));
+        }
+    }
+
+    #[test]
+    fn ui_values_covers_every_id_in_wire_order() {
+        let values = ui_values(&default_params());
+        assert_eq!(values.len(), PARAM_COUNT);
+        for (index, (id, _)) in values.iter().enumerate() {
+            assert_eq!(*id, UI_PARAM_IDS[index]);
+        }
+    }
+
+    #[test]
+    fn state_round_trips() {
+        let mut params = default_params();
+        assert!(apply_ui_param(&mut params, "attack", 40.0));
+        assert!(apply_ui_param(&mut params, "sustain", -25.0));
+        let json = TransientState::new(params).to_json().unwrap();
+        let decoded = TransientState::from_json(&json).unwrap();
+        assert_eq!(decoded.params.attack, 40.0);
+        assert_eq!(decoded.params.sustain, -25.0);
+        assert_eq!(decoded.version, STATE_VERSION);
+    }
+
+    #[test]
+    fn out_of_range_values_are_clamped_not_rejected() {
+        let mut params = default_params();
+        assert!(apply_ui_param(&mut params, "attack", 200.0));
+        assert_eq!(params.attack, 100.0);
+        assert!(apply_ui_param(&mut params, "sustain", -200.0));
+        assert_eq!(params.sustain, -100.0);
+        assert!(apply_ui_param(&mut params, "speed", -10.0));
+        assert_eq!(params.speed, 0.0);
+    }
+
+    #[test]
+    fn invalid_and_non_finite_updates_are_rejected() {
+        let mut params = default_params();
+        assert!(!apply_wire_param(&mut params, u32::MAX, 1.0));
+        assert!(!apply_wire_param(&mut params, PARAM_COUNT as u32, 1.0));
+        assert!(!apply_wire_param(&mut params, ATTACK_INDEX, f32::NAN));
+        assert!(!apply_wire_param(&mut params, ATTACK_INDEX, f32::INFINITY));
+        assert!(!apply_ui_param(&mut params, "notAParam", 1.0));
+    }
+
+    #[test]
+    fn sanitize_pulls_a_hand_edited_blob_back_into_range() {
+        let mut params = default_params();
+        params.attack = 150.0;
+        params.sustain = -150.0;
+        params.speed = 200.0;
+        params.mix = -10.0;
+        sanitize_params(&mut params);
+        assert_eq!(params.attack, 100.0);
+        assert_eq!(params.sustain, -100.0);
+        assert_eq!(params.speed, 100.0);
+        assert_eq!(params.mix, 0.0);
+    }
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/Transient/src/lib.rs
@@ -1,0 +1,527 @@
+//! Transient — attack / sustain transient shaper.
+//!
+//! A dual-envelope detector separates the fast (attack) and slow (body)
+//! portions of the signal. Attack and Sustain knobs boost or cut each region
+//! independently, with Speed scaling the envelope times and Mix blending wet
+//! into dry. Allocation-free after construction.
+
+use builtin_dsp_core::{
+    ParamDescriptor, PluginCategory, PluginDescriptor, StereoEffect, clamp, db_to_linear,
+    linear_to_db, mix, time_constant,
+};
+use serde::{Deserialize, Serialize};
+
+pub mod ipc;
+pub mod ui;
+
+pub use ipc::{UI_PARAM_IDS, ui_param_id, ui_param_index};
+
+pub const PLUGIN_ID: &str = "futureboard.transient";
+
+const CLIP_THRESHOLD: f32 = 1.0;
+const RMS_WINDOW_SECONDS: f32 = 0.300;
+const PEAK_FALL_SECONDS: f32 = 0.400;
+/// Peak shaping depth at ±100% attack / sustain.
+const MAX_SHAPE_DB: f32 = 18.0;
+const FAST_ATTACK_SEC: f32 = 0.000_2;
+const FAST_RELEASE_BASE_SEC: f32 = 0.010;
+const SLOW_ATTACK_BASE_SEC: f32 = 0.020;
+const SLOW_RELEASE_BASE_SEC: f32 = 0.200;
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct MeterFrame {
+    pub in_peak: f32,
+    pub in_rms: f32,
+    pub out_peak: f32,
+    pub out_rms: f32,
+    /// Absolute magnitude of the applied dynamic gain change in dB.
+    pub gain_reduction_db: f32,
+    pub in_clip: bool,
+    pub out_clip: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Params {
+    pub power: bool,
+    pub attack: f32,
+    pub sustain: f32,
+    pub speed: f32,
+    pub mix: f32,
+    pub stereo_link: bool,
+}
+
+pub fn default_params() -> Params {
+    Params {
+        power: true,
+        attack: 0.0,
+        sustain: 0.0,
+        speed: 50.0,
+        mix: 100.0,
+        stereo_link: true,
+    }
+}
+
+pub fn descriptor() -> PluginDescriptor {
+    PluginDescriptor {
+        id: PLUGIN_ID,
+        name: "Transient",
+        vendor: "Futureboard",
+        category: PluginCategory::Effect,
+        version: env!("CARGO_PKG_VERSION"),
+        params: &[
+            ParamDescriptor {
+                id: "power",
+                name: "Power",
+                default_value: 1.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
+            ParamDescriptor {
+                id: "attack",
+                name: "Attack",
+                default_value: 0.0,
+                min: -100.0,
+                max: 100.0,
+                unit: "%",
+            },
+            ParamDescriptor {
+                id: "sustain",
+                name: "Sustain",
+                default_value: 0.0,
+                min: -100.0,
+                max: 100.0,
+                unit: "%",
+            },
+            ParamDescriptor {
+                id: "speed",
+                name: "Speed",
+                default_value: 50.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+            ParamDescriptor {
+                id: "mix",
+                name: "Mix",
+                default_value: 100.0,
+                min: 0.0,
+                max: 100.0,
+                unit: "%",
+            },
+            ParamDescriptor {
+                id: "stereoLink",
+                name: "Stereo Link",
+                default_value: 1.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
+        ],
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Meters {
+    in_peak: f32,
+    out_peak: f32,
+    in_ms: f32,
+    out_ms: f32,
+    rms_coeff: f32,
+    peak_coeff: f32,
+    in_clip: bool,
+    out_clip: bool,
+}
+
+impl Meters {
+    fn new(sample_rate: f32) -> Self {
+        Self {
+            in_peak: 0.0,
+            out_peak: 0.0,
+            in_ms: 0.0,
+            out_ms: 0.0,
+            rms_coeff: time_constant(sample_rate, RMS_WINDOW_SECONDS),
+            peak_coeff: time_constant(sample_rate, PEAK_FALL_SECONDS),
+            in_clip: false,
+            out_clip: false,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.in_peak = 0.0;
+        self.out_peak = 0.0;
+        self.in_ms = 0.0;
+        self.out_ms = 0.0;
+        self.in_clip = false;
+        self.out_clip = false;
+    }
+
+    #[inline]
+    fn push(&mut self, input: f32, output: f32) {
+        let in_abs = input.abs();
+        let out_abs = output.abs();
+
+        self.in_peak = if in_abs > self.in_peak {
+            in_abs
+        } else {
+            self.in_peak * self.peak_coeff
+        };
+        self.out_peak = if out_abs > self.out_peak {
+            out_abs
+        } else {
+            self.out_peak * self.peak_coeff
+        };
+
+        self.in_ms = self.rms_coeff * self.in_ms + (1.0 - self.rms_coeff) * input * input;
+        self.out_ms = self.rms_coeff * self.out_ms + (1.0 - self.rms_coeff) * output * output;
+
+        if in_abs >= CLIP_THRESHOLD {
+            self.in_clip = true;
+        }
+        if out_abs >= CLIP_THRESHOLD {
+            self.out_clip = true;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct EnvelopePair {
+    fast: f32,
+    slow: f32,
+}
+
+impl EnvelopePair {
+    fn reset(&mut self) {
+        self.fast = 0.0;
+        self.slow = 0.0;
+    }
+
+    #[inline]
+    fn push(&mut self, level: f32, fast_a: f32, fast_r: f32, slow_a: f32, slow_r: f32) {
+        self.fast = if level > self.fast {
+            level + fast_a * (self.fast - level)
+        } else {
+            level + fast_r * (self.fast - level)
+        };
+        self.slow = if level > self.slow {
+            level + slow_a * (self.slow - level)
+        } else {
+            level + slow_r * (self.slow - level)
+        };
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Dsp {
+    params: Params,
+    sample_rate: f32,
+    meters: Meters,
+    linked: EnvelopePair,
+    left: EnvelopePair,
+    right: EnvelopePair,
+    mix_amount: f32,
+    attack_amt: f32,
+    sustain_amt: f32,
+    fast_attack: f32,
+    fast_release: f32,
+    slow_attack: f32,
+    slow_release: f32,
+    shape_db: f32,
+}
+
+impl Dsp {
+    pub fn new(sample_rate: f32) -> Self {
+        let sr = sample_rate.max(1.0);
+        let mut dsp = Self {
+            params: default_params(),
+            sample_rate: sr,
+            meters: Meters::new(sr),
+            linked: EnvelopePair::default(),
+            left: EnvelopePair::default(),
+            right: EnvelopePair::default(),
+            mix_amount: 1.0,
+            attack_amt: 0.0,
+            sustain_amt: 0.0,
+            fast_attack: 0.0,
+            fast_release: 0.0,
+            slow_attack: 0.0,
+            slow_release: 0.0,
+            shape_db: 0.0,
+        };
+        dsp.apply_params();
+        dsp
+    }
+
+    pub fn params(&self) -> &Params {
+        &self.params
+    }
+
+    pub fn set_params(&mut self, params: Params) {
+        self.params = params;
+        ipc::sanitize_params(&mut self.params);
+        self.apply_params();
+    }
+
+    pub fn meter_frame(&self) -> MeterFrame {
+        MeterFrame {
+            in_peak: self.meters.in_peak,
+            in_rms: self.meters.in_ms.max(0.0).sqrt(),
+            out_peak: self.meters.out_peak,
+            out_rms: self.meters.out_ms.max(0.0).sqrt(),
+            gain_reduction_db: if self.params.power {
+                self.shape_db.abs()
+            } else {
+                0.0
+            },
+            in_clip: self.meters.in_clip,
+            out_clip: self.meters.out_clip,
+        }
+    }
+
+    pub fn clear_clip(&mut self) {
+        self.meters.in_clip = false;
+        self.meters.out_clip = false;
+    }
+
+    pub fn apply_wire_param(&mut self, wire_index: u32, value: f32) -> bool {
+        if !ipc::apply_wire_param(&mut self.params, wire_index, value) {
+            return false;
+        }
+        self.apply_params();
+        true
+    }
+
+    pub fn apply_ui_param(&mut self, id: &str, value: f32) -> bool {
+        match ipc::ui_param_index(id) {
+            Some(index) => self.apply_wire_param(index, value),
+            None => false,
+        }
+    }
+
+    pub fn latency_samples(&self) -> usize {
+        0
+    }
+
+    fn apply_params(&mut self) {
+        self.mix_amount = self.params.mix / 100.0;
+        self.attack_amt = self.params.attack / 100.0;
+        self.sustain_amt = self.params.sustain / 100.0;
+
+        // Speed 0 = slowest envelopes, 100 = fastest. Map to a 0.25×…4× span.
+        let speed_norm = clamp(self.params.speed, 0.0, 100.0) / 100.0;
+        let speed_scale = 4.0_f32.powf(1.0 - 2.0 * speed_norm);
+        let sr = self.sample_rate.max(1.0);
+        self.fast_attack = time_constant(sr, FAST_ATTACK_SEC);
+        self.fast_release = time_constant(sr, FAST_RELEASE_BASE_SEC * speed_scale);
+        self.slow_attack = time_constant(sr, SLOW_ATTACK_BASE_SEC * speed_scale);
+        self.slow_release = time_constant(sr, SLOW_RELEASE_BASE_SEC * speed_scale);
+    }
+
+    fn set_sample_rate_internal(&mut self, sample_rate: f32) {
+        self.sample_rate = sample_rate.max(1.0);
+        self.meters = Meters::new(self.sample_rate);
+    }
+
+    /// Gain from the dual-envelope state. Attack weights the fast−slow
+    /// difference; Sustain weights the residual body once the transient has
+    /// passed.
+    #[inline]
+    fn shape_gain(env: &EnvelopePair, attack_amt: f32, sustain_amt: f32) -> f32 {
+        let fast = env.fast.max(0.0);
+        let slow = env.slow.max(0.0);
+        let transient = (fast - slow).max(0.0);
+        let denom = fast.max(1.0e-6);
+        let transient_weight = (transient / denom).clamp(0.0, 1.0);
+        let body_weight = 1.0 - transient_weight;
+
+        let attack_db = attack_amt * MAX_SHAPE_DB * transient_weight;
+        let sustain_db = sustain_amt * MAX_SHAPE_DB * body_weight * (slow / (slow + 1.0e-3)).min(1.0);
+        db_to_linear(attack_db + sustain_db)
+    }
+}
+
+impl StereoEffect for Dsp {
+    fn reset(&mut self) {
+        self.meters.reset();
+        self.linked.reset();
+        self.left.reset();
+        self.right.reset();
+        self.shape_db = 0.0;
+    }
+
+    fn set_sample_rate(&mut self, sample_rate: f32) {
+        self.set_sample_rate_internal(sample_rate);
+        self.apply_params();
+    }
+
+    fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32) {
+        let in_sum = (left + right) * 0.5;
+        if !self.params.power {
+            self.meters.push(in_sum, in_sum);
+            self.shape_db = 0.0;
+            return (left, right);
+        }
+
+        let (gain_l, gain_r) = if self.params.stereo_link {
+            let level = left.abs().max(right.abs());
+            self.linked.push(
+                level,
+                self.fast_attack,
+                self.fast_release,
+                self.slow_attack,
+                self.slow_release,
+            );
+            let gain = Self::shape_gain(&self.linked, self.attack_amt, self.sustain_amt);
+            (gain, gain)
+        } else {
+            self.left.push(
+                left.abs(),
+                self.fast_attack,
+                self.fast_release,
+                self.slow_attack,
+                self.slow_release,
+            );
+            self.right.push(
+                right.abs(),
+                self.fast_attack,
+                self.fast_release,
+                self.slow_attack,
+                self.slow_release,
+            );
+            (
+                Self::shape_gain(&self.left, self.attack_amt, self.sustain_amt),
+                Self::shape_gain(&self.right, self.attack_amt, self.sustain_amt),
+            )
+        };
+
+        let wet_l = left * gain_l;
+        let wet_r = right * gain_r;
+        let out_l = mix(left, wet_l, self.mix_amount);
+        let out_r = mix(right, wet_r, self.mix_amount);
+
+        let report_gain = gain_l.min(gain_r);
+        self.shape_db = if report_gain > 1.0e-12 {
+            linear_to_db(report_gain)
+        } else {
+            -90.0
+        };
+
+        self.meters.push(in_sum, (out_l + out_r) * 0.5);
+        (out_l, out_r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_impulse(dsp: &mut Dsp, samples: usize) -> Vec<f32> {
+        let mut out = Vec::with_capacity(samples);
+        for n in 0..samples {
+            let x = if n == 0 { 0.9 } else { 0.0 };
+            let (l, _) = dsp.process_stereo(x, x);
+            assert!(l.is_finite());
+            out.push(l);
+        }
+        out
+    }
+
+    #[test]
+    fn descriptor_ids_are_unique_and_match_defaults() {
+        let d = descriptor();
+        assert_eq!(d.id, PLUGIN_ID);
+        assert_eq!(d.name, "Transient");
+        assert_eq!(d.category, PluginCategory::Effect);
+
+        let mut ids: Vec<_> = d.params.iter().map(|p| p.id).collect();
+        let count = ids.len();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(count, ids.len(), "duplicate parameter id in descriptor");
+
+        let defaults = ipc::ui_values(&default_params());
+        for param in d.params {
+            let (_, actual) = defaults
+                .iter()
+                .find(|(id, _)| *id == param.id)
+                .copied()
+                .unwrap_or_else(|| panic!("`{}` is missing from ui_values", param.id));
+            assert!(
+                (actual - param.default_value).abs() < 1.0e-5,
+                "{} default drifted: descriptor={} ui_values={}",
+                param.id,
+                param.default_value,
+                actual
+            );
+        }
+    }
+
+    #[test]
+    fn power_off_passes_signal_and_reports_zero_shaping() {
+        let mut dsp = Dsp::new(48_000.0);
+        assert!(dsp.apply_ui_param("power", 0.0));
+        let (l, r) = dsp.process_stereo(0.5, -0.4);
+        assert!((l - 0.5).abs() < 1.0e-6);
+        assert!((r - (-0.4)).abs() < 1.0e-6);
+        assert_eq!(dsp.meter_frame().gain_reduction_db, 0.0);
+    }
+
+    #[test]
+    fn boosting_attack_raises_the_impulse_peak() {
+        let mut neutral = Dsp::new(48_000.0);
+        let mut boosted = Dsp::new(48_000.0);
+        assert!(boosted.apply_ui_param("attack", 80.0));
+        assert!(boosted.apply_ui_param("sustain", 0.0));
+
+        let n = run_impulse(&mut neutral, 64);
+        let b = run_impulse(&mut boosted, 64);
+        assert!(
+            b[0].abs() > n[0].abs() + 0.05,
+            "boosted={} neutral={}",
+            b[0],
+            n[0]
+        );
+    }
+
+    #[test]
+    fn cutting_sustain_lowers_the_tail() {
+        let mut neutral = Dsp::new(48_000.0);
+        let mut cut = Dsp::new(48_000.0);
+        assert!(cut.apply_ui_param("attack", 0.0));
+        assert!(cut.apply_ui_param("sustain", -80.0));
+
+        // Drive a short burst so both envelopes rise, then compare the tail.
+        for _ in 0..64 {
+            let _ = neutral.process_stereo(0.6, 0.6);
+            let _ = cut.process_stereo(0.6, 0.6);
+        }
+        let mut neutral_tail = 0.0f32;
+        let mut cut_tail = 0.0f32;
+        for _ in 0..256 {
+            let (nl, _) = neutral.process_stereo(0.05, 0.05);
+            let (cl, _) = cut.process_stereo(0.05, 0.05);
+            neutral_tail = neutral_tail.max(nl.abs());
+            cut_tail = cut_tail.max(cl.abs());
+        }
+        assert!(
+            cut_tail < neutral_tail * 0.95,
+            "cut_tail={cut_tail} neutral_tail={neutral_tail}"
+        );
+    }
+
+    #[test]
+    fn wire_params_round_trip() {
+        let mut dsp = Dsp::new(48_000.0);
+        assert!(dsp.apply_ui_param("attack", -40.0));
+        assert!(dsp.apply_ui_param("sustain", 25.0));
+        assert!(dsp.apply_ui_param("speed", 10.0));
+        assert!(dsp.apply_ui_param("mix", 50.0));
+        assert!(dsp.apply_ui_param("stereoLink", 0.0));
+        assert_eq!(dsp.params().attack, -40.0);
+        assert_eq!(dsp.params().sustain, 25.0);
+        assert_eq!(dsp.params().speed, 10.0);
+        assert_eq!(dsp.params().mix, 50.0);
+        assert!(!dsp.params().stereo_link);
+    }
+}

--- a/crates/BuiltinAudioPlugins/crates/Transient/src/ui.rs
+++ b/crates/BuiltinAudioPlugins/crates/Transient/src/ui.rs
@@ -1,0 +1,101 @@
+//! Embedded editor UI for Transient.
+//!
+//! The asset table is produced at build time by `build.rs` from `editorui/dist`
+//! and lives in the library's read-only data segment. The CEF host serves it
+//! through the `mikoplugin://transient/...` scheme; see [`builtin_ui_embed`]
+//! for the lookup and URL rules.
+
+use builtin_ui_embed::{EmbeddedPluginUi, EmbeddedUiAsset, EmbeddedUiAssetTable};
+
+// Emits `static EMBEDDED_UI_ASSETS: &[::builtin_ui_embed::EmbeddedUiAsset]`,
+// sorted by path so the table can be binary-searched.
+include!(concat!(env!("OUT_DIR"), "/embedded_ui_assets.rs"));
+
+/// The URL origin (`mikoplugin://<origin>/...`) this plugin's assets are served
+/// under. Must match the `stem` in `SpherePluginHost`'s built-in catalog.
+pub const UI_ORIGIN: &str = "transient";
+
+/// Marker type carrying the embedded editor assets.
+pub struct TransientUi;
+
+impl TransientUi {
+    /// The embedded asset table. Empty when `editorui/dist` was not built.
+    pub fn table() -> EmbeddedUiAssetTable {
+        EmbeddedUiAssetTable::new(EMBEDDED_UI_ASSETS)
+    }
+
+    /// Whether a UI was actually embedded at build time. The host uses this to
+    /// report a clear error instead of opening a blank editor window.
+    pub fn is_embedded() -> bool {
+        !EMBEDDED_UI_ASSETS.is_empty()
+    }
+}
+
+impl EmbeddedPluginUi for TransientUi {
+    fn get_ui_asset(path: &str) -> Option<EmbeddedUiAsset> {
+        Self::table().get(path).copied()
+    }
+
+    fn resolve_ui_asset(path: &str) -> Option<EmbeddedUiAsset> {
+        Self::table().resolve(path).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookups_are_total_and_never_panic() {
+        for path in [
+            "",
+            "/",
+            "/index.html",
+            "/../secret",
+            "/assets/%zz",
+            "\\windows\\path",
+            "/a/b/c/d/e",
+        ] {
+            let _ = TransientUi::get_ui_asset(path);
+            let _ = TransientUi::resolve_ui_asset(path);
+        }
+    }
+
+    #[test]
+    fn traversal_is_rejected_even_when_a_table_is_present() {
+        assert!(TransientUi::get_ui_asset("/../../etc/passwd").is_none());
+        assert!(TransientUi::resolve_ui_asset("/../../etc/passwd").is_none());
+    }
+
+    #[test]
+    fn a_built_dist_serves_index_html_and_round_trips_every_entry() {
+        if !TransientUi::is_embedded() {
+            return;
+        }
+        let index = TransientUi::get_ui_asset("/index.html")
+            .expect("an embedded table always contains /index.html");
+        assert!(!index.is_empty());
+        assert!(index.mime_type.starts_with("text/html"));
+
+        assert_eq!(
+            TransientUi::resolve_ui_asset("/").map(|a| a.path),
+            Some("/index.html")
+        );
+        assert_eq!(
+            TransientUi::resolve_ui_asset("").map(|a| a.path),
+            Some("/index.html")
+        );
+
+        let table = TransientUi::table();
+        for asset in EMBEDDED_UI_ASSETS {
+            assert_eq!(
+                table
+                    .get(asset.path)
+                    .map(|found: &EmbeddedUiAsset| found.path),
+                Some(asset.path),
+                "asset {} is not retrievable — table is not sorted by path",
+                asset.path
+            );
+        }
+    }
+}

--- a/crates/BuiltinAudioPlugins/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/src/lib.rs
@@ -28,6 +28,7 @@ pub use fa2a;
 pub use fa76;
 pub use clipper67;
 pub use meowsyn;
+pub use transient;
 pub use wrapsynth;
 
 use builtin_dsp_core::PluginDescriptor;
@@ -42,6 +43,7 @@ pub fn focus_descriptors() -> Vec<PluginDescriptor> {
         fa76::descriptor(),
         burnlimit::descriptor(),
         clipper67::descriptor(),
+        transient::descriptor(),
         c1073::descriptor(),
         meowsyn::descriptor(),
         wrapsynth::descriptor(),
@@ -63,6 +65,7 @@ mod tests {
         assert!(ids.contains(&fa76::PLUGIN_ID));
         assert!(ids.contains(&burnlimit::PLUGIN_ID));
         assert!(ids.contains(&clipper67::PLUGIN_ID));
+        assert!(ids.contains(&transient::PLUGIN_ID));
         assert!(ids.contains(&c1073::PLUGIN_ID));
         assert!(ids.contains(&meowsyn::PLUGIN_ID));
         assert!(ids.contains(&wrapsynth::PLUGIN_ID));

--- a/crates/SpherePluginHost/Cargo.toml
+++ b/crates/SpherePluginHost/Cargo.toml
@@ -42,6 +42,7 @@ fa2a.workspace = true
 fa76.workspace = true
 burnlimit.workspace = true
 clipper67.workspace = true
+transient.workspace = true
 wrapsynth.workspace = true
 # Analyser FFT for the bridged-insert spectrum (src/spectrum.rs). Already a
 # workspace dependency via rodharerist / SphereAudioProcessor — no new tree.

--- a/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
+++ b/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
@@ -250,6 +250,7 @@ enum BuiltinDsp {
     Fa76(fa76::Dsp),
     BurnLimit(burnlimit::Dsp),
     Clipper67(clipper67::Dsp),
+    Transient(transient::Dsp),
     WrapSynth(wrapsynth::Dsp),
 }
 
@@ -299,6 +300,7 @@ impl BuiltinHostProcessor {
             "fa76" => Some(Self::fa76(sample_rate, state_json)),
             "burnlimit" => Some(Self::burnlimit(sample_rate, state_json)),
             "clipper67" => Some(Self::clipper67(sample_rate, state_json)),
+            "transient" => Some(Self::transient(sample_rate, state_json)),
             "wrapsynth" => Some(Self::wrapsynth(sample_rate, state_json)),
             _ => None,
         }
@@ -471,6 +473,32 @@ impl BuiltinHostProcessor {
         }
     }
 
+    fn transient(sample_rate: u32, state_json: Option<&str>) -> Self {
+        let sr = sample_rate.max(1) as f32;
+        let mut dsp = transient::Dsp::new(sr);
+        if let Some(json) = state_json {
+            match transient::ipc::TransientState::from_json(json) {
+                Ok(state) => {
+                    dsp.set_params(state.params);
+                    eprintln!(
+                        "[plugin-host-builtin] restored state version={}",
+                        state.version
+                    );
+                }
+                Err(error) => {
+                    eprintln!("[plugin-host-builtin] state blob rejected, using defaults: {error}");
+                }
+            }
+        }
+        Self {
+            dsp: UnsafeCell::new(BuiltinDsp::Transient(dsp)),
+            spectrum: UnsafeCell::new(SpectrumAnalyzer::new(sr)),
+            nam_loader: None,
+            ir_loader: None,
+            sample_rate: sr,
+        }
+    }
+
     fn echospace(sample_rate: u32, state_json: Option<&str>) -> Self {
         let sr = sample_rate.max(1) as f32;
         let mut dsp = echospace::Dsp::new(sr);
@@ -608,6 +636,13 @@ impl BuiltinHostProcessor {
                     interleaved[i * 2 + 1] = r;
                 }
             }
+            BuiltinDsp::Transient(dsp) => {
+                for i in 0..frames {
+                    let (l, r) = dsp.process_stereo(in_l[i], in_r[i]);
+                    interleaved[i * 2] = l;
+                    interleaved[i * 2 + 1] = r;
+                }
+            }
             BuiltinDsp::WrapSynth(dsp) => {
                 for i in 0..frames {
                     let (l, r) = dsp.process_stereo();
@@ -702,6 +737,18 @@ impl BuiltinHostProcessor {
                     out_clip: f.out_clip,
                 })
             }
+            BuiltinDsp::Transient(dsp) => {
+                let f = dsp.meter_frame();
+                Some(SpherePluginHost::audio_bridge::BuiltinMeterFrame {
+                    in_peak: f.in_peak,
+                    in_rms: f.in_rms,
+                    out_peak: f.out_peak,
+                    out_rms: f.out_rms,
+                    gain_reduction_db: f.gain_reduction_db,
+                    in_clip: f.in_clip,
+                    out_clip: f.out_clip,
+                })
+            }
             BuiltinDsp::Equz8(_)
             | BuiltinDsp::Verbspace(_)
             | BuiltinDsp::Echospace(_)
@@ -724,6 +771,7 @@ impl BuiltinHostProcessor {
             BuiltinDsp::Fa76(dsp) => dsp.latency_samples(),
             BuiltinDsp::BurnLimit(dsp) => dsp.latency_samples(),
             BuiltinDsp::Clipper67(dsp) => dsp.latency_samples(),
+            BuiltinDsp::Transient(dsp) => dsp.latency_samples(),
             BuiltinDsp::Echospace(dsp) => dsp.latency_samples(),
             BuiltinDsp::WrapSynth(_) => 0,
         }
@@ -762,6 +810,9 @@ impl BuiltinHostProcessor {
                 let _ = dsp.apply_wire_param(param_id, value);
             }
             BuiltinDsp::Clipper67(dsp) => {
+                let _ = dsp.apply_wire_param(param_id, value);
+            }
+            BuiltinDsp::Transient(dsp) => {
                 let _ = dsp.apply_wire_param(param_id, value);
             }
             BuiltinDsp::WrapSynth(dsp) => {
@@ -1418,6 +1469,68 @@ mod builtin_processor_tests {
         assert!(output.iter().all(|sample| sample.is_finite()));
 
         let fallback = BuiltinHostProcessor::clipper67(48_000, Some("not json"));
+        fallback.process_block(&in_l, &in_r, &mut output, 32);
+        assert!(output.iter().all(|sample| sample.is_finite()));
+    }
+
+    #[test]
+    fn transient_publishes_real_shaping_through_the_host_frame() {
+        let processor = BuiltinHostProcessor::transient(48_000, None);
+        let attack = transient::ui_param_index("attack").expect("in wire table");
+        let sustain = transient::ui_param_index("sustain").expect("in wire table");
+        processor.apply_param(attack, 80.0);
+        processor.apply_param(sustain, -40.0);
+
+        let silence = [0.0f32; 64];
+        let mut output = [0.0f32; 128];
+        processor.process_block(&silence, &silence, &mut output, 64);
+        let quiet = processor
+            .meter_frame()
+            .expect("transient always publishes a frame");
+        assert!(quiet.gain_reduction_db < 1.0);
+
+        let mut impulse = [0.0f32; 64];
+        impulse[0] = 0.9;
+        for _ in 0..32 {
+            processor.process_block(&impulse, &impulse, &mut output, 64);
+        }
+        let frame = processor
+            .meter_frame()
+            .expect("transient always publishes a frame");
+        assert!(
+            frame.gain_reduction_db > 0.2,
+            "no shaping reported for an impulse: {}",
+            frame.gain_reduction_db
+        );
+        assert!(frame.in_peak > 0.0);
+    }
+
+    #[test]
+    fn transient_restores_state_and_takes_wire_params() {
+        let mut params = transient::default_params();
+        params.power = false;
+        let json = transient::ipc::TransientState::new(params)
+            .to_json()
+            .expect("state serializes");
+
+        let restored = BuiltinHostProcessor::transient(48_000, Some(&json));
+        let in_l = [0.25f32; 32];
+        let in_r = [-0.5f32; 32];
+        let mut output = [0.0f32; 64];
+        restored.process_block(&in_l, &in_r, &mut output, 32);
+        for i in 0..32 {
+            assert_eq!(output[i * 2], in_l[i], "restored power-off must bypass");
+            assert_eq!(output[i * 2 + 1], in_r[i], "restored power-off must bypass");
+        }
+        let frame = restored.meter_frame().expect("frame is published");
+        assert_eq!(frame.gain_reduction_db, 0.0);
+
+        restored.apply_param(u32::MAX, 1.0);
+        restored.apply_param(transient::UI_PARAM_IDS.len() as u32, 1.0);
+        restored.process_block(&in_l, &in_r, &mut output, 32);
+        assert!(output.iter().all(|sample| sample.is_finite()));
+
+        let fallback = BuiltinHostProcessor::transient(48_000, Some("not json"));
         fallback.process_block(&in_l, &in_r, &mut output, 32);
         assert!(output.iter().all(|sample| sample.is_finite()));
     }

--- a/crates/SpherePluginHost/src/builtin.rs
+++ b/crates/SpherePluginHost/src/builtin.rs
@@ -102,6 +102,13 @@ const CATALOG: &[BuiltinEntry] = &[
         has_editor: true,
     },
     BuiltinEntry {
+        stem: "transient",
+        name: "Transient",
+        category: "Dynamics",
+        kind: PluginKind::Effect,
+        has_editor: true,
+    },
+    BuiltinEntry {
         stem: "c1073",
         name: "C1073",
         category: "EQ",
@@ -186,6 +193,7 @@ pub const AUDIO_BRIDGE_STEMS: &[&str] = &[
     "fa76",
     "burnlimit",
     "clipper67",
+    "transient",
     "wrapsynth",
 ];
 
@@ -321,6 +329,10 @@ mod tests {
             builtin_editor_url(&builtin_id("clipper67")).as_deref(),
             Some("mikoplugin://clipper67/index.html")
         );
+        assert_eq!(
+            builtin_editor_url(&builtin_id("transient")).as_deref(),
+            Some("mikoplugin://transient/index.html")
+        );
         assert!(builtin_editor_url(&builtin_id("compresser")).is_none());
         assert!(builtin_editor_url("vst3:whatever").is_none());
     }
@@ -350,6 +362,8 @@ mod tests {
         assert!(builtin_audio_bridge_supported("builtin:burnlimit"));
         assert!(builtin_audio_bridge_supported("clipper67"));
         assert!(builtin_audio_bridge_supported("builtin:clipper67"));
+        assert!(builtin_audio_bridge_supported("transient"));
+        assert!(builtin_audio_bridge_supported("builtin:transient"));
         assert!(builtin_audio_bridge_supported("wrapsynth"));
         assert!(builtin_audio_bridge_supported("builtin:wrapsynth"));
         // Catalogued, but the host has no DSP for it — must keep its old path.
@@ -381,6 +395,7 @@ mod tests {
         assert_eq!(builtin_display_name("builtin:fa76"), Some("FA-76"));
         assert_eq!(builtin_display_name("builtin:burnlimit"), Some("BurnLimit"));
         assert_eq!(builtin_display_name("builtin:clipper67"), Some("67Clipper"));
+        assert_eq!(builtin_display_name("builtin:transient"), Some("Transient"));
         assert_eq!(builtin_display_name("builtin:wrapsynth"), Some("WrapSynth"));
         assert_eq!(builtin_display_name("vst3:whatever"), None);
     }

--- a/crates/SphereUIComponents/Cargo.toml
+++ b/crates/SphereUIComponents/Cargo.toml
@@ -33,6 +33,7 @@ builtin-plugin-editor = [
     "dep:fa76",
     "dep:burnlimit",
     "dep:clipper67",
+    "dep:transient",
     "dep:wrapsynth",
     "dep:builtin-ui-embed",
 ]
@@ -71,6 +72,7 @@ fa2a = { workspace = true, optional = true }
 fa76 = { workspace = true, optional = true }
 burnlimit = { workspace = true, optional = true }
 clipper67 = { workspace = true, optional = true }
+transient = { workspace = true, optional = true }
 wrapsynth = { workspace = true, optional = true }
 builtin-ui-embed = { workspace = true, optional = true }
 # Reusable native graphics/text/window backend (DirectWrite, DWM, GDI paint).

--- a/crates/SphereUIComponents/src/components/builtin_plugin_editor.rs
+++ b/crates/SphereUIComponents/src/components/builtin_plugin_editor.rs
@@ -79,6 +79,7 @@ pub fn builtin_param_index(plugin_id: &str, param_id: &str) -> Option<u32> {
         fa76::ui::UI_ORIGIN => fa76::ui_param_index(param_id),
         burnlimit::ui::UI_ORIGIN => burnlimit::ui_param_index(param_id),
         clipper67::ui::UI_ORIGIN => clipper67::ui_param_index(param_id),
+        transient::ui::UI_ORIGIN => transient::ui_param_index(param_id),
         wrapsynth::ui::UI_ORIGIN => wrapsynth::ui_param_index(param_id),
         _ => None,
     }
@@ -122,6 +123,7 @@ mod state_mirror {
         Fa76(Box<fa76::Params>),
         BurnLimit(Box<burnlimit::Params>),
         Clipper67(Box<clipper67::Params>),
+        Transient(Box<transient::Params>),
         WrapSynth(Box<wrapsynth::Params>),
     }
 
@@ -136,6 +138,7 @@ mod state_mirror {
                 Self::Fa76(_) => fa76::ui::UI_ORIGIN,
                 Self::BurnLimit(_) => burnlimit::ui::UI_ORIGIN,
                 Self::Clipper67(_) => clipper67::ui::UI_ORIGIN,
+                Self::Transient(_) => transient::ui::UI_ORIGIN,
                 Self::WrapSynth(_) => wrapsynth::ui::UI_ORIGIN,
             }
         }
@@ -160,6 +163,9 @@ mod state_mirror {
                 }
                 clipper67::ui::UI_ORIGIN => {
                     Some(Self::Clipper67(Box::new(clipper67::default_params())))
+                }
+                transient::ui::UI_ORIGIN => {
+                    Some(Self::Transient(Box::new(transient::default_params())))
                 }
                 wrapsynth::ui::UI_ORIGIN => {
                     Some(Self::WrapSynth(Box::new(wrapsynth::default_params())))
@@ -206,6 +212,7 @@ mod state_mirror {
             fa76::ui::UI_ORIGIN => fa76::ui_param_id(wire_index).is_some(),
             burnlimit::ui::UI_ORIGIN => burnlimit::ui_param_id(wire_index).is_some(),
             clipper67::ui::UI_ORIGIN => clipper67::ui_param_id(wire_index).is_some(),
+            transient::ui::UI_ORIGIN => transient::ui_param_id(wire_index).is_some(),
             wrapsynth::ui::UI_ORIGIN => wrapsynth::ui_param_id(wire_index).is_some(),
             _ => false,
         };
@@ -241,6 +248,9 @@ mod state_mirror {
             }
             Some(BuiltinParams::Clipper67(params)) => {
                 let _ = clipper67::ipc::apply_wire_param(params, wire_index, value);
+            }
+            Some(BuiltinParams::Transient(params)) => {
+                let _ = transient::ipc::apply_wire_param(params, wire_index, value);
             }
             Some(BuiltinParams::WrapSynth(params)) => {
                 let _ = wrapsynth::ipc::apply_wire_param(params, wire_index, value);
@@ -283,6 +293,9 @@ mod state_mirror {
             clipper67::ui::UI_ORIGIN => clipper67::ipc::Clipper67State::from_json(text)
                 .ok()
                 .map(|state| BuiltinParams::Clipper67(Box::new(state.params))),
+            transient::ui::UI_ORIGIN => transient::ipc::TransientState::from_json(text)
+                .ok()
+                .map(|state| BuiltinParams::Transient(Box::new(state.params))),
             wrapsynth::ui::UI_ORIGIN => wrapsynth::ipc::WrapSynthState::from_json(text)
                 .ok()
                 .map(|state| BuiltinParams::WrapSynth(Box::new(state.params))),
@@ -347,6 +360,11 @@ mod state_mirror {
             }
             BuiltinParams::Clipper67(params) if origin == clipper67::ui::UI_ORIGIN => {
                 clipper67::ipc::Clipper67State::new((**params).clone())
+                    .to_json()
+                    .ok()?
+            }
+            BuiltinParams::Transient(params) if origin == transient::ui::UI_ORIGIN => {
+                transient::ipc::TransientState::new((**params).clone())
                     .to_json()
                     .ok()?
             }
@@ -419,6 +437,12 @@ mod state_mirror {
                 clipper67::ipc::ui_values(params)
                     .into_iter()
                     .filter_map(|(id, value)| clipper67::ui_param_index(id).map(|i| (i, value)))
+                    .collect()
+            }
+            Some(BuiltinParams::Transient(params)) if origin == transient::ui::UI_ORIGIN => {
+                transient::ipc::ui_values(params)
+                    .into_iter()
+                    .filter_map(|(id, value)| transient::ui_param_index(id).map(|i| (i, value)))
                     .collect()
             }
             Some(BuiltinParams::WrapSynth(params)) if origin == wrapsynth::ui::UI_ORIGIN => {
@@ -822,6 +846,7 @@ mod imp {
             fa76::ui::UI_ORIGIN => fa76::ui::Fa76Ui::resolve_ui_asset(path)?,
             burnlimit::ui::UI_ORIGIN => burnlimit::ui::BurnLimitUi::resolve_ui_asset(path)?,
             clipper67::ui::UI_ORIGIN => clipper67::ui::Clipper67Ui::resolve_ui_asset(path)?,
+            transient::ui::UI_ORIGIN => transient::ui::TransientUi::resolve_ui_asset(path)?,
             wrapsynth::ui::UI_ORIGIN => wrapsynth::ui::WrapSynthUi::resolve_ui_asset(path)?,
             _ => return None,
         };
@@ -846,6 +871,7 @@ mod imp {
                 | fa76::ui::UI_ORIGIN
                 | burnlimit::ui::UI_ORIGIN
                 | clipper67::ui::UI_ORIGIN
+                | transient::ui::UI_ORIGIN
                 | wrapsynth::ui::UI_ORIGIN
         )
     }
@@ -861,6 +887,7 @@ mod imp {
             fa76::ui::UI_ORIGIN => fa76::ui::Fa76Ui::is_embedded(),
             burnlimit::ui::UI_ORIGIN => burnlimit::ui::BurnLimitUi::is_embedded(),
             clipper67::ui::UI_ORIGIN => clipper67::ui::Clipper67Ui::is_embedded(),
+            transient::ui::UI_ORIGIN => transient::ui::TransientUi::is_embedded(),
             wrapsynth::ui::UI_ORIGIN => wrapsynth::ui::WrapSynthUi::is_embedded(),
             _ => false,
         }
@@ -1795,6 +1822,7 @@ mod tests {
         assert_eq!(origin_for_plugin_id("builtin:fa76"), Some("fa76"));
         assert_eq!(origin_for_plugin_id("builtin:burnlimit"), Some("burnlimit"));
         assert_eq!(origin_for_plugin_id("builtin:clipper67"), Some("clipper67"));
+        assert_eq!(origin_for_plugin_id("builtin:transient"), Some("transient"));
     }
 
     /// Regression guard for the bug that left the editor unopenable in the real
@@ -1810,6 +1838,7 @@ mod tests {
         assert_eq!(origin_for_plugin_id("fa76"), Some("fa76"));
         assert_eq!(origin_for_plugin_id("burnlimit"), Some("burnlimit"));
         assert_eq!(origin_for_plugin_id("clipper67"), Some("clipper67"));
+        assert_eq!(origin_for_plugin_id("transient"), Some("transient"));
         assert_eq!(
             origin_for_plugin_id("rodharerist"),
             origin_for_plugin_id("builtin:rodharerist"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Transient**, a new Futureboard built-in dynamics plugin modeled on the existing 67Clipper / BurnLimit pattern:

- Rust DSP core under `crates/BuiltinAudioPlugins/crates/Transient`
- Dual-envelope attack/sustain shaper (`attack`, `sustain`, `speed`, `mix`, `stereoLink`, `power`)
- Embedded Svelte 5 editor served at `mikoplugin://transient/index.html`
- Wired into the builtin catalog, audio bridge host, and CEF editor state mirror

## Controls

| Param | Range | Role |
| --- | --- | --- |
| Attack | −100…100% | Boost/cut the fast (transient) region |
| Sustain | −100…100% | Boost/cut the body after the attack |
| Speed | 0…100% | Scales envelope times |
| Mix | 0…100% | Dry/wet |
| Stereo Link | bool | Shared vs per-channel detectors |
| Power | bool | Bypass |

## Validation

- `bun test` + `bun run build` in `Transient/editorui` — pass
- `cargo test -p transient` — 14 pass
- `cargo test -p BuiltinAudioPlugins --lib` — pass
- `cargo test -p sphere-plugin-host --lib builtin::` — pass
- `cargo test -p sphere-plugin-host --features plugin-host-bin --bin FutureboardPluginHostX64 transient_` — pass

## Manual remaining

- Open Transient from the plugin browser in a debug Studio build with CEF (`builtin-plugin-editor`) and confirm editor attach, meters, and param gestures.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34333e78-c21c-4d5b-8355-61e654ebb0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34333e78-c21c-4d5b-8355-61e654ebb0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

