### PR TITLE
Rewrite Z-Comp editor as hardware faceplate

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/App.tsx
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/App.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useState, type CSSProperties } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
 import {
   MODEL_LABEL,
   MODEL_WIRE,
@@ -6,291 +14,483 @@ import {
   connectBridge,
   defaults,
   postParam,
-  type CompModel,
   type MeterFrame,
   type ZcompParams,
 } from './bridge'
+import { MeterBay } from './MeterBay'
+import { clamp, type MeterMode } from './meter'
+import {
+  MODEL_CIRCUIT,
+  PARAM_SPECS,
+  releaseIsProgrammed,
+  sanitizeParams,
+  type ParamSpec,
+} from './params'
+import { PresetControl } from './PresetControl'
+import {
+  FACTORY_PRESETS,
+  matchingPresetIndex,
+  postAllParams,
+} from './presets'
+
+const TRAVEL_PX = 240
+const START_DEG = -240
+const SWEEP_DEG = 300
 
 type KnobProps = {
-  label: string
+  spec: ParamSpec
   value: number
-  min: number
-  max: number
-  step?: number
-  display?: (value: number) => string
+  display: (value: number) => string
   onChange: (value: number) => void
+  size?: 'lg' | 'sm'
+  disabled?: boolean
+  disabledReadout?: string
 }
 
-function Knob({ label, value, min, max, step = 0.01, display, onChange }: KnobProps) {
-  const ratio = (value - min) / Math.max(max - min, 1e-9)
-  const angle = -135 + ratio * 270
-  return (
-    <label className="knob-control">
-      <span className="knob-label">{label}</span>
-      <span className="knob" style={{ '--knob-angle': `${angle}deg` } as CSSProperties}>
-        <span className="knob-cap">
-          <i />
-        </span>
-        <input
-          aria-label={label}
-          type="range"
-          min={min}
-          max={max}
-          step={step}
-          value={value}
-          onChange={(event) => onChange(Number(event.target.value))}
-        />
-      </span>
-      <output>{display ? display(value) : value.toFixed(step < 1 ? 1 : 0)}</output>
-    </label>
+function AluminumKnob({
+  spec,
+  value,
+  display,
+  onChange,
+  size = 'lg',
+  disabled = false,
+  disabledReadout,
+}: KnobProps) {
+  const uid = useId().replace(/:/g, '')
+  const gesture = useRef<{ y: number; norm: number } | null>(null)
+  const [dragging, setDragging] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { min, max, step, label, unit, defaultValue } = spec
+  const norm = (value - min) / Math.max(max - min, 1e-9)
+  const fromNorm = useCallback(
+    (n: number) => {
+      const raw = min + clamp(n, 0, 1) * (max - min)
+      return clamp(Math.round(raw / step) * step, min, max)
+    },
+    [max, min, step],
   )
-}
 
-function LevelBar({
-  label,
-  peak,
-  rms,
-  clip,
-}: {
-  label: string
-  peak: number
-  rms: number
-  clip: boolean
-}) {
-  const toDb = (linear: number) => 20 * Math.log10(Math.max(linear, 1e-9))
-  const peakDb = toDb(peak)
-  const rmsDb = toDb(rms)
-  const map = (db: number) => Math.max(0, Math.min(1, (db + 60) / 60))
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+  }, [editing])
+
+  const pointerAngle = START_DEG + SWEEP_DEG * clamp(norm, 0, 1)
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (disabled || editing || event.button !== 0) return
+    gesture.current = { y: event.clientY, norm }
+    event.currentTarget.setPointerCapture(event.pointerId)
+    setDragging(true)
+    event.preventDefault()
+  }
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!gesture.current || disabled) return
+    const travel = event.shiftKey ? TRAVEL_PX * 5 : TRAVEL_PX
+    onChange(
+      fromNorm(gesture.current.norm + (gesture.current.y - event.clientY) / travel),
+    )
+  }
+  const onPointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!gesture.current) return
+    gesture.current = null
+    event.currentTarget.releasePointerCapture(event.pointerId)
+    setDragging(false)
+  }
+
   return (
-    <div className={`level-bar ${clip ? 'clip' : ''}`}>
-      <span>{label}</span>
-      <div className="level-track">
-        <i className="rms" style={{ height: `${map(rmsDb) * 100}%` }} />
-        <i className="peak" style={{ height: `${map(peakDb) * 100}%` }} />
+    <div className={`knob ${size}${disabled ? ' is-disabled' : ''}`}>
+      <div
+        className={`cap${dragging ? ' is-dragging' : ''}`}
+        role="slider"
+        aria-label={label}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-valuetext={
+          disabled && disabledReadout
+            ? disabledReadout
+            : `${display(value)} ${unit}`
+        }
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
+        title={
+          disabled
+            ? disabledReadout ?? `${label} programmed by Auto Rel`
+            : `${label} — drag vertically, Shift for fine, double-click to reset`
+        }
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        onDoubleClick={() => !disabled && onChange(defaultValue)}
+        onWheel={(event) => {
+          if (disabled) return
+          event.preventDefault()
+          const delta = event.shiftKey ? step / 5 : step
+          onChange(
+            clamp(value + (event.deltaY < 0 ? delta : -delta), min, max),
+          )
+        }}
+        onKeyDown={(event) => {
+          if (disabled) return
+          const delta = event.shiftKey ? step / 5 : step
+          if (event.key === 'ArrowUp' || event.key === 'ArrowRight') {
+            event.preventDefault()
+            onChange(clamp(value + delta, min, max))
+          } else if (event.key === 'ArrowDown' || event.key === 'ArrowLeft') {
+            event.preventDefault()
+            onChange(clamp(value - delta, min, max))
+          } else if (event.key === 'Home') {
+            event.preventDefault()
+            onChange(defaultValue)
+          }
+        }}
+      >
+        <svg viewBox="0 0 100 100" aria-hidden="true">
+          <defs>
+            <radialGradient id={`${uid}-body`} cx="0.32" cy="0.28" r="0.78">
+              <stop offset="0" stopColor="#d8dee8" />
+              <stop offset="0.45" stopColor="#9aa4b4" />
+              <stop offset="1" stopColor="#4a5360" />
+            </radialGradient>
+            <linearGradient id={`${uid}-rim`} x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0" stopColor="#eef2f8" />
+              <stop offset="0.5" stopColor="#8a95a6" />
+              <stop offset="1" stopColor="#3a4250" />
+            </linearGradient>
+          </defs>
+          <circle className="rim" cx="50" cy="50" r="31" fill={`url(#${uid}-rim)`} />
+          <g
+            style={{
+              transform: `rotate(${pointerAngle + 90}deg)`,
+              transformOrigin: '50px 50px',
+            }}
+          >
+            <circle className="body" cx="50" cy="50" r="26" fill={`url(#${uid}-body)`} />
+            <path className="gloss" d="M 34 38 A 20 20 0 0 1 66 34" />
+            <rect className="pointer" x="48.7" y="24" width="2.6" height="16" rx="1.2" />
+          </g>
+        </svg>
       </div>
-      <output>{peakDb.toFixed(0)}</output>
+      <div className="plate">
+        <div className="name">{label}</div>
+        {editing && !disabled ? (
+          <input
+            ref={inputRef}
+            className="input"
+            value={draft}
+            aria-label={`${label} value`}
+            onChange={(event) => setDraft(event.target.value)}
+            onBlur={() => {
+              const parsed = Number(draft.replace(/[^\d.+-]/g, ''))
+              if (Number.isFinite(parsed)) onChange(clamp(parsed, min, max))
+              setEditing(false)
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') (event.target as HTMLInputElement).blur()
+              if (event.key === 'Escape') setEditing(false)
+            }}
+          />
+        ) : (
+          <button
+            type="button"
+            className="readout"
+            disabled={disabled}
+            title={disabled ? disabledReadout : 'Click to type a value'}
+            onClick={() => {
+              if (disabled) return
+              setDraft(String(Number(value.toFixed(2))))
+              setEditing(true)
+            }}
+          >
+            {disabled && disabledReadout ? (
+              disabledReadout
+            ) : (
+              <>
+                {display(value)}
+                <span className="unit">{unit}</span>
+              </>
+            )}
+          </button>
+        )}
+      </div>
     </div>
   )
 }
 
-function GrMeter({ db }: { db: number }) {
-  const amount = Math.max(0, Math.min(1, db / 24))
-  const ticks = [0, 3, 6, 9, 12, 18, 24]
-  return (
-    <div className="gr-meter" aria-label={`Gain reduction ${db.toFixed(1)} dB`}>
-      <header>
-        <strong>GR</strong>
-        <output>{db.toFixed(1)} dB</output>
-      </header>
-      <div className="gr-face">
-        <div className="gr-fill" style={{ width: `${amount * 100}%` }} />
-        <div className="gr-ticks">
-          {ticks.map((tick) => (
-            <span key={tick} style={{ left: `${(tick / 24) * 100}%` }}>
-              {tick}
-            </span>
-          ))}
-        </div>
-      </div>
-    </div>
-  )
+function formatMs(value: number) {
+  return value < 10 ? value.toFixed(2) : String(Math.round(value))
+}
+function formatDb(value: number) {
+  return value.toFixed(1)
+}
+function formatPct(value: number) {
+  return String(Math.round(value))
+}
+function formatHz(value: number) {
+  return String(Math.round(value))
+}
+function formatRatio(value: number) {
+  return value.toFixed(1)
 }
 
 function App() {
   const [params, setParams] = useState<ZcompParams>(defaults)
   const [connected, setConnected] = useState(false)
-  const [meters, setMeters] = useState<MeterFrame>({
-    inPeak: 0,
-    inRms: 0,
-    outPeak: 0,
-    outRms: 0,
-    gainReductionDb: 0,
-    inClip: false,
-    outClip: false,
-  })
+  const [meterLive, setMeterLive] = useState(false)
+  const [meterMode, setMeterMode] = useState<MeterMode>('reduction')
+  const metersRef = useRef<MeterFrame | null>(null)
+  const [preset, setPreset] = useState<number | null>(0)
+  const [skinPulse, setSkinPulse] = useState(false)
+  const prevModel = useRef(params.model)
 
-  useEffect(() => connectBridge(setParams, setConnected, setMeters), [])
+  useEffect(
+    () =>
+      connectBridge(
+        (next) => {
+          const clean = sanitizeParams(next)
+          setParams(clean)
+          setPreset(matchingPresetIndex(clean))
+        },
+        (isConnected) => {
+          setConnected(isConnected)
+          if (!isConnected) {
+            metersRef.current = null
+            setMeterLive(false)
+          }
+        },
+        (frame) => {
+          metersRef.current = frame
+          setMeterLive((was) => was || true)
+        },
+      ),
+    [],
+  )
+
+  useEffect(() => {
+    if (prevModel.current === params.model) return
+    prevModel.current = params.model
+    setSkinPulse(true)
+    const timer = window.setTimeout(() => setSkinPulse(false), 420)
+    return () => window.clearTimeout(timer)
+  }, [params.model])
 
   const change = <K extends keyof ZcompParams>(
     id: K,
     value: ZcompParams[K],
     wire?: number,
   ) => {
-    setParams((current) => ({ ...current, [id]: value }))
+    setParams((current) => sanitizeParams({ ...current, [id]: value }))
+    setPreset(null)
     postParam(id, wire ?? Number(value))
   }
 
-  const setModel = (model: CompModel) => {
-    change('model', model, MODEL_WIRE[model])
+  const loadPreset = (index: number) => {
+    const wrapped =
+      ((index % FACTORY_PRESETS.length) + FACTORY_PRESETS.length) %
+      FACTORY_PRESETS.length
+    const next = sanitizeParams({ ...FACTORY_PRESETS[wrapped]!.params })
+    setParams(next)
+    setPreset(wrapped)
+    postAllParams(next)
   }
 
-  const ms = (value: number) =>
-    value < 10 ? `${value.toFixed(2)} ms` : `${Math.round(value)} ms`
-  const db = (value: number) => `${value.toFixed(1)} dB`
-  const pct = (value: number) => `${Math.round(value)}%`
-  const hz = (value: number) => `${Math.round(value)} Hz`
-  const ratio = (value: number) => `${value.toFixed(1)}:1`
+  const programmedRelease = releaseIsProgrammed(params)
+  const circuit = MODEL_CIRCUIT[params.model]
+  const metersActive = connected && meterLive
 
   return (
-    <main className={`shell ${params.power ? '' : 'powered-off'} model-${params.model}`}>
-      <header className="topbar">
-        <div className="brand">
-          <span>Z</span>
-          <div>
-            <strong>Z-Comp</strong>
-            <small>Ultimate Dynamics</small>
+    <div
+      className={`unit${skinPulse ? ' is-skin-pulse' : ''}`}
+      data-model={params.model}
+      style={
+        {
+          '--drive': String(clamp(params.color / 100, 0, 1)),
+        } as CSSProperties
+      }
+    >
+      <div className={`panel${params.power ? '' : ' is-off'}`}>
+        <header className="top">
+          <div className="identity">
+            <div className="wordmark">
+              <span className="z">Z</span>
+              <div>
+                <strong>Z-Comp</strong>
+                <em>{MODEL_LABEL[params.model]} circuit</em>
+              </div>
+            </div>
+            <PresetControl
+              preset={preset}
+              names={FACTORY_PRESETS.map((entry) => entry.name)}
+              onChange={loadPreset}
+              onPrevious={() => loadPreset((preset ?? 0) - 1)}
+              onNext={() => loadPreset((preset ?? -1) + 1)}
+            />
           </div>
-        </div>
-        <div className="model-strip" role="tablist" aria-label="Compressor model">
-          {MODELS.map((model) => (
+
+          <MeterBay
+            metersRef={metersRef}
+            live={metersActive}
+            mode={meterMode}
+            onClearOutClip={() => {
+              const frame = metersRef.current
+              if (frame) metersRef.current = { ...frame, outClip: false }
+            }}
+          />
+
+          <div className="side">
+            <div className="meter-switch" role="group" aria-label="Meter mode">
+              <button
+                type="button"
+                className={meterMode === 'reduction' ? 'is-on' : undefined}
+                onClick={() => setMeterMode('reduction')}
+              >
+                GR
+              </button>
+              <button
+                type="button"
+                className={meterMode === 'output' ? 'is-on' : undefined}
+                onClick={() => setMeterMode('output')}
+              >
+                +4
+              </button>
+            </div>
             <button
-              key={model}
               type="button"
-              role="tab"
-              aria-selected={params.model === model}
-              className={params.model === model ? 'active' : ''}
-              onClick={() => setModel(model)}
+              className={`power${params.power ? ' is-on' : ''}`}
+              role="switch"
+              aria-checked={params.power}
+              aria-label="Power"
+              onClick={() => change('power', !params.power, params.power ? 0 : 1)}
             >
-              {MODEL_LABEL[model]}
+              <span className="lamp" />
+              <span className="legend">Power</span>
             </button>
-          ))}
-        </div>
-        <div className="top-actions">
+            <span
+              className={`link${connected ? ' is-live' : ''}`}
+              title={connected ? 'Host linked' : 'Preview'}
+            />
+          </div>
+        </header>
+
+        <section className="models" aria-label="Compressor model">
+          <span className="bank-label">Model</span>
+          <div className="bank" role="radiogroup" aria-label="Circuit model">
+            {MODELS.map((model) => (
+              <button
+                key={model}
+                type="button"
+                className={params.model === model ? 'is-on' : undefined}
+                role="radio"
+                aria-checked={params.model === model}
+                onClick={() => change('model', model, MODEL_WIRE[model])}
+              >
+                {MODEL_LABEL[model]}
+              </button>
+            ))}
+          </div>
           <button
             type="button"
-            className={`toggle ${params.autoRelease ? 'on' : ''}`}
-            onClick={() => change('autoRelease', !params.autoRelease, params.autoRelease ? 0 : 1)}
+            className={`auto${params.autoRelease ? ' is-on' : ''}`}
+            aria-pressed={params.autoRelease}
+            title={
+              params.model === 'ssl'
+                ? 'Program-dependent release (SSL path in DSP)'
+                : 'Auto release flag (SSL circuit uses it)'
+            }
+            onClick={() =>
+              change('autoRelease', !params.autoRelease, params.autoRelease ? 0 : 1)
+            }
           >
             Auto Rel
           </button>
-          <button
-            type="button"
-            className={`power ${params.power ? 'on' : ''}`}
-            onClick={() => change('power', !params.power, params.power ? 0 : 1)}
-          >
-            {params.power ? 'On' : 'Off'}
-          </button>
-          <span className={`link-dot ${connected ? 'live' : ''}`} title={connected ? 'Host linked' : 'Preview'} />
-        </div>
-      </header>
+        </section>
 
-      <section className="workspace">
-        <aside className="meters">
-          <LevelBar label="IN" peak={meters.inPeak} rms={meters.inRms} clip={meters.inClip} />
-          <LevelBar label="OUT" peak={meters.outPeak} rms={meters.outRms} clip={meters.outClip} />
-        </aside>
+        <p className="circuit" aria-live="polite">
+          <strong>{circuit.title}</strong>
+          <span>{circuit.topology}</span>
+        </p>
 
-        <div className="center">
-          <GrMeter db={meters.gainReductionDb} />
-          <p className="model-blurb">
-            {params.model === 'comp2500' && 'VCA feed-forward · soft dual knee · THD colour'}
-            {params.model === 'distressor' && 'Aggressive detector · British grit · hard ratios'}
-            {params.model === 'avalon' && 'Class-A optical leveling · slow musical recovery'}
-            {params.model === 'ssl' && 'Bus glue · program auto-release · soft knee'}
-          </p>
-          <div className="knob-row primary">
-            <Knob
-              label="THRESH"
-              value={params.thresholdDb}
-              min={-60}
-              max={0}
-              step={0.1}
-              display={db}
-              onChange={(value) => change('thresholdDb', value)}
-            />
-            <Knob
-              label="RATIO"
-              value={params.ratio}
-              min={1}
-              max={20}
-              step={0.1}
-              display={ratio}
-              onChange={(value) => change('ratio', value)}
-            />
-            <Knob
-              label="ATTACK"
-              value={params.attackMs}
-              min={0.01}
-              max={120}
-              step={0.01}
-              display={ms}
-              onChange={(value) => change('attackMs', value)}
-            />
-            <Knob
-              label="RELEASE"
-              value={params.releaseMs}
-              min={10}
-              max={2500}
-              step={1}
-              display={ms}
-              onChange={(value) => change('releaseMs', value)}
-            />
-            <Knob
-              label="MAKEUP"
-              value={params.makeupDb}
-              min={-24}
-              max={24}
-              step={0.1}
-              display={db}
-              onChange={(value) => change('makeupDb', value)}
-            />
-          </div>
-        </div>
-      </section>
+        <section className="knobs" aria-label="Main controls">
+          <AluminumKnob
+            spec={PARAM_SPECS.thresholdDb}
+            value={params.thresholdDb}
+            display={formatDb}
+            onChange={(value) => change('thresholdDb', value)}
+          />
+          <AluminumKnob
+            spec={PARAM_SPECS.ratio}
+            value={params.ratio}
+            display={formatRatio}
+            onChange={(value) => change('ratio', value)}
+          />
+          <AluminumKnob
+            spec={PARAM_SPECS.attackMs}
+            value={params.attackMs}
+            display={formatMs}
+            onChange={(value) => change('attackMs', value)}
+          />
+          <AluminumKnob
+            spec={PARAM_SPECS.releaseMs}
+            value={params.releaseMs}
+            display={formatMs}
+            onChange={(value) => change('releaseMs', value)}
+            disabled={programmedRelease}
+            disabledReadout="AUTO"
+          />
+          <AluminumKnob
+            spec={PARAM_SPECS.makeupDb}
+            value={params.makeupDb}
+            display={formatDb}
+            onChange={(value) => change('makeupDb', value)}
+          />
+        </section>
 
-      <section className="secondary">
-        <Knob
-          label="KNEE"
-          value={params.kneeDb}
-          min={0}
-          max={24}
-          step={0.1}
-          display={db}
-          onChange={(value) => change('kneeDb', value)}
-        />
-        <Knob
-          label="MIX"
-          value={params.mix}
-          min={0}
-          max={100}
-          step={1}
-          display={pct}
-          onChange={(value) => change('mix', value)}
-        />
-        <Knob
-          label="SC HPF"
-          value={params.sidechainHpfHz}
-          min={20}
-          max={500}
-          step={1}
-          display={hz}
-          onChange={(value) => change('sidechainHpfHz', value)}
-        />
-        <Knob
-          label="LINK"
-          value={params.stereoLink}
-          min={0}
-          max={100}
-          step={1}
-          display={pct}
-          onChange={(value) => change('stereoLink', value)}
-        />
-        <Knob
-          label="COLOR"
-          value={params.color}
-          min={0}
-          max={100}
-          step={1}
-          display={pct}
-          onChange={(value) => change('color', value)}
-        />
-      </section>
-
-      <footer>
-        <span>Futureboard · Z-Comp</span>
-        <span>{MODEL_LABEL[params.model]} circuit</span>
-      </footer>
-    </main>
+        <section className="extras" aria-label="Extras">
+          <AluminumKnob
+            size="sm"
+            spec={PARAM_SPECS.kneeDb}
+            value={params.kneeDb}
+            display={formatDb}
+            onChange={(value) => change('kneeDb', value)}
+          />
+          <AluminumKnob
+            size="sm"
+            spec={PARAM_SPECS.mix}
+            value={params.mix}
+            display={formatPct}
+            onChange={(value) => change('mix', value)}
+          />
+          <AluminumKnob
+            size="sm"
+            spec={PARAM_SPECS.sidechainHpfHz}
+            value={params.sidechainHpfHz}
+            display={formatHz}
+            onChange={(value) => change('sidechainHpfHz', value)}
+          />
+          <AluminumKnob
+            size="sm"
+            spec={PARAM_SPECS.stereoLink}
+            value={params.stereoLink}
+            display={formatPct}
+            onChange={(value) => change('stereoLink', value)}
+          />
+          <AluminumKnob
+            size="sm"
+            spec={PARAM_SPECS.color}
+            value={params.color}
+            display={formatPct}
+            onChange={(value) => change('color', value)}
+          />
+        </section>
+      </div>
+    </div>
   )
 }
 

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/MeterBay.tsx
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/MeterBay.tsx
@@ -1,0 +1,514 @@
+/**
+ * Hardware meter bay: IN ladder · enamel VU · OUT ladder.
+ *
+ * Host telemetry is consumed via a ref so App knobs never re-render at meter
+ * rate. One RAF loop advances ballistics, paints both LED canvases, and rotates
+ * the needle with a transform — no React setState on the hot path.
+ */
+
+import {
+  useEffect,
+  useId,
+  useRef,
+  type MutableRefObject,
+  type RefObject,
+} from 'react'
+import type { MeterFrame } from './bridge'
+import {
+  LADDER_SEGMENTS,
+  LED_ATTACK_TAU,
+  LED_RELEASE_TAU,
+  PEAK_HOLD_SECONDS,
+  advance,
+  angleFor,
+  createPeakHold,
+  formatLadderDb,
+  holdNorm,
+  ladderNormFromLinear,
+  linearToDb,
+  normFor,
+  pushPeakHold,
+  ticksFor,
+  type MeterMode,
+  type PeakHold,
+} from './meter'
+
+const OUTPUT_REF_DBFS = -18
+const PIVOT_X = 100
+const PIVOT_Y = 134
+const NEEDLE_R = 100
+const SCALE_R = 104
+const LABEL_R = 86
+const TICK_MAJOR = 9
+const TICK_MINOR = 5
+const READOUT_HZ = 15
+
+type Props = {
+  metersRef: MutableRefObject<MeterFrame | null>
+  live: boolean
+  mode: MeterMode
+  onClearOutClip: () => void
+}
+
+type LadderState = {
+  peak: number
+  rms: number
+  hold: PeakHold
+}
+
+function polar(norm: number, radius: number) {
+  const rad = (angleFor(norm) * Math.PI) / 180
+  return {
+    x: PIVOT_X + Math.sin(rad) * radius,
+    y: PIVOT_Y - Math.cos(rad) * radius,
+  }
+}
+
+function arcPath(a: { x: number; y: number }, b: { x: number; y: number }) {
+  return `M ${a.x.toFixed(2)} ${a.y.toFixed(2)} A ${SCALE_R} ${SCALE_R} 0 0 1 ${b.x.toFixed(2)} ${b.y.toFixed(2)}`
+}
+
+function readCssColor(el: Element, name: string, fallback: string) {
+  const value = getComputedStyle(el).getPropertyValue(name).trim()
+  return value || fallback
+}
+
+function paintLadder(
+  canvas: HTMLCanvasElement,
+  peakNorm: number,
+  rmsNorm: number,
+  hold: number,
+  colors: { cool: string; warm: string; hot: string; idle: string; hold: string },
+) {
+  const dpr = Math.min(window.devicePixelRatio || 1, 2)
+  const cssW = canvas.clientWidth || 12
+  const cssH = canvas.clientHeight || 120
+  const w = Math.max(1, Math.round(cssW * dpr))
+  const h = Math.max(1, Math.round(cssH * dpr))
+  if (canvas.width !== w || canvas.height !== h) {
+    canvas.width = w
+    canvas.height = h
+  }
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.clearRect(0, 0, cssW, cssH)
+
+  const gap = 1.15
+  const segH = (cssH - gap * (LADDER_SEGMENTS - 1)) / LADDER_SEGMENTS
+  const peakSeg = Math.round(peakNorm * LADDER_SEGMENTS)
+  const rmsSeg = Math.round(rmsNorm * LADDER_SEGMENTS)
+  const holdSeg = Math.round(hold * LADDER_SEGMENTS)
+
+  for (let i = 0; i < LADDER_SEGMENTS; i++) {
+    // i = 0 at top (hot), matching hardware LED strips.
+    const fromTop = LADDER_SEGMENTS - i
+    const y = i * (segH + gap)
+    const lit = fromTop <= peakSeg
+    const rmsLit = fromTop <= rmsSeg
+    const isHold = fromTop === holdSeg && holdSeg > 0
+
+    let fill = colors.idle
+    if (lit) {
+      const t = fromTop / LADDER_SEGMENTS
+      if (t > 0.88) fill = colors.hot
+      else if (t > 0.68) fill = colors.warm
+      else fill = colors.cool
+    }
+
+    ctx.globalAlpha = lit ? (rmsLit ? 1 : 0.72) : 0.22
+    ctx.fillStyle = fill
+    const inset = lit ? 0 : 0.5
+    const x = inset
+    const ww = cssW - inset * 2
+    if (typeof ctx.roundRect === 'function') {
+      ctx.beginPath()
+      ctx.roundRect(x, y, ww, segH, 1)
+      ctx.fill()
+    } else {
+      ctx.fillRect(x, y, ww, segH)
+    }
+
+    if (isHold) {
+      ctx.globalAlpha = 1
+      ctx.fillStyle = colors.hold
+      ctx.fillRect(0, y, cssW, Math.max(1.2, segH * 0.55))
+    }
+  }
+  ctx.globalAlpha = 1
+}
+
+function VuFace({
+  mode,
+  faceId,
+  needleRef,
+  parkedRef,
+}: {
+  mode: MeterMode
+  faceId: string
+  needleRef: RefObject<SVGGElement | null>
+  parkedRef: RefObject<SVGTextElement | null>
+}) {
+  const ticks = ticksFor(mode)
+  const arcStart = polar(0, SCALE_R)
+  const arcEnd = polar(1, SCALE_R)
+  const hot = ticks.filter((tick) => tick.hot)
+  const hotA = hot.length > 1 ? polar(Math.min(...hot.map((t) => t.norm)), SCALE_R) : null
+  const hotB = hot.length > 1 ? polar(Math.max(...hot.map((t) => t.norm)), SCALE_R) : null
+  const restAngle = angleFor(normFor(mode, mode === 'reduction' ? 0 : -20))
+
+  return (
+    <svg
+      viewBox="0 0 200 120"
+      role="img"
+      aria-label={mode === 'reduction' ? 'Gain reduction meter' : 'Output level meter'}
+    >
+      <defs>
+        <linearGradient id={`${faceId}-face`} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor="var(--meter-face-hi)" />
+          <stop offset="0.55" stopColor="var(--meter-face)" />
+          <stop offset="1" stopColor="var(--meter-face-lo)" />
+        </linearGradient>
+        <linearGradient id={`${faceId}-glass`} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor="rgba(255,255,255,0.22)" />
+          <stop offset="0.35" stopColor="rgba(255,255,255,0.05)" />
+          <stop offset="1" stopColor="rgba(0,0,0,0.12)" />
+        </linearGradient>
+        <filter id={`${faceId}-needle`} x="-40%" y="-40%" width="180%" height="180%">
+          <feDropShadow dx="0.4" dy="1.1" stdDeviation="0.7" floodOpacity="0.45" />
+        </filter>
+      </defs>
+
+      <rect x="0" y="0" width="200" height="120" rx="7" fill={`url(#${faceId}-face)`} />
+      <path className="arc" d={arcPath(arcStart, arcEnd)} />
+      {hotA && hotB ? <path className="arc hot" d={arcPath(hotA, hotB)} /> : null}
+
+      {ticks.map((tick) => {
+        const outer = polar(tick.norm, SCALE_R)
+        const inner = polar(tick.norm, SCALE_R - (tick.major ? TICK_MAJOR : TICK_MINOR))
+        const labelAt = polar(tick.norm, LABEL_R)
+        return (
+          <g key={`${mode}-${tick.norm}-${tick.label}`}>
+            <line
+              className={`tick${tick.major ? ' major' : ''}${tick.hot ? ' hot' : ''}`}
+              x1={inner.x}
+              y1={inner.y}
+              x2={outer.x}
+              y2={outer.y}
+            />
+            {tick.label ? (
+              <text
+                className={`label${tick.hot ? ' hot' : ''}`}
+                x={labelAt.x}
+                y={labelAt.y}
+              >
+                {tick.label}
+              </text>
+            ) : null}
+          </g>
+        )
+      })}
+
+      <text className="caption" x="100" y="18">
+        {mode === 'reduction' ? 'GAIN REDUCTION' : 'OUTPUT'}
+      </text>
+      <text className="unit" x="100" y="88">
+        {mode === 'reduction' ? 'dB' : 'VU'}
+      </text>
+
+      <g
+        ref={needleRef}
+        className="needle-g"
+        transform={`rotate(${restAngle.toFixed(3)} ${PIVOT_X} ${PIVOT_Y})`}
+        filter={`url(#${faceId}-needle)`}
+      >
+        <line
+          className="needle"
+          x1={PIVOT_X}
+          y1={PIVOT_Y}
+          x2={PIVOT_X}
+          y2={PIVOT_Y - NEEDLE_R}
+        />
+        <circle className="hub" cx={PIVOT_X} cy={PIVOT_Y} r="4.2" />
+      </g>
+
+      <rect
+        className="bezel"
+        x="0.7"
+        y="0.7"
+        width="198.6"
+        height="118.6"
+        rx="6.4"
+      />
+      <rect
+        x="2"
+        y="2"
+        width="196"
+        height="52"
+        rx="5"
+        fill={`url(#${faceId}-glass)`}
+        pointerEvents="none"
+      />
+      <text ref={parkedRef} className="parked" x="100" y="108" style={{ display: 'none' }}>
+        no signal
+      </text>
+    </svg>
+  )
+}
+
+export function MeterBay({ metersRef, live, mode, onClearOutClip }: Props) {
+  const faceId = useId().replace(/:/g, '')
+  const rootRef = useRef<HTMLDivElement>(null)
+  const inCanvasRef = useRef<HTMLCanvasElement>(null)
+  const outCanvasRef = useRef<HTMLCanvasElement>(null)
+  const inReadoutRef = useRef<HTMLOutputElement>(null)
+  const outReadoutRef = useRef<HTMLOutputElement>(null)
+  const grReadoutRef = useRef<HTMLOutputElement>(null)
+  const needleRef = useRef<SVGGElement>(null)
+  const parkedRef = useRef<SVGTextElement>(null)
+  const clipBtnRef = useRef<HTMLButtonElement>(null)
+  const inClipRef = useRef<HTMLSpanElement>(null)
+  const outClipRef = useRef<HTMLSpanElement>(null)
+  const modeRef = useRef(mode)
+  const liveRef = useRef(live)
+  modeRef.current = mode
+  liveRef.current = live
+
+  useEffect(() => {
+    const inState: LadderState = {
+      peak: 0,
+      rms: 0,
+      hold: createPeakHold(),
+    }
+    const outState: LadderState = {
+      peak: 0,
+      rms: 0,
+      hold: createPeakHold(),
+    }
+    let needle = normFor(modeRef.current, modeRef.current === 'reduction' ? 0 : -20)
+    let last = performance.now()
+    let readoutAcc = 0
+    let lastGrText = ''
+    let lastInText = ''
+    let lastOutText = ''
+    let raf = 0
+
+    const colors = {
+      cool: '#4a9a8c',
+      warm: '#c9a35a',
+      hot: '#c43a28',
+      idle: 'rgba(255,255,255,0.06)',
+      hold: 'rgba(245,240,230,0.95)',
+    }
+
+    const syncColors = () => {
+      const root = rootRef.current
+      if (!root) return
+      colors.cool = readCssColor(root, '--btn-on', colors.cool)
+      colors.hot = readCssColor(root, '--clip', colors.hot)
+    }
+    syncColors()
+
+    const step = (now: number) => {
+      const dt = Math.min((now - last) / 1000, 0.25)
+      last = now
+      readoutAcc += dt
+
+      const frame = metersRef.current
+      const isLive = liveRef.current && frame !== null
+      const meterMode = modeRef.current
+
+      const inPeakLin = isLive ? frame!.inPeak : 0
+      const inRmsLin = isLive ? frame!.inRms : 0
+      const outPeakLin = isLive ? frame!.outPeak : 0
+      const outRmsLin = isLive ? frame!.outRms : 0
+      const grDb = isLive ? frame!.gainReductionDb : 0
+      const outClip = isLive ? frame!.outClip : false
+      const inClip = isLive ? frame!.inClip : false
+
+      inState.peak = advance(
+        inState.peak,
+        ladderNormFromLinear(inPeakLin),
+        dt,
+        LED_ATTACK_TAU,
+        LED_RELEASE_TAU,
+      )
+      inState.rms = advance(
+        inState.rms,
+        ladderNormFromLinear(inRmsLin),
+        dt,
+        LED_RELEASE_TAU,
+        LED_RELEASE_TAU * 1.4,
+      )
+      outState.peak = advance(
+        outState.peak,
+        ladderNormFromLinear(outPeakLin),
+        dt,
+        LED_ATTACK_TAU,
+        LED_RELEASE_TAU,
+      )
+      outState.rms = advance(
+        outState.rms,
+        ladderNormFromLinear(outRmsLin),
+        dt,
+        LED_RELEASE_TAU,
+        LED_RELEASE_TAU * 1.4,
+      )
+
+      if (isLive) {
+        pushPeakHold(inState.hold, linearToDb(inPeakLin), dt)
+        pushPeakHold(outState.hold, linearToDb(outPeakLin), dt)
+      } else {
+        inState.hold.db = -60
+        inState.hold.age = PEAK_HOLD_SECONDS
+        outState.hold.db = -60
+        outState.hold.age = PEAK_HOLD_SECONDS
+      }
+
+      const target =
+        isLive
+          ? normFor(
+              meterMode,
+              meterMode === 'reduction'
+                ? grDb
+                : linearToDb(outRmsLin) - OUTPUT_REF_DBFS,
+            )
+          : normFor(meterMode, meterMode === 'reduction' ? 0 : -20)
+
+      needle = advance(needle, target, dt)
+      const angle = angleFor(needle)
+      if (needleRef.current) {
+        needleRef.current.setAttribute(
+          'transform',
+          `rotate(${angle.toFixed(3)} ${PIVOT_X} ${PIVOT_Y})`,
+        )
+      }
+
+      if (inCanvasRef.current) {
+        paintLadder(
+          inCanvasRef.current,
+          inState.peak,
+          inState.rms,
+          holdNorm(inState.hold),
+          colors,
+        )
+      }
+      if (outCanvasRef.current) {
+        paintLadder(
+          outCanvasRef.current,
+          outState.peak,
+          outState.rms,
+          holdNorm(outState.hold),
+          colors,
+        )
+      }
+
+      if (parkedRef.current) {
+        parkedRef.current.style.display = isLive ? 'none' : ''
+      }
+      if (clipBtnRef.current) {
+        clipBtnRef.current.hidden = !outClip
+      }
+      if (inClipRef.current) {
+        inClipRef.current.classList.toggle('is-on', inClip)
+      }
+      if (outClipRef.current) {
+        outClipRef.current.classList.toggle('is-on', outClip)
+      }
+
+      if (readoutAcc >= 1 / READOUT_HZ) {
+        readoutAcc = 0
+        syncColors()
+        const grText = isLive ? grDb.toFixed(1) : '—'
+        if (grReadoutRef.current && grText !== lastGrText) {
+          grReadoutRef.current.textContent = grText
+          lastGrText = grText
+        }
+        const inText = isLive ? formatLadderDb(inPeakLin) : '—'
+        if (inReadoutRef.current && inText !== lastInText) {
+          inReadoutRef.current.textContent = inText
+          lastInText = inText
+        }
+        const outText = isLive ? formatLadderDb(outPeakLin) : '—'
+        if (outReadoutRef.current && outText !== lastOutText) {
+          outReadoutRef.current.textContent = outText
+          lastOutText = outText
+        }
+      }
+
+      raf = requestAnimationFrame(step)
+    }
+
+    raf = requestAnimationFrame(step)
+    const onVis = () => {
+      if (document.visibilityState === 'visible') syncColors()
+    }
+    document.addEventListener('visibilitychange', onVis)
+    return () => {
+      cancelAnimationFrame(raf)
+      document.removeEventListener('visibilitychange', onVis)
+    }
+  }, [metersRef])
+
+  // Resync needle rest + cool LED color when the model skin changes.
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+    // Force a color pull on next paint by toggling a data attr the loop reads
+    // via getComputedStyle when visibility fires; also poke canvases size.
+    for (const canvas of [inCanvasRef.current, outCanvasRef.current]) {
+      if (canvas) {
+        canvas.width = 0
+        canvas.height = 0
+      }
+    }
+  }, [live, mode])
+
+  return (
+    <div
+      ref={rootRef}
+      className={`meter-bay${!live ? ' is-dark' : ''}`}
+      aria-label="Level meters"
+    >
+      <div className="io-strip">
+        <span className="io-label">In</span>
+        <span ref={inClipRef} className="clip-led" aria-hidden="true" />
+        <canvas ref={inCanvasRef} className="io-ladder" aria-hidden="true" />
+        <output ref={inReadoutRef}>—</output>
+      </div>
+
+      <div className="meter-well">
+        <div className="meter">
+          <VuFace
+            mode={mode}
+            faceId={faceId}
+            needleRef={needleRef}
+            parkedRef={parkedRef}
+          />
+          <button
+            ref={clipBtnRef}
+            type="button"
+            className="clip-flag"
+            hidden
+            onClick={onClearOutClip}
+          >
+            CLIP
+          </button>
+        </div>
+        <div className="gr-readout" aria-live="polite">
+          <span>GR</span>
+          <output ref={grReadoutRef}>—</output>
+          <small>dB</small>
+        </div>
+      </div>
+
+      <div className="io-strip">
+        <span className="io-label">Out</span>
+        <span ref={outClipRef} className="clip-led" aria-hidden="true" />
+        <canvas ref={outCanvasRef} className="io-ladder" aria-hidden="true" />
+        <output ref={outReadoutRef}>—</output>
+      </div>
+    </div>
+  )
+}

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/PresetControl.tsx
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/PresetControl.tsx
@@ -1,0 +1,54 @@
+type PresetControlProps = {
+  preset: number | null
+  names: string[]
+  onChange: (index: number) => void
+  onPrevious: () => void
+  onNext: () => void
+}
+
+export function PresetControl({
+  preset,
+  names,
+  onChange,
+  onPrevious,
+  onNext,
+}: PresetControlProps) {
+  return (
+    <div className="preset">
+      <button
+        type="button"
+        className="step"
+        aria-label="Previous preset"
+        onClick={onPrevious}
+      >
+        ‹
+      </button>
+      <label className="select">
+        <span>{preset === null ? 'Custom' : names[preset]}</span>
+        <select
+          aria-label="Preset"
+          value={preset ?? 'custom'}
+          onChange={(event) => {
+            const value = event.currentTarget.value
+            if (value !== 'custom') onChange(Number(value))
+          }}
+        >
+          {preset === null ? <option value="custom">Custom</option> : null}
+          {names.map((name, index) => (
+            <option key={name} value={index}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="button"
+        className="step"
+        aria-label="Next preset"
+        onClick={onNext}
+      >
+        ›
+      </button>
+    </div>
+  )
+}

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/bridge.ts
@@ -161,7 +161,22 @@ function parseParams(state: unknown): ZcompParams | null {
     const value = params[key]
     if (typeof value !== 'number' || !Number.isFinite(value)) return null
   }
-  return params as unknown as ZcompParams
+  // Clamp like `ipc::sanitize_params` so a hand-edited blob cannot drive
+  // knobs outside the ranges the DSP accepts.
+  const raw = params as unknown as ZcompParams
+  return {
+    ...raw,
+    thresholdDb: Math.min(0, Math.max(-60, raw.thresholdDb)),
+    ratio: Math.min(20, Math.max(1, raw.ratio)),
+    attackMs: Math.min(120, Math.max(0.01, raw.attackMs)),
+    releaseMs: Math.min(2500, Math.max(10, raw.releaseMs)),
+    kneeDb: Math.min(24, Math.max(0, raw.kneeDb)),
+    makeupDb: Math.min(24, Math.max(-24, raw.makeupDb)),
+    mix: Math.min(100, Math.max(0, raw.mix)),
+    sidechainHpfHz: Math.min(500, Math.max(20, raw.sidechainHpfHz)),
+    stereoLink: Math.min(100, Math.max(0, raw.stereoLink)),
+    color: Math.min(100, Math.max(0, raw.color)),
+  }
 }
 
 export function connectBridge(

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/main.tsx
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/main.tsx
@@ -1,10 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
-import '@fontsource/ibm-plex-sans/400.css'
-import '@fontsource/ibm-plex-sans/500.css'
-import '@fontsource/ibm-plex-sans/600.css'
-import '@fontsource/ibm-plex-sans/700.css'
 import './styles.css'
 
 createRoot(document.getElementById('root')!).render(

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/meter.ts
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/meter.ts
@@ -1,0 +1,162 @@
+/**
+ * VU scale, LED ladder mapping, and ballistics.
+ *
+ * Levels come from host `futureboard.meters` — this module only maps readings
+ * onto the face and moves needles/LEDs with hardware-correct time constants.
+ * Nothing here invents a level.
+ */
+
+export type MeterMode = 'reduction' | 'output'
+
+/**
+ * VU ballistics: a step reaches 99 % in 300 ms → 4.6 τ, so τ = 300/4.6 ms.
+ * Real elapsed `dt` keeps the feel correct at 60 Hz or when throttled.
+ */
+export const VU_TAU_SECONDS = 0.3 / 4.6
+
+/** LED peak rise is near-instant; fall is slower so the ladder reads. */
+export const LED_ATTACK_TAU = 0.008
+export const LED_RELEASE_TAU = 0.09
+
+/** Peak-hold dwell then linear fall (hardware LED meters). */
+export const PEAK_HOLD_SECONDS = 1.15
+export const PEAK_HOLD_FALL_DB_PER_SEC = 14
+
+/** Needle sweep either side of vertical. */
+export const HALF_SWEEP_DEG = 40
+
+/** Far-left of the GAIN REDUCTION scale. */
+export const REDUCTION_FULL_SCALE_DB = 24
+
+/** OUTPUT scale ends, dB relative to 0 VU. */
+export const OUTPUT_MIN_DB = -20
+export const OUTPUT_MAX_DB = 3
+
+/** LED ladder floor / ceiling (dBFS). */
+export const LADDER_FLOOR_DB = -60
+export const LADDER_CEIL_DB = 0
+export const LADDER_SEGMENTS = 24
+
+/** Quiet-end expansion on the GR face (matches FA enamel spacing). */
+const REDUCTION_CURVE = 0.6
+
+export function clamp(value: number, min: number, max: number) {
+  return value < min ? min : value > max ? max : value
+}
+
+export function linearToDb(linear: number) {
+  return 20 * Math.log10(Math.max(linear, 1e-6))
+}
+
+/**
+ * One-pole step. Optional separate attack/release τ for LED peak edges.
+ */
+export function advance(
+  current: number,
+  target: number,
+  dt: number,
+  tau = VU_TAU_SECONDS,
+  releaseTau = tau,
+): number {
+  if (!Number.isFinite(target) || dt <= 0) return current
+  const useTau = target > current ? tau : releaseTau
+  const alpha = 1 - Math.exp(-dt / Math.max(useTau, 1e-4))
+  return current + (target - current) * alpha
+}
+
+/** 0 left … 1 right. Reduction rests right and swings left as GR grows. */
+export function normFor(mode: MeterMode, value: number) {
+  if (mode === 'reduction') {
+    const t = clamp(value / REDUCTION_FULL_SCALE_DB, 0, 1)
+    return clamp(1 - Math.pow(t, REDUCTION_CURVE), 0, 1)
+  }
+  return clamp(
+    (value - OUTPUT_MIN_DB) / (OUTPUT_MAX_DB - OUTPUT_MIN_DB),
+    0,
+    1,
+  )
+}
+
+/** Degrees from vertical; positive = right. */
+export function angleFor(norm: number) {
+  return (clamp(norm, 0, 1) * 2 - 1) * HALF_SWEEP_DEG
+}
+
+/** Linear amplitude → ladder fill 0…1 (bottom quiet → top hot). */
+export function ladderNormFromLinear(linear: number) {
+  const db = linearToDb(linear)
+  return clamp((db - LADDER_FLOOR_DB) / (LADDER_CEIL_DB - LADDER_FLOOR_DB), 0, 1)
+}
+
+export function formatLadderDb(linear: number) {
+  if (linear < 1e-6) return '−∞'
+  const db = linearToDb(linear)
+  if (db <= LADDER_FLOOR_DB + 0.5) return '−∞'
+  return db.toFixed(0)
+}
+
+export type Tick = {
+  label: string
+  norm: number
+  major: boolean
+  hot: boolean
+}
+
+const REDUCTION_TICKS = [0, 1.5, 3, 4.5, 6, 9, 12, 18, 24]
+const OUTPUT_TICKS = [-20, -10, -7, -5, -3, -1, 0, 1, 3]
+const REDUCTION_LABELLED = new Set([0, 3, 6, 12, 24])
+const OUTPUT_LABELLED = new Set([-20, -10, -7, -3, 0, 3])
+
+export function ticksFor(mode: MeterMode): Tick[] {
+  if (mode === 'reduction') {
+    return REDUCTION_TICKS.map((db) => ({
+      label: REDUCTION_LABELLED.has(db) ? String(db) : '',
+      norm: normFor('reduction', db),
+      major: REDUCTION_LABELLED.has(db),
+      // Deep GR is a setting, not a fault — red reserved for output over 0 VU.
+      hot: false,
+    }))
+  }
+  return OUTPUT_TICKS.map((db) => ({
+    label: OUTPUT_LABELLED.has(db)
+      ? db > 0
+        ? `+${db}`
+        : String(db)
+      : '',
+    norm: normFor('output', db),
+    major: OUTPUT_LABELLED.has(db),
+    hot: db >= 0,
+  }))
+}
+
+/** Mutable peak-hold cell — updated in the meter RAF, never allocated per frame. */
+export type PeakHold = {
+  db: number
+  age: number
+}
+
+export function createPeakHold(): PeakHold {
+  return { db: LADDER_FLOOR_DB, age: PEAK_HOLD_SECONDS }
+}
+
+export function pushPeakHold(hold: PeakHold, peakDb: number, dt: number) {
+  if (peakDb >= hold.db - 0.05) {
+    hold.db = peakDb
+    hold.age = 0
+    return
+  }
+  hold.age += dt
+  if (hold.age < PEAK_HOLD_SECONDS) return
+  hold.db = Math.max(
+    LADDER_FLOOR_DB,
+    hold.db - PEAK_HOLD_FALL_DB_PER_SEC * dt,
+  )
+}
+
+export function holdNorm(hold: PeakHold) {
+  return clamp(
+    (hold.db - LADDER_FLOOR_DB) / (LADDER_CEIL_DB - LADDER_FLOOR_DB),
+    0,
+    1,
+  )
+}

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/params.ts
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/params.ts
@@ -1,0 +1,161 @@
+/**
+ * Editor-side mirror of `zcomp::ipc` / `descriptor()` ranges and defaults.
+ * Rust remains authoritative — this only keeps knobs and sanitization honest.
+ */
+
+import { defaults, type CompModel, type ZcompParams } from './bridge'
+
+export type ParamSpec = {
+  id: keyof ZcompParams
+  label: string
+  min: number
+  max: number
+  step: number
+  unit: string
+  defaultValue: number
+}
+
+export const PARAM_SPECS = {
+  thresholdDb: {
+    id: 'thresholdDb',
+    label: 'Thresh',
+    min: -60,
+    max: 0,
+    step: 0.1,
+    unit: 'dB',
+    defaultValue: defaults.thresholdDb,
+  },
+  ratio: {
+    id: 'ratio',
+    label: 'Ratio',
+    min: 1,
+    max: 20,
+    step: 0.1,
+    unit: ':1',
+    defaultValue: defaults.ratio,
+  },
+  attackMs: {
+    id: 'attackMs',
+    label: 'Attack',
+    min: 0.01,
+    max: 120,
+    step: 0.01,
+    unit: 'ms',
+    defaultValue: defaults.attackMs,
+  },
+  releaseMs: {
+    id: 'releaseMs',
+    label: 'Release',
+    min: 10,
+    max: 2500,
+    step: 1,
+    unit: 'ms',
+    defaultValue: defaults.releaseMs,
+  },
+  kneeDb: {
+    id: 'kneeDb',
+    label: 'Knee',
+    min: 0,
+    max: 24,
+    step: 0.1,
+    unit: 'dB',
+    defaultValue: defaults.kneeDb,
+  },
+  makeupDb: {
+    id: 'makeupDb',
+    label: 'Makeup',
+    min: -24,
+    max: 24,
+    step: 0.1,
+    unit: 'dB',
+    defaultValue: defaults.makeupDb,
+  },
+  mix: {
+    id: 'mix',
+    label: 'Mix',
+    min: 0,
+    max: 100,
+    step: 1,
+    unit: '%',
+    defaultValue: defaults.mix,
+  },
+  sidechainHpfHz: {
+    id: 'sidechainHpfHz',
+    label: 'SC HPF',
+    min: 20,
+    max: 500,
+    step: 1,
+    unit: 'Hz',
+    defaultValue: defaults.sidechainHpfHz,
+  },
+  stereoLink: {
+    id: 'stereoLink',
+    label: 'Link',
+    min: 0,
+    max: 100,
+    step: 1,
+    unit: '%',
+    defaultValue: defaults.stereoLink,
+  },
+  color: {
+    id: 'color',
+    label: 'Color',
+    min: 0,
+    max: 100,
+    step: 1,
+    unit: '%',
+    defaultValue: defaults.color,
+  },
+} as const satisfies Record<string, ParamSpec>
+
+/** Matches `CompModel` / `model_coeffs` character in Rust — engraved, not marketing. */
+export const MODEL_CIRCUIT: Record<
+  CompModel,
+  { title: string; topology: string }
+> = {
+  comp2500: {
+    title: '2500',
+    topology: 'VCA feed-forward · soft dual knee · THD colour',
+  },
+  distressor: {
+    title: 'Distress',
+    topology: 'Aggressive detector · British grit · hard ratios',
+  },
+  avalon: {
+    title: 'Avalon',
+    topology: 'Class-A optical feedback · slow musical recovery',
+  },
+  ssl: {
+    title: 'SSL',
+    topology: 'Bus glue · soft knee · program auto-release',
+  },
+}
+
+export function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value))
+}
+
+/** Same clamps as `ipc::sanitize_params`. */
+export function sanitizeParams(params: ZcompParams): ZcompParams {
+  return {
+    ...params,
+    thresholdDb: clamp(params.thresholdDb, -60, 0),
+    ratio: clamp(params.ratio, 1, 20),
+    attackMs: clamp(params.attackMs, 0.01, 120),
+    releaseMs: clamp(params.releaseMs, 10, 2500),
+    kneeDb: clamp(params.kneeDb, 0, 24),
+    makeupDb: clamp(params.makeupDb, -24, 24),
+    mix: clamp(params.mix, 0, 100),
+    sidechainHpfHz: clamp(params.sidechainHpfHz, 20, 500),
+    stereoLink: clamp(params.stereoLink, 0, 100),
+    color: clamp(params.color, 0, 100),
+  }
+}
+
+/**
+ * SSL auto-release owns recovery timing in `model_coeffs` — the release knob
+ * is ignored while that path is active. Mirror that in the faceplate.
+ */
+export function releaseIsProgrammed(params: ZcompParams) {
+  return params.model === 'ssl' && params.autoRelease
+}

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/presets.ts
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/presets.ts
@@ -1,0 +1,176 @@
+/**
+ * Factory presets for Z-Comp.
+ *
+ * Editor-side starting points that push real values through the bridge. Rust
+ * still clamps and owns DSP state.
+ */
+
+import {
+  MODEL_WIRE,
+  defaults,
+  postParam,
+  type CompModel,
+  type ZcompParams,
+} from './bridge'
+
+export type FactoryPreset = {
+  name: string
+  params: ZcompParams
+}
+
+function preset(name: string, patch: Partial<ZcompParams>): FactoryPreset {
+  return {
+    name,
+    params: { ...defaults, ...patch, power: true },
+  }
+}
+
+export const FACTORY_PRESETS: FactoryPreset[] = [
+  preset('Default', {}),
+  preset('Vocal Catch', {
+    model: 'avalon',
+    thresholdDb: -22,
+    ratio: 3,
+    attackMs: 12,
+    releaseMs: 180,
+    kneeDb: 8,
+    makeupDb: 2,
+    mix: 100,
+    sidechainHpfHz: 120,
+    stereoLink: 100,
+    color: 22,
+    autoRelease: true,
+  }),
+  preset('Drum Punch', {
+    model: 'distressor',
+    thresholdDb: -16,
+    ratio: 6,
+    attackMs: 0.8,
+    releaseMs: 80,
+    kneeDb: 2,
+    makeupDb: 3,
+    mix: 100,
+    sidechainHpfHz: 80,
+    stereoLink: 100,
+    color: 45,
+    autoRelease: false,
+  }),
+  preset('Bass Glue', {
+    model: 'comp2500',
+    thresholdDb: -20,
+    ratio: 4,
+    attackMs: 25,
+    releaseMs: 280,
+    kneeDb: 6,
+    makeupDb: 1.5,
+    mix: 100,
+    sidechainHpfHz: 40,
+    stereoLink: 100,
+    color: 28,
+    autoRelease: true,
+  }),
+  preset('Bus Soft', {
+    model: 'ssl',
+    thresholdDb: -14,
+    ratio: 2.5,
+    attackMs: 18,
+    releaseMs: 420,
+    kneeDb: 10,
+    makeupDb: 0.5,
+    mix: 100,
+    sidechainHpfHz: 90,
+    stereoLink: 100,
+    color: 12,
+    autoRelease: true,
+  }),
+  preset('Mix Bus Glue', {
+    model: 'ssl',
+    thresholdDb: -12,
+    ratio: 2,
+    attackMs: 30,
+    releaseMs: 600,
+    kneeDb: 12,
+    makeupDb: 0,
+    mix: 100,
+    sidechainHpfHz: 100,
+    stereoLink: 100,
+    color: 8,
+    autoRelease: true,
+  }),
+  preset('Parallel Smash', {
+    model: 'distressor',
+    thresholdDb: -28,
+    ratio: 12,
+    attackMs: 0.2,
+    releaseMs: 60,
+    kneeDb: 0,
+    makeupDb: 6,
+    mix: 38,
+    sidechainHpfHz: 150,
+    stereoLink: 100,
+    color: 70,
+    autoRelease: false,
+  }),
+  preset('Optical Level', {
+    model: 'avalon',
+    thresholdDb: -24,
+    ratio: 4,
+    attackMs: 40,
+    releaseMs: 800,
+    kneeDb: 14,
+    makeupDb: 3,
+    mix: 100,
+    sidechainHpfHz: 60,
+    stereoLink: 100,
+    color: 18,
+    autoRelease: true,
+  }),
+]
+
+const NUMERIC_KEYS: (keyof ZcompParams)[] = [
+  'thresholdDb',
+  'ratio',
+  'attackMs',
+  'releaseMs',
+  'kneeDb',
+  'makeupDb',
+  'mix',
+  'sidechainHpfHz',
+  'stereoLink',
+  'color',
+]
+
+export function cloneParams(params: ZcompParams): ZcompParams {
+  return { ...params }
+}
+
+export function paramsMatch(left: ZcompParams, right: ZcompParams) {
+  if (
+    left.power !== right.power ||
+    left.model !== right.model ||
+    left.autoRelease !== right.autoRelease
+  ) {
+    return false
+  }
+  return NUMERIC_KEYS.every((key) => {
+    const a = left[key] as number
+    const b = right[key] as number
+    return Math.abs(a - b) < 0.05
+  })
+}
+
+export function matchingPresetIndex(params: ZcompParams) {
+  const index = FACTORY_PRESETS.findIndex((entry) =>
+    paramsMatch(params, entry.params),
+  )
+  return index >= 0 ? index : null
+}
+
+export function postAllParams(params: ZcompParams) {
+  postParam('power', params.power ? 1 : 0)
+  postParam('model', MODEL_WIRE[params.model as CompModel])
+  postParam('autoRelease', params.autoRelease ? 1 : 0)
+  for (const key of NUMERIC_KEYS) {
+    postParam(key, params[key] as number)
+  }
+}

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/styles.css
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/styles.css
@@ -1,336 +1,975 @@
+/*
+ * Z-Comp — multi-circuit compressor faceplate in the FA family language.
+ *
+ * Craft comes from materials (painted metal, aluminum knobs, enamel VU), not
+ * glow / glassmorphism. Switching Model retints the panel enamel and meter
+ * face — the colour change stays, but it reads as different hardware skins.
+ */
+
+@property --panel-hi {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #2e343c;
+}
+@property --panel {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #1f242b;
+}
+@property --panel-lo {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #15191e;
+}
+@property --meter-face-hi {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #3a6fad;
+}
+@property --meter-face {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #2a5f9a;
+}
+@property --meter-face-lo {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #1a4574;
+}
+@property --meter-ink {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #f0f4f8;
+}
+@property --meter-hot {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #d4452e;
+}
+@property --btn-on {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #d8b35a;
+}
+@property --btn-on-ink {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #1a160e;
+}
+@property --focus {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #c9a24a;
+}
+
 :root {
-  --bg: #101418;
-  --panel: #171c21;
-  --raised: #1d242b;
-  --line: #2c353e;
-  --text: #d7dee4;
-  --muted: #7d8a95;
-  --signal: #4ec8d8;
-  --signal-dim: #2a7f8c;
-  --warn: #d28a4a;
-  --danger: #d45a5a;
-  --knob: #252c34;
-  --knob-rim: #3a4550;
-  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
-  color: var(--text);
-  background: var(--bg);
-  font-synthesis: none;
+  --panel-hi: #2e343c;
+  --panel: #1f242b;
+  --panel-lo: #15191e;
+  --base: #0e1013;
+  --chassis: #0a0b0d;
+
+  --inset: #101317;
+  --bezel: #4a5563;
+  --bezel-hi: #8a96a6;
+
+  --border: rgba(0, 0, 0, 0.55);
+  --border-hi: rgba(255, 255, 255, 0.1);
+  --border-soft: rgba(255, 255, 255, 0.06);
+
+  --engrave: #e6e9ee;
+  --engrave-muted: rgba(220, 226, 234, 0.58);
+  --readout: #c5ced8;
+
+  --focus: #c9a24a;
+  --lamp: #e8a83a;
+  --lamp-soft: rgba(232, 168, 58, 0.4);
+  --clip: #c43a28;
+
+  --meter-face-hi: #3a6fad;
+  --meter-face: #2a5f9a;
+  --meter-face-lo: #1a4574;
+  --meter-ink: #f0f4f8;
+  --meter-hot: #d4452e;
+
+  --btn: #1a1e24;
+  --btn-hi: #323942;
+  --btn-on: #d8b35a;
+  --btn-on-ink: #1a160e;
+  --drive: 0;
+
+  --knob-lg: clamp(5.25rem, 10vw, 6.75rem);
+  --knob-sm: clamp(3rem, 5.5vw, 3.75rem);
+
+  --radius: 0.55rem;
+  --radius-sm: 0.4rem;
+  --radius-panel: 0.85rem;
+  --radius-well: 0.7rem;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+
+  --skin-ease: 320ms cubic-bezier(0.22, 0.8, 0.28, 1);
+
   color-scheme: dark;
 }
 
-* { box-sizing: border-box; }
-html, body, #root {
+/* Model skins — enamel + VU face, not neon accents. */
+.unit[data-model='ssl'] {
+  --panel-hi: #2e343c;
+  --panel: #1f242b;
+  --panel-lo: #15191e;
+  --meter-face-hi: #3a6fad;
+  --meter-face: #2a5f9a;
+  --meter-face-lo: #1a4574;
+  --btn-on: #7eb8d4;
+  --btn-on-ink: #0e1820;
+  --focus: #7eb8d4;
+}
+
+.unit[data-model='comp2500'] {
+  --panel-hi: #2a3338;
+  --panel: #1c2428;
+  --panel-lo: #13191c;
+  --meter-face-hi: #4aa8b4;
+  --meter-face: #2f8794;
+  --meter-face-lo: #1c5e68;
+  --btn-on: #5ec4d4;
+  --btn-on-ink: #0c1a1c;
+  --focus: #5ec4d4;
+}
+
+.unit[data-model='distressor'] {
+  --panel-hi: #3a322c;
+  --panel: #28221e;
+  --panel-lo: #1a1613;
+  --meter-face-hi: #e0b56a;
+  --meter-face: #c9923e;
+  --meter-face-lo: #8a6024;
+  --meter-ink: #1c140a;
+  --meter-hot: #8a2418;
+  --btn-on: #d4a05e;
+  --btn-on-ink: #1a1208;
+  --focus: #d4a05e;
+}
+
+.unit[data-model='avalon'] {
+  --panel-hi: #2e3832;
+  --panel: #1f2823;
+  --panel-lo: #141a16;
+  --meter-face-hi: #8fbf96;
+  --meter-face: #6a9a72;
+  --meter-face-lo: #43664a;
+  --meter-ink: #101610;
+  --meter-hot: #8a3218;
+  --btn-on: #7eb68a;
+  --btn-on-ink: #0e1610;
+  --focus: #7eb68a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
   width: 100%;
-  min-width: 860px;
-  min-height: 100%;
+  min-width: 760px;
+  height: 100%;
+  min-height: 460px;
   margin: 0;
-}
-button, input { font: inherit; }
-button { color: inherit; cursor: pointer; }
-
-.shell {
-  min-height: 100vh;
-  display: grid;
-  grid-template-rows: auto 1fr auto auto;
-  background:
-    radial-gradient(1200px 420px at 50% -10%, rgba(78, 200, 216, 0.08), transparent 60%),
-    linear-gradient(180deg, #14191e 0%, var(--bg) 42%, #0c1014 100%);
-  transition: filter 180ms ease, opacity 180ms ease;
+  overflow: hidden;
 }
 
-.shell.powered-off .workspace,
-.shell.powered-off .secondary {
-  filter: saturate(0.2);
-  opacity: 0.48;
+body {
+  background: var(--chassis);
+  color: var(--engrave);
+  font-family: 'Helvetica Neue', Helvetica, Arial, 'Segoe UI', sans-serif;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-synthesis: none;
+  line-height: 1.2;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  user-select: none;
+  cursor: default;
 }
 
-.topbar {
-  display: grid;
-  grid-template-columns: 180px 1fr auto;
-  align-items: center;
-  gap: 16px;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--line);
-  background: rgba(18, 23, 28, 0.92);
+button,
+input {
+  margin: 0;
+  font: inherit;
+  color: inherit;
 }
 
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+button {
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
 }
-.brand > span {
-  width: 32px;
-  height: 32px;
+
+button:focus-visible,
+[role='slider']:focus-visible,
+[role='switch']:focus-visible,
+[role='radio']:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.unit {
   display: grid;
   place-items: center;
-  border: 1px solid var(--signal);
-  color: var(--signal);
-  font: 700 15px/1 "IBM Plex Sans", sans-serif;
-  letter-spacing: 0.02em;
-}
-.brand div { display: flex; flex-direction: column; gap: 1px; }
-.brand strong { font-size: 14px; font-weight: 650; letter-spacing: 0.02em; }
-.brand small,
-footer,
-.knob-label,
-.level-bar > span,
-.model-blurb {
-  color: var(--muted);
-  font: 600 10px/1.4 "IBM Plex Sans", sans-serif;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.model-strip {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 6px;
-  max-width: 520px;
-  justify-self: center;
   width: 100%;
-}
-.model-strip button {
-  height: 34px;
-  border: 1px solid var(--line);
-  background: var(--raised);
-  color: var(--muted);
-  font: 600 11px/1 "IBM Plex Sans", sans-serif;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  transition: border-color 140ms ease, color 140ms ease, background 140ms ease;
-}
-.model-strip button.active {
-  border-color: var(--signal);
-  color: var(--text);
-  background: #1a2a30;
-  box-shadow: inset 0 -2px 0 var(--signal);
+  height: 100%;
+  padding: var(--space-3);
+  background: var(--chassis);
+  transition:
+    --panel-hi var(--skin-ease),
+    --panel var(--skin-ease),
+    --panel-lo var(--skin-ease),
+    --meter-face-hi var(--skin-ease),
+    --meter-face var(--skin-ease),
+    --meter-face-lo var(--skin-ease),
+    --meter-ink var(--skin-ease),
+    --meter-hot var(--skin-ease),
+    --btn-on var(--skin-ease),
+    --btn-on-ink var(--skin-ease),
+    --focus var(--skin-ease);
 }
 
-.top-actions {
+.unit.is-skin-pulse .panel {
+  animation: skin-bloom 420ms cubic-bezier(0.2, 0.85, 0.25, 1);
+}
+
+.unit.is-skin-pulse .meter-well {
+  animation: well-glow 420ms cubic-bezier(0.2, 0.85, 0.25, 1);
+}
+
+@keyframes skin-bloom {
+  0% {
+    filter: brightness(1);
+  }
+  35% {
+    filter: brightness(1.08);
+  }
+  100% {
+    filter: brightness(1);
+  }
+}
+
+@keyframes well-glow {
+  0% {
+    box-shadow:
+      inset 0 2px 5px rgba(0, 0, 0, 0.7),
+      0 1px 0 var(--border-hi);
+  }
+  40% {
+    box-shadow:
+      inset 0 2px 5px rgba(0, 0, 0, 0.7),
+      0 0 0 1px color-mix(in srgb, var(--btn-on) 35%, transparent),
+      0 0 18px color-mix(in srgb, var(--btn-on) 22%, transparent);
+  }
+  100% {
+    box-shadow:
+      inset 0 2px 5px rgba(0, 0, 0, 0.7),
+      0 1px 0 var(--border-hi);
+  }
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  width: min(100%, 58rem);
+  padding: clamp(0.85rem, 2vw, 1.25rem);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-panel);
+  background: linear-gradient(
+    180deg,
+    var(--panel-hi) 0%,
+    var(--panel) 42%,
+    var(--panel-lo) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 var(--border-hi),
+    0 14px 32px rgba(0, 0, 0, 0.5);
+  transition:
+    background var(--skin-ease),
+    filter 160ms ease,
+    opacity 160ms ease,
+    box-shadow var(--skin-ease);
+}
+
+.panel.is-off .knobs,
+.panel.is-off .extras,
+.panel.is-off .models .bank,
+.panel.is-off .meter-well {
+  filter: grayscale(0.45) brightness(0.78);
+  opacity: 0.62;
+}
+
+.top {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 11rem) minmax(0, 1fr) auto;
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.identity {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.wordmark {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.65rem;
 }
-.toggle,
-.power {
-  height: 32px;
-  min-width: 72px;
-  padding: 0 12px;
-  border: 1px solid var(--line);
-  background: var(--panel);
-  font: 600 11px/1 "IBM Plex Sans", sans-serif;
-  letter-spacing: 0.04em;
+
+.wordmark .z {
+  display: grid;
+  place-items: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  border: 1px solid var(--border-hi);
+  border-radius: var(--radius-sm);
+  background: var(--inset);
+  color: var(--btn-on);
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  transition: color var(--skin-ease), border-color var(--skin-ease);
+}
+
+.wordmark strong {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
-.toggle.on {
-  border-color: var(--signal-dim);
-  color: var(--signal);
+
+.wordmark em {
+  display: block;
+  margin-top: 0.15rem;
+  color: var(--engrave-muted);
+  font-size: 0.58rem;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
-.power.on {
-  border-color: var(--signal);
-  color: var(--signal);
+
+.meter-bay {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.55rem;
+  align-items: stretch;
+  justify-self: center;
+  width: min(100%, 28rem);
 }
-.link-dot {
-  width: 8px;
-  height: 8px;
+
+.meter-well {
+  display: grid;
+  gap: 0.35rem;
+  justify-self: stretch;
+  width: 100%;
+  padding: 0.45rem;
+  border-radius: var(--radius-well);
+  background:
+    radial-gradient(
+      120% 80% at 50% 0%,
+      color-mix(in srgb, var(--btn-on) calc(var(--drive) * 18%), transparent),
+      transparent 62%
+    ),
+    #0c0e11;
+  box-shadow:
+    inset 0 2px 5px rgba(0, 0, 0, 0.7),
+    0 1px 0 var(--border-hi);
+  transition: box-shadow var(--skin-ease), background var(--skin-ease);
+}
+
+.gr-readout {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  padding: 0 0.15rem 0.1rem;
+}
+
+.gr-readout span,
+.gr-readout small {
+  color: var(--engrave-muted);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.gr-readout output {
+  margin-left: auto;
+  color: var(--btn-on);
+  font-size: 1.05rem;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  transition: color var(--skin-ease);
+}
+
+.io-strip {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  justify-items: center;
+  gap: 0.28rem;
+  min-width: 1.85rem;
+  padding: 0.15rem 0;
+}
+
+.io-label {
+  color: var(--engrave-muted);
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.clip-led {
+  width: 0.38rem;
+  height: 0.38rem;
+  border-radius: 50%;
+  background: #2a3038;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.55);
+}
+
+.clip-led.is-on {
+  background: var(--clip);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--clip) 40%, transparent),
+    0 0 8px color-mix(in srgb, var(--clip) 55%, transparent);
+}
+
+.io-ladder {
+  display: block;
+  width: 0.78rem;
+  height: 100%;
+  min-height: 6.8rem;
+  border-radius: 2px;
+  background: #07090c;
+  box-shadow:
+    inset 0 1px 3px rgba(0, 0, 0, 0.75),
+    0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.io-strip output {
+  color: var(--engrave-muted);
+  font-size: 0.58rem;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+}
+
+.io-strip:has(.clip-led.is-on) output {
+  color: var(--clip);
+}
+
+.circuit {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: center;
+  gap: 0.45rem 0.7rem;
+  margin: -0.15rem 0 0;
+  color: var(--engrave-muted);
+  font-size: 0.62rem;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-align: center;
+}
+
+.circuit strong {
+  color: var(--engrave);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.circuit span {
+  color: var(--engrave-muted);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+
+.link {
+  width: 0.45rem;
+  height: 0.45rem;
+  margin: 0.15rem auto 0;
   border-radius: 50%;
   background: #3a4550;
 }
-.link-dot.live {
-  background: var(--signal);
-  box-shadow: 0 0 0 3px rgba(78, 200, 216, 0.18);
+
+.link.is-live {
+  background: var(--btn-on);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--btn-on) 28%, transparent);
+  transition: background var(--skin-ease), box-shadow var(--skin-ease);
 }
 
-.workspace {
-  display: grid;
-  grid-template-columns: 72px 1fr;
-  gap: 18px;
-  padding: 18px 18px 8px;
+.knob.is-disabled {
+  opacity: 0.48;
+}
+
+.knob.is-disabled .cap {
+  cursor: default;
+  filter: none;
+}
+
+.knob.is-disabled .readout {
+  color: var(--btn-on);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
   align-items: stretch;
 }
 
-.meters {
+.meter-switch {
   display: grid;
-  grid-template-rows: 1fr 1fr;
-  gap: 10px;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.2rem;
+  padding: 0.18rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--inset);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.45);
 }
 
-.level-bar {
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  justify-items: center;
-  gap: 6px;
-  padding: 8px 6px;
-  border: 1px solid var(--line);
-  background: var(--panel);
-}
-.level-bar.clip output { color: var(--danger); }
-.level-track {
-  position: relative;
-  width: 18px;
-  height: 100%;
-  min-height: 120px;
-  border: 1px solid #243038;
-  background: #0b0f13;
-  overflow: hidden;
-}
-.level-track i {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: block;
-}
-.level-track .rms {
-  background: linear-gradient(180deg, #3aa3b4, #1d6672);
-  opacity: 0.85;
-}
-.level-track .peak {
-  background: linear-gradient(180deg, var(--signal), #2f7f8c 70%, transparent);
-  mix-blend-mode: screen;
-}
-.level-bar output {
-  font: 600 10px/1 "IBM Plex Sans", monospace;
-  font-variant-numeric: tabular-nums;
+.meter-switch button,
+.auto,
+.models .bank button {
+  height: 1.7rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: var(--btn);
+  color: var(--engrave-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  transition:
+    background var(--skin-ease),
+    color var(--skin-ease),
+    border-color var(--skin-ease),
+    box-shadow 140ms ease;
 }
 
-.center {
-  display: grid;
-  grid-template-rows: auto auto 1fr;
-  gap: 14px;
-  align-content: start;
+.meter-switch button.is-on,
+.auto.is-on,
+.models .bank button.is-on {
+  border-color: rgba(0, 0, 0, 0.35);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--btn-on) 88%, #fff), var(--btn-on));
+  color: var(--btn-on-ink);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.35),
+    0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
-.gr-meter {
-  border: 1px solid var(--line);
-  background: var(--panel);
-  padding: 12px 14px 16px;
-}
-.gr-meter header {
+.power {
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  margin-bottom: 10px;
-}
-.gr-meter strong {
-  font-size: 12px;
-  letter-spacing: 0.08em;
-}
-.gr-meter output {
-  font: 600 18px/1 "IBM Plex Sans", monospace;
-  font-variant-numeric: tabular-nums;
-  color: var(--signal);
-}
-.gr-face {
-  position: relative;
-  height: 28px;
-  border: 1px solid #243038;
-  background:
-    repeating-linear-gradient(
-      90deg,
-      transparent 0,
-      transparent calc(12.5% - 1px),
-      #243038 calc(12.5% - 1px),
-      #243038 12.5%
-    ),
-    #0b0f13;
-  overflow: hidden;
-}
-.gr-fill {
-  position: absolute;
-  inset: 0 auto 0 0;
-  background: linear-gradient(90deg, #2a8a98, var(--signal));
-  transition: width 80ms linear;
-}
-.gr-ticks {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-}
-.gr-ticks span {
-  position: absolute;
-  top: 100%;
-  transform: translate(-50%, 4px);
-  font: 600 8px/1 "IBM Plex Sans", monospace;
-  color: var(--muted);
+  align-items: center;
+  gap: 0.45rem;
+  height: 2rem;
+  padding: 0 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, var(--btn-hi), var(--btn));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
-.model-blurb {
-  margin: 0;
-  text-align: center;
-  letter-spacing: 0.08em;
+.power .lamp {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #2a2e34;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.6);
 }
 
-.knob-row,
-.secondary {
+.power.is-on .lamp {
+  background: var(--lamp);
+  box-shadow:
+    0 0 0 2px var(--lamp-soft),
+    0 0 8px var(--lamp-soft);
+}
+
+.power .legend {
+  color: var(--engrave-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.power.is-on .legend {
+  color: var(--engrave);
+}
+
+.models {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.bank-label {
+  color: var(--engrave-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.bank {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.28rem;
+}
+
+.auto {
+  min-width: 5.2rem;
+  padding: 0 0.55rem;
+}
+
+.knobs,
+.extras {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 10px 18px;
-}
-.secondary {
-  padding: 8px 18px 14px;
-  border-top: 1px solid var(--line);
-  background: rgba(14, 18, 22, 0.7);
+  gap: clamp(0.55rem, 1.8vw, 1.35rem);
 }
 
-.knob-control {
-  width: 88px;
-  display: grid;
-  justify-items: center;
-  gap: 6px;
+.extras {
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--border-soft);
 }
+
+/* Aluminum knob — FA-76 language */
 .knob {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.cap {
+  width: var(--knob-lg);
+  height: var(--knob-lg);
+  cursor: ns-resize;
+  touch-action: none;
+  outline: none;
+  filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.55));
+}
+
+.knob.sm .cap {
+  width: var(--knob-sm);
+  height: var(--knob-sm);
+}
+
+.cap.is-dragging {
+  filter: drop-shadow(0 5px 8px rgba(0, 0, 0, 0.65));
+}
+
+.cap svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.cap .rim {
+  stroke: rgba(0, 0, 0, 0.55);
+  stroke-width: 1;
+}
+
+.cap .body {
+  stroke: rgba(20, 24, 32, 0.7);
+  stroke-width: 1;
+}
+
+.cap .gloss {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.35);
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.cap .pointer {
+  fill: #11151c;
+}
+
+.plate {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.plate .name {
+  color: var(--engrave);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.plate .readout {
+  padding: 0.08rem 0.35rem;
+  border-radius: var(--radius-sm);
+  color: var(--readout);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: text;
+}
+
+.plate .readout:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.plate .unit {
+  margin-left: 0.1rem;
+  font-size: 0.58rem;
+  opacity: 0.65;
+}
+
+.plate .input {
+  width: 3.6rem;
+  padding: 0.06rem 0.2rem;
+  border: 1px solid var(--border-hi);
+  border-radius: var(--radius-sm);
+  outline: none;
+  background: #0c1016;
+  color: var(--engrave);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-align: center;
+  user-select: text;
+}
+
+/* VU face — FA cream/blue enamel family */
+.meter-bay.is-dark .meter {
+  filter: brightness(0.82) saturate(0.85);
+}
+
+.meter {
   position: relative;
-  width: 64px;
-  height: 64px;
 }
-.knob-cap {
+
+.meter svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: calc(var(--radius-sm) + 0.1rem);
+  overflow: hidden;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 0 0 1px rgba(0, 0, 0, 0.55);
+}
+
+.meter .arc {
+  fill: none;
+  stroke: var(--meter-ink);
+  stroke-width: 1.4;
+  opacity: 0.55;
+  transition: stroke var(--skin-ease);
+}
+
+.meter .arc.hot {
+  stroke: var(--meter-hot);
+  opacity: 0.9;
+  stroke-width: 2.1;
+}
+
+.meter .tick {
+  stroke: var(--meter-ink);
+  stroke-width: 1.05;
+  stroke-linecap: round;
+  opacity: 0.75;
+  transition: stroke var(--skin-ease);
+}
+
+.meter .tick.major {
+  stroke-width: 1.65;
+  opacity: 0.9;
+}
+
+.meter .tick.hot {
+  stroke: var(--meter-hot);
+}
+
+.meter .label {
+  fill: var(--meter-ink);
+  font-size: 7.5px;
+  font-weight: 700;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  transition: fill var(--skin-ease);
+}
+
+.meter .label.hot {
+  fill: var(--meter-hot);
+}
+
+.meter .needle {
+  stroke: #1a120c;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+}
+
+.meter .hub {
+  fill: #2a241c;
+  stroke: #0c0a08;
+  stroke-width: 0.8;
+}
+
+.meter .caption {
+  fill: var(--meter-ink);
+  font-size: 7px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-anchor: middle;
+  opacity: 0.72;
+  transition: fill var(--skin-ease);
+}
+
+.meter .unit {
+  fill: var(--meter-ink);
+  font-size: 6.4px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-anchor: middle;
+  opacity: 0.45;
+  transition: fill var(--skin-ease);
+}
+
+.meter .bezel {
+  fill: none;
+  stroke: rgba(0, 0, 0, 0.35);
+  stroke-width: 1.35;
+  pointer-events: none;
+}
+
+.meter .parked {
+  fill: var(--meter-ink);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-anchor: middle;
+  text-transform: uppercase;
+  opacity: 0.45;
+}
+
+.clip-flag {
   position: absolute;
-  inset: 0;
-  border-radius: 50%;
-  border: 1px solid var(--knob-rim);
-  background:
-    radial-gradient(circle at 35% 28%, #36414b, var(--knob) 58%),
-    var(--knob);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  right: 0.4rem;
+  bottom: 0.35rem;
+  height: 1.15rem;
+  padding: 0 0.4rem;
+  border: 1px solid rgba(0, 0, 0, 0.35);
+  border-radius: var(--radius-sm);
+  background: var(--clip);
+  color: #fff4ef;
+  font-size: 0.55rem;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  box-shadow: 0 0 10px color-mix(in srgb, var(--clip) 45%, transparent);
 }
-.knob-cap i {
-  position: absolute;
-  left: 50%;
-  top: 10px;
-  width: 2px;
-  height: 16px;
-  margin-left: -1px;
-  background: var(--signal);
-  transform-origin: 50% 22px;
-  transform: rotate(var(--knob-angle));
-  border-radius: 1px;
+
+/* Preset stepper — FA-76 language */
+.preset {
+  display: grid;
+  grid-template-columns: 1.55rem minmax(0, 1fr) 1.55rem;
+  align-items: stretch;
+  width: 100%;
+  max-width: 11rem;
+  height: 1.85rem;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.55);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, #2a3038, #161a20);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 1px 2px rgba(0, 0, 0, 0.35);
 }
-.knob input {
+
+.preset .step {
+  color: var(--engrave-muted);
+  font-size: 0.95rem;
+}
+
+.preset .step:hover {
+  color: var(--engrave);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.preset .select {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  border-inline: 1px solid rgba(0, 0, 0, 0.4);
+}
+
+.preset .select > span {
+  overflow: hidden;
+  width: 100%;
+  padding: 0 0.35rem;
+  color: var(--engrave);
+  font-size: 0.68rem;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preset .select select {
   position: absolute;
   inset: 0;
   width: 100%;
-  height: 100%;
+  border: 0;
   opacity: 0;
-  cursor: ns-resize;
-  margin: 0;
-}
-.knob-control output {
-  font: 600 11px/1 "IBM Plex Sans", monospace;
-  font-variant-numeric: tabular-nums;
-  color: #c5ced5;
+  cursor: pointer;
+  background: #1a1e24;
+  color: var(--engrave);
 }
 
-footer {
-  display: flex;
-  justify-content: space-between;
-  padding: 8px 14px 12px;
-  border-top: 1px solid var(--line);
-}
+@media (max-width: 880px) {
+  .top {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
 
-.shell.model-comp2500 { --signal: #5ec4d4; }
-.shell.model-distressor { --signal: #d4a05e; }
-.shell.model-avalon { --signal: #7eb68a; }
-.shell.model-ssl { --signal: #4ec8d8; }
+  .identity,
+  .side,
+  .meter-bay {
+    width: min(100%, 28rem);
+  }
+
+  .models {
+    grid-template-columns: 1fr;
+    justify-items: stretch;
+  }
+
+  .auto {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- Rebuild the Z-Comp embedded editor as an FA-family hardware faceplate (model skins, aluminum knobs, enamel VU, factory presets).
- Mirror Rust `ipc` ranges/defaults/sanitize and surface SSL Auto Rel program-dependent release in the UI.
- Drive IN/OUT LED ladders + VU from `futureboard.meters` via a RAF/canvas path (`metersRef`) so knobs do not re-render at meter rate; peak-hold and VU ballistics match hardware feel.

## Test plan
- [ ] `bun run --cwd crates/BuiltinAudioPlugins/crates/zcomp/editor typecheck`
- [ ] `bun run --cwd crates/BuiltinAudioPlugins/crates/zcomp/editor build`
- [ ] `cargo test -p zcomp --lib`
- [ ] Open Z-Comp in Studio: knobs/model/auto-rel change DSP; SSL+Auto Rel disables Release (AUTO)
- [ ] Confirm IN/OUT ladders, GR readout, and VU track live audio; CLIP clears locally
- [ ] Switch models and confirm skin/circuit legend update


Made with [Cursor](https://cursor.com)