### PR TITLE
Rebuild the Z-Comp gain cell and faceplate

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/App.tsx
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/App.tsx
@@ -1,228 +1,27 @@
+import { useEffect, useRef, useState, type CSSProperties } from 'react'
 import {
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-  type CSSProperties,
-  type PointerEvent as ReactPointerEvent,
-} from 'react'
-import {
+  MODELS,
   MODEL_LABEL,
   MODEL_WIRE,
-  MODELS,
   connectBridge,
   defaults,
   postParam,
   type MeterFrame,
   type ZcompParams,
 } from './bridge'
+import { CurveDisplay } from './CurveDisplay'
+import {
+  CIRCUIT_INFO,
+  DEVICE_HEIGHT,
+  DEVICE_WIDTH,
+  MAX_SCALE,
+} from './device'
+import { Knob } from './Knob'
 import { MeterBay } from './MeterBay'
 import { clamp, type MeterMode } from './meter'
-import {
-  MODEL_CIRCUIT,
-  PARAM_SPECS,
-  releaseIsProgrammed,
-  sanitizeParams,
-  type ParamSpec,
-} from './params'
+import { PARAM_SPECS, releaseIsProgrammed, sanitizeParams } from './params'
 import { PresetControl } from './PresetControl'
-import {
-  FACTORY_PRESETS,
-  matchingPresetIndex,
-  postAllParams,
-} from './presets'
-
-const TRAVEL_PX = 240
-const START_DEG = -240
-const SWEEP_DEG = 300
-
-type KnobProps = {
-  spec: ParamSpec
-  value: number
-  display: (value: number) => string
-  onChange: (value: number) => void
-  size?: 'lg' | 'sm'
-  disabled?: boolean
-  disabledReadout?: string
-}
-
-function AluminumKnob({
-  spec,
-  value,
-  display,
-  onChange,
-  size = 'lg',
-  disabled = false,
-  disabledReadout,
-}: KnobProps) {
-  const uid = useId().replace(/:/g, '')
-  const gesture = useRef<{ y: number; norm: number } | null>(null)
-  const [dragging, setDragging] = useState(false)
-  const [editing, setEditing] = useState(false)
-  const [draft, setDraft] = useState('')
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  const { min, max, step, label, unit, defaultValue } = spec
-  const norm = (value - min) / Math.max(max - min, 1e-9)
-  const fromNorm = useCallback(
-    (n: number) => {
-      const raw = min + clamp(n, 0, 1) * (max - min)
-      return clamp(Math.round(raw / step) * step, min, max)
-    },
-    [max, min, step],
-  )
-
-  useEffect(() => {
-    if (editing) {
-      inputRef.current?.focus()
-      inputRef.current?.select()
-    }
-  }, [editing])
-
-  const pointerAngle = START_DEG + SWEEP_DEG * clamp(norm, 0, 1)
-
-  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (disabled || editing || event.button !== 0) return
-    gesture.current = { y: event.clientY, norm }
-    event.currentTarget.setPointerCapture(event.pointerId)
-    setDragging(true)
-    event.preventDefault()
-  }
-  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (!gesture.current || disabled) return
-    const travel = event.shiftKey ? TRAVEL_PX * 5 : TRAVEL_PX
-    onChange(
-      fromNorm(gesture.current.norm + (gesture.current.y - event.clientY) / travel),
-    )
-  }
-  const onPointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (!gesture.current) return
-    gesture.current = null
-    event.currentTarget.releasePointerCapture(event.pointerId)
-    setDragging(false)
-  }
-
-  return (
-    <div className={`knob ${size}${disabled ? ' is-disabled' : ''}`}>
-      <div
-        className={`cap${dragging ? ' is-dragging' : ''}`}
-        role="slider"
-        aria-label={label}
-        aria-valuemin={min}
-        aria-valuemax={max}
-        aria-valuenow={value}
-        aria-valuetext={
-          disabled && disabledReadout
-            ? disabledReadout
-            : `${display(value)} ${unit}`
-        }
-        aria-disabled={disabled}
-        tabIndex={disabled ? -1 : 0}
-        title={
-          disabled
-            ? disabledReadout ?? `${label} programmed by Auto Rel`
-            : `${label} — drag vertically, Shift for fine, double-click to reset`
-        }
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerUp}
-        onDoubleClick={() => !disabled && onChange(defaultValue)}
-        onWheel={(event) => {
-          if (disabled) return
-          event.preventDefault()
-          const delta = event.shiftKey ? step / 5 : step
-          onChange(
-            clamp(value + (event.deltaY < 0 ? delta : -delta), min, max),
-          )
-        }}
-        onKeyDown={(event) => {
-          if (disabled) return
-          const delta = event.shiftKey ? step / 5 : step
-          if (event.key === 'ArrowUp' || event.key === 'ArrowRight') {
-            event.preventDefault()
-            onChange(clamp(value + delta, min, max))
-          } else if (event.key === 'ArrowDown' || event.key === 'ArrowLeft') {
-            event.preventDefault()
-            onChange(clamp(value - delta, min, max))
-          } else if (event.key === 'Home') {
-            event.preventDefault()
-            onChange(defaultValue)
-          }
-        }}
-      >
-        <svg viewBox="0 0 100 100" aria-hidden="true">
-          <defs>
-            <radialGradient id={`${uid}-body`} cx="0.32" cy="0.28" r="0.78">
-              <stop offset="0" stopColor="#d8dee8" />
-              <stop offset="0.45" stopColor="#9aa4b4" />
-              <stop offset="1" stopColor="#4a5360" />
-            </radialGradient>
-            <linearGradient id={`${uid}-rim`} x1="0" x2="0" y1="0" y2="1">
-              <stop offset="0" stopColor="#eef2f8" />
-              <stop offset="0.5" stopColor="#8a95a6" />
-              <stop offset="1" stopColor="#3a4250" />
-            </linearGradient>
-          </defs>
-          <circle className="rim" cx="50" cy="50" r="31" fill={`url(#${uid}-rim)`} />
-          <g
-            style={{
-              transform: `rotate(${pointerAngle + 90}deg)`,
-              transformOrigin: '50px 50px',
-            }}
-          >
-            <circle className="body" cx="50" cy="50" r="26" fill={`url(#${uid}-body)`} />
-            <path className="gloss" d="M 34 38 A 20 20 0 0 1 66 34" />
-            <rect className="pointer" x="48.7" y="24" width="2.6" height="16" rx="1.2" />
-          </g>
-        </svg>
-      </div>
-      <div className="plate">
-        <div className="name">{label}</div>
-        {editing && !disabled ? (
-          <input
-            ref={inputRef}
-            className="input"
-            value={draft}
-            aria-label={`${label} value`}
-            onChange={(event) => setDraft(event.target.value)}
-            onBlur={() => {
-              const parsed = Number(draft.replace(/[^\d.+-]/g, ''))
-              if (Number.isFinite(parsed)) onChange(clamp(parsed, min, max))
-              setEditing(false)
-            }}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') (event.target as HTMLInputElement).blur()
-              if (event.key === 'Escape') setEditing(false)
-            }}
-          />
-        ) : (
-          <button
-            type="button"
-            className="readout"
-            disabled={disabled}
-            title={disabled ? disabledReadout : 'Click to type a value'}
-            onClick={() => {
-              if (disabled) return
-              setDraft(String(Number(value.toFixed(2))))
-              setEditing(true)
-            }}
-          >
-            {disabled && disabledReadout ? (
-              disabledReadout
-            ) : (
-              <>
-                {display(value)}
-                <span className="unit">{unit}</span>
-              </>
-            )}
-          </button>
-        )}
-      </div>
-    </div>
-  )
-}
+import { FACTORY_PRESETS, matchingPresetIndex, postAllParams } from './presets'
 
 function formatMs(value: number) {
   return value < 10 ? value.toFixed(2) : String(Math.round(value))
@@ -240,15 +39,50 @@ function formatRatio(value: number) {
   return value.toFixed(1)
 }
 
+/**
+ * Scale the fixed-size faceplate to the client rectangle the native host gave
+ * the browser.
+ *
+ * The panel owns its own layout in design pixels; this hook owns nothing but
+ * the scale factor. Nothing inside the device measures the window, so no
+ * region can end up sized by a circular percentage chain.
+ */
+function useDeviceScale() {
+  const stageRef = useRef<HTMLDivElement>(null)
+  const [scale, setScale] = useState(1)
+
+  useEffect(() => {
+    const stage = stageRef.current
+    if (!stage) return
+    const fit = (width: number, height: number) => {
+      if (width <= 0 || height <= 0) return
+      setScale(
+        clamp(Math.min(width / DEVICE_WIDTH, height / DEVICE_HEIGHT), 0.2, MAX_SCALE),
+      )
+    }
+    fit(stage.clientWidth, stage.clientHeight)
+    const observer = new ResizeObserver((entries) => {
+      const box = entries[0]?.contentRect
+      if (box) fit(box.width, box.height)
+    })
+    observer.observe(stage)
+    return () => observer.disconnect()
+  }, [])
+
+  return { stageRef, scale }
+}
+
 function App() {
   const [params, setParams] = useState<ZcompParams>(defaults)
   const [connected, setConnected] = useState(false)
   const [meterLive, setMeterLive] = useState(false)
   const [meterMode, setMeterMode] = useState<MeterMode>('reduction')
   const metersRef = useRef<MeterFrame | null>(null)
+  // Mirrors `meterLive` so the meter callback can stay out of React entirely
+  // until the first frame arrives — telemetry runs at frame rate.
+  const meterLiveRef = useRef(false)
   const [preset, setPreset] = useState<number | null>(0)
-  const [skinPulse, setSkinPulse] = useState(false)
-  const prevModel = useRef(params.model)
+  const { stageRef, scale } = useDeviceScale()
 
   useEffect(
     () =>
@@ -262,24 +96,19 @@ function App() {
           setConnected(isConnected)
           if (!isConnected) {
             metersRef.current = null
+            meterLiveRef.current = false
             setMeterLive(false)
           }
         },
         (frame) => {
           metersRef.current = frame
-          setMeterLive((was) => was || true)
+          if (meterLiveRef.current) return
+          meterLiveRef.current = true
+          setMeterLive(true)
         },
       ),
     [],
   )
-
-  useEffect(() => {
-    if (prevModel.current === params.model) return
-    prevModel.current = params.model
-    setSkinPulse(true)
-    const timer = window.setTimeout(() => setSkinPulse(false), 420)
-    return () => window.clearTimeout(timer)
-  }, [params.model])
 
   const change = <K extends keyof ZcompParams>(
     id: K,
@@ -302,193 +131,258 @@ function App() {
   }
 
   const programmedRelease = releaseIsProgrammed(params)
-  const circuit = MODEL_CIRCUIT[params.model]
+  const circuit = CIRCUIT_INFO[params.model]
   const metersActive = connected && meterLive
 
   return (
-    <div
-      className={`unit${skinPulse ? ' is-skin-pulse' : ''}`}
-      data-model={params.model}
-      style={
-        {
-          '--drive': String(clamp(params.color / 100, 0, 1)),
-        } as CSSProperties
-      }
-    >
-      <div className={`panel${params.power ? '' : ' is-off'}`}>
-        <header className="top">
-          <div className="identity">
-            <div className="wordmark">
-              <span className="z">Z</span>
-              <div>
-                <strong>Z-Comp</strong>
-                <em>{MODEL_LABEL[params.model]} circuit</em>
+    <div className="stage" ref={stageRef}>
+      <div
+        className={`device${params.power ? '' : ' is-off'}`}
+        data-model={params.model}
+        style={
+          {
+            width: `${DEVICE_WIDTH}px`,
+            height: `${DEVICE_HEIGHT}px`,
+            transform: `translate(-50%, -50%) scale(${scale})`,
+          } as CSSProperties
+        }
+      >
+        <div className="ear" aria-hidden="true">
+          <span className="screw" />
+          <span className="screw" />
+        </div>
+
+        <div className="face">
+          <header className="head">
+            <div className="identity">
+              <div className="nameplate">
+                <span className="mark">Z</span>
+                <div className="titles">
+                  <strong>Z—COMP</strong>
+                  <em>Multi-Circuit Dynamics</em>
+                </div>
               </div>
+              <div className="maker">
+                <span>Futureboard</span>
+                <span
+                  className={`link${connected ? ' is-live' : ''}`}
+                  title={connected ? 'Linked to the host' : 'No host instance bound'}
+                >
+                  <i />
+                  {connected ? 'Linked' : 'Standby'}
+                </span>
+              </div>
+              <PresetControl
+                preset={preset}
+                names={FACTORY_PRESETS.map((entry) => entry.name)}
+                onChange={loadPreset}
+                onPrevious={() => loadPreset((preset ?? 0) - 1)}
+                onNext={() => loadPreset((preset ?? -1) + 1)}
+              />
+
+              {/* Silkscreen of the actual chain in `zcomp::dsp`. */}
+              <ol className="signal-path" aria-label="Signal path">
+                <li>Sidechain HPF</li>
+                <li>Detector</li>
+                <li>Gain cell</li>
+                <li>Colour</li>
+              </ol>
             </div>
-            <PresetControl
-              preset={preset}
-              names={FACTORY_PRESETS.map((entry) => entry.name)}
-              onChange={loadPreset}
-              onPrevious={() => loadPreset((preset ?? 0) - 1)}
-              onNext={() => loadPreset((preset ?? -1) + 1)}
+
+            <MeterBay
+              metersRef={metersRef}
+              live={metersActive}
+              mode={meterMode}
+              onClearOutClip={() => {
+                const frame = metersRef.current
+                if (frame) metersRef.current = { ...frame, outClip: false }
+              }}
             />
-          </div>
 
-          <MeterBay
-            metersRef={metersRef}
-            live={metersActive}
-            mode={meterMode}
-            onClearOutClip={() => {
-              const frame = metersRef.current
-              if (frame) metersRef.current = { ...frame, outClip: false }
-            }}
-          />
+            <CurveDisplay params={params} metersRef={metersRef} live={metersActive} />
 
-          <div className="side">
-            <div className="meter-switch" role="group" aria-label="Meter mode">
+            <div className="master">
+              <div className="switchbank" role="group" aria-label="Meter mode">
+                <button
+                  type="button"
+                  className={meterMode === 'reduction' ? 'is-on' : undefined}
+                  aria-pressed={meterMode === 'reduction'}
+                  title="Meter shows gain reduction"
+                  onClick={() => setMeterMode('reduction')}
+                >
+                  GR
+                </button>
+                <button
+                  type="button"
+                  className={meterMode === 'output' ? 'is-on' : undefined}
+                  aria-pressed={meterMode === 'output'}
+                  title="Meter shows output level, 0 VU = −18 dBFS"
+                  onClick={() => setMeterMode('output')}
+                >
+                  +4
+                </button>
+              </div>
+
               <button
                 type="button"
-                className={meterMode === 'reduction' ? 'is-on' : undefined}
-                onClick={() => setMeterMode('reduction')}
+                className={`rocker${params.power ? ' is-on' : ''}`}
+                role="switch"
+                aria-checked={params.power}
+                aria-label="Power"
+                title={params.power ? 'Engaged — click to bypass' : 'Bypassed'}
+                onClick={() => change('power', !params.power, params.power ? 0 : 1)}
               >
-                GR
+                <span className="lamp" />
+                <span className="legend">{params.power ? 'In' : 'Byp'}</span>
+              </button>
+              <span className="master-tag">Power</span>
+            </div>
+          </header>
+
+          <section className="circuit" aria-label="Circuit">
+            <span className="bay-label">Circuit</span>
+            <div className="bank" role="radiogroup" aria-label="Circuit model">
+              {MODELS.map((model) => (
+                <button
+                  key={model}
+                  type="button"
+                  className={`lamp-button${params.model === model ? ' is-on' : ''}`}
+                  role="radio"
+                  aria-checked={params.model === model}
+                  onClick={() => change('model', model, MODEL_WIRE[model])}
+                >
+                  <i />
+                  {MODEL_LABEL[model]}
+                </button>
+              ))}
+            </div>
+
+            <p className="engraved" aria-live="polite">
+              <span>{circuit.topology}</span>
+            </p>
+
+            <div className="modes">
+              <button
+                type="button"
+                className={`lamp-button${params.autoRelease ? ' is-on' : ''}`}
+                aria-pressed={params.autoRelease}
+                title={
+                  params.model === 'ssl'
+                    ? 'Dual time-constant automatic release'
+                    : 'Adds program dependence to this circuit’s release'
+                }
+                onClick={() =>
+                  change('autoRelease', !params.autoRelease, params.autoRelease ? 0 : 1)
+                }
+              >
+                <i />
+                Auto Rel
               </button>
               <button
                 type="button"
-                className={meterMode === 'output' ? 'is-on' : undefined}
-                onClick={() => setMeterMode('output')}
+                className={`lamp-button alert${params.scListen ? ' is-on' : ''}`}
+                aria-pressed={params.scListen}
+                title="Audition the filtered sidechain the detector hears"
+                onClick={() =>
+                  change('scListen', !params.scListen, params.scListen ? 0 : 1)
+                }
               >
-                +4
+                <i />
+                SC Listen
               </button>
             </div>
-            <button
-              type="button"
-              className={`power${params.power ? ' is-on' : ''}`}
-              role="switch"
-              aria-checked={params.power}
-              aria-label="Power"
-              onClick={() => change('power', !params.power, params.power ? 0 : 1)}
-            >
-              <span className="lamp" />
-              <span className="legend">Power</span>
-            </button>
-            <span
-              className={`link${connected ? ' is-live' : ''}`}
-              title={connected ? 'Host linked' : 'Preview'}
-            />
-          </div>
-        </header>
+          </section>
 
-        <section className="models" aria-label="Compressor model">
-          <span className="bank-label">Model</span>
-          <div className="bank" role="radiogroup" aria-label="Circuit model">
-            {MODELS.map((model) => (
-              <button
-                key={model}
-                type="button"
-                className={params.model === model ? 'is-on' : undefined}
-                role="radio"
-                aria-checked={params.model === model}
-                onClick={() => change('model', model, MODEL_WIRE[model])}
-              >
-                {MODEL_LABEL[model]}
-              </button>
-            ))}
-          </div>
-          <button
-            type="button"
-            className={`auto${params.autoRelease ? ' is-on' : ''}`}
-            aria-pressed={params.autoRelease}
-            title={
-              params.model === 'ssl'
-                ? 'Program-dependent release (SSL path in DSP)'
-                : 'Auto release flag (SSL circuit uses it)'
-            }
-            onClick={() =>
-              change('autoRelease', !params.autoRelease, params.autoRelease ? 0 : 1)
-            }
-          >
-            Auto Rel
-          </button>
-        </section>
+          <section className="controls" aria-label="Controls">
+            <div className="row main">
+              <Knob
+                spec={PARAM_SPECS.thresholdDb}
+                scale={PARAM_SPECS.thresholdDb.scale}
+                value={params.thresholdDb}
+                display={formatDb}
+                onChange={(value) => change('thresholdDb', value)}
+              />
+              <Knob
+                spec={PARAM_SPECS.ratio}
+                scale={PARAM_SPECS.ratio.scale}
+                value={params.ratio}
+                display={formatRatio}
+                onChange={(value) => change('ratio', value)}
+              />
+              <Knob
+                spec={PARAM_SPECS.attackMs}
+                scale={PARAM_SPECS.attackMs.scale}
+                value={params.attackMs}
+                display={formatMs}
+                onChange={(value) => change('attackMs', value)}
+              />
+              <Knob
+                spec={PARAM_SPECS.releaseMs}
+                scale={PARAM_SPECS.releaseMs.scale}
+                value={params.releaseMs}
+                display={formatMs}
+                onChange={(value) => change('releaseMs', value)}
+                disabled={programmedRelease}
+                disabledReadout="Auto"
+              />
+              <Knob
+                spec={PARAM_SPECS.makeupDb}
+                scale={PARAM_SPECS.makeupDb.scale}
+                value={params.makeupDb}
+                display={formatDb}
+                onChange={(value) => change('makeupDb', value)}
+              />
+            </div>
 
-        <p className="circuit" aria-live="polite">
-          <strong>{circuit.title}</strong>
-          <span>{circuit.topology}</span>
-        </p>
+            <div className="row trim">
+              <Knob
+                size="sm"
+                spec={PARAM_SPECS.kneeDb}
+                scale={PARAM_SPECS.kneeDb.scale}
+                value={params.kneeDb}
+                display={formatDb}
+                onChange={(value) => change('kneeDb', value)}
+              />
+              <Knob
+                size="sm"
+                spec={PARAM_SPECS.sidechainHpfHz}
+                scale={PARAM_SPECS.sidechainHpfHz.scale}
+                value={params.sidechainHpfHz}
+                display={formatHz}
+                onChange={(value) => change('sidechainHpfHz', value)}
+              />
+              <Knob
+                size="sm"
+                spec={PARAM_SPECS.stereoLink}
+                scale={PARAM_SPECS.stereoLink.scale}
+                value={params.stereoLink}
+                display={formatPct}
+                onChange={(value) => change('stereoLink', value)}
+              />
+              <Knob
+                size="sm"
+                spec={PARAM_SPECS.color}
+                scale={PARAM_SPECS.color.scale}
+                value={params.color}
+                display={formatPct}
+                onChange={(value) => change('color', value)}
+              />
+              <Knob
+                size="sm"
+                spec={PARAM_SPECS.mix}
+                scale={PARAM_SPECS.mix.scale}
+                value={params.mix}
+                display={formatPct}
+                onChange={(value) => change('mix', value)}
+              />
+            </div>
+          </section>
+        </div>
 
-        <section className="knobs" aria-label="Main controls">
-          <AluminumKnob
-            spec={PARAM_SPECS.thresholdDb}
-            value={params.thresholdDb}
-            display={formatDb}
-            onChange={(value) => change('thresholdDb', value)}
-          />
-          <AluminumKnob
-            spec={PARAM_SPECS.ratio}
-            value={params.ratio}
-            display={formatRatio}
-            onChange={(value) => change('ratio', value)}
-          />
-          <AluminumKnob
-            spec={PARAM_SPECS.attackMs}
-            value={params.attackMs}
-            display={formatMs}
-            onChange={(value) => change('attackMs', value)}
-          />
-          <AluminumKnob
-            spec={PARAM_SPECS.releaseMs}
-            value={params.releaseMs}
-            display={formatMs}
-            onChange={(value) => change('releaseMs', value)}
-            disabled={programmedRelease}
-            disabledReadout="AUTO"
-          />
-          <AluminumKnob
-            spec={PARAM_SPECS.makeupDb}
-            value={params.makeupDb}
-            display={formatDb}
-            onChange={(value) => change('makeupDb', value)}
-          />
-        </section>
-
-        <section className="extras" aria-label="Extras">
-          <AluminumKnob
-            size="sm"
-            spec={PARAM_SPECS.kneeDb}
-            value={params.kneeDb}
-            display={formatDb}
-            onChange={(value) => change('kneeDb', value)}
-          />
-          <AluminumKnob
-            size="sm"
-            spec={PARAM_SPECS.mix}
-            value={params.mix}
-            display={formatPct}
-            onChange={(value) => change('mix', value)}
-          />
-          <AluminumKnob
-            size="sm"
-            spec={PARAM_SPECS.sidechainHpfHz}
-            value={params.sidechainHpfHz}
-            display={formatHz}
-            onChange={(value) => change('sidechainHpfHz', value)}
-          />
-          <AluminumKnob
-            size="sm"
-            spec={PARAM_SPECS.stereoLink}
-            value={params.stereoLink}
-            display={formatPct}
-            onChange={(value) => change('stereoLink', value)}
-          />
-          <AluminumKnob
-            size="sm"
-            spec={PARAM_SPECS.color}
-            value={params.color}
-            display={formatPct}
-            onChange={(value) => change('color', value)}
-          />
-        </section>
+        <div className="ear" aria-hidden="true">
+          <span className="screw" />
+          <span className="screw" />
+        </div>
       </div>
     </div>
   )

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/CurveDisplay.tsx
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/CurveDisplay.tsx
@@ -1,0 +1,168 @@
+/**
+ * Transfer-curve window: the static curve the selected circuit is running,
+ * plus a live operating point.
+ *
+ * The curve comes from `device.circuitCurve` / `device.targetGrDb`, which
+ * mirror `zcomp::dsp::model_coeffs` and `target_gr_db`. The dot comes from host
+ * telemetry — nothing here invents a level. Both use the same
+ * `toX`/`toY` transform, so the drawn curve and the plotted point cannot
+ * disagree about where a decibel is.
+ */
+
+import { useEffect, useMemo, useRef, type MutableRefObject } from 'react'
+import type { MeterFrame, ZcompParams } from './bridge'
+import { circuitCurve, targetGrDb } from './device'
+import { clamp, linearToDb } from './meter'
+
+const VIEW_W = 208
+const VIEW_H = 156
+const PAD_L = 20
+const PAD_R = 8
+const PAD_T = 16
+const PAD_B = 18
+const MIN_DB = -60
+const MAX_DB = 0
+const GRID_DB = [-60, -48, -36, -24, -12, 0]
+
+const PLOT_W = VIEW_W - PAD_L - PAD_R
+const PLOT_H = VIEW_H - PAD_T - PAD_B
+
+function toX(db: number) {
+  return PAD_L + ((clamp(db, MIN_DB, MAX_DB) - MIN_DB) / (MAX_DB - MIN_DB)) * PLOT_W
+}
+
+function toY(db: number) {
+  return PAD_T + (1 - (clamp(db, MIN_DB, MAX_DB) - MIN_DB) / (MAX_DB - MIN_DB)) * PLOT_H
+}
+
+/**
+ * Steady-state output for one input level, including makeup and the dry/wet
+ * blend. Mix is summed in the linear domain because that is where the DSP
+ * blends it — a dB-domain approximation would draw parallel compression wrong.
+ */
+function outputDb(params: ZcompParams, inputDb: number) {
+  const curve = circuitCurve(params)
+  const gr = targetGrDb(curve, inputDb)
+  const dry = Math.pow(10, inputDb / 20)
+  const wet = dry * Math.pow(10, (params.makeupDb - gr) / 20)
+  const amount = clamp(params.mix, 0, 100) / 100
+  return linearToDb(dry * (1 - amount) + wet * amount)
+}
+
+type Props = {
+  params: ZcompParams
+  metersRef: MutableRefObject<MeterFrame | null>
+  live: boolean
+}
+
+export function CurveDisplay({ params, metersRef, live }: Props) {
+  const dotRef = useRef<SVGCircleElement>(null)
+  const traceRef = useRef<SVGLineElement>(null)
+  const liveRef = useRef(live)
+  liveRef.current = live
+
+  const path = useMemo(() => {
+    if (!params.power) return ''
+    const points: string[] = []
+    for (let db = MIN_DB; db <= MAX_DB + 1e-6; db += 1) {
+      const x = toX(db)
+      const y = toY(outputDb(params, db))
+      points.push(`${points.length === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`)
+    }
+    return points.join(' ')
+  }, [params])
+
+  const thresholdX = toX(circuitCurve(params).thresholdDb)
+
+  useEffect(() => {
+    let raf = 0
+    const step = () => {
+      const frame = metersRef.current
+      const dot = dotRef.current
+      const trace = traceRef.current
+      if (dot && trace) {
+        if (liveRef.current && frame && frame.inPeak > 1e-5) {
+          const inDb = linearToDb(frame.inPeak)
+          const outDb = linearToDb(Math.max(frame.outPeak, 1e-6))
+          const x = toX(inDb)
+          const y = toY(outDb)
+          dot.setAttribute('cx', x.toFixed(2))
+          dot.setAttribute('cy', y.toFixed(2))
+          dot.style.display = ''
+          trace.setAttribute('x1', x.toFixed(2))
+          trace.setAttribute('y1', (PAD_T + PLOT_H).toFixed(2))
+          trace.setAttribute('x2', x.toFixed(2))
+          trace.setAttribute('y2', y.toFixed(2))
+          trace.style.display = ''
+        } else {
+          dot.style.display = 'none'
+          trace.style.display = 'none'
+        }
+      }
+      raf = requestAnimationFrame(step)
+    }
+    raf = requestAnimationFrame(step)
+    return () => cancelAnimationFrame(raf)
+  }, [metersRef])
+
+  return (
+    <div className="curve">
+      <svg viewBox={`0 0 ${VIEW_W} ${VIEW_H}`} role="img" aria-label="Transfer curve">
+        <rect className="screen" x="0" y="0" width={VIEW_W} height={VIEW_H} rx="4" />
+
+        {GRID_DB.map((db) => (
+          <g key={db}>
+            <line
+              className={`grid${db === 0 ? ' edge' : ''}`}
+              x1={toX(db)}
+              y1={PAD_T}
+              x2={toX(db)}
+              y2={PAD_T + PLOT_H}
+            />
+            <line
+              className={`grid${db === 0 ? ' edge' : ''}`}
+              x1={PAD_L}
+              y1={toY(db)}
+              x2={PAD_L + PLOT_W}
+              y2={toY(db)}
+            />
+          </g>
+        ))}
+
+        <line
+          className="unity"
+          x1={toX(MIN_DB)}
+          y1={toY(MIN_DB)}
+          x2={toX(MAX_DB)}
+          y2={toY(MAX_DB)}
+        />
+
+        <line
+          className="threshold"
+          x1={thresholdX}
+          y1={PAD_T}
+          x2={thresholdX}
+          y2={PAD_T + PLOT_H}
+        />
+
+        {path ? <path className="transfer" d={path} /> : null}
+
+        <line ref={traceRef} className="trace" style={{ display: 'none' }} />
+        <circle ref={dotRef} className="dot" r="2.6" style={{ display: 'none' }} />
+
+        <text className="axis" x={PAD_L} y={VIEW_H - 6}>
+          −60
+        </text>
+        <text className="axis" x={PAD_L + PLOT_W} y={VIEW_H - 6} textAnchor="end">
+          0 dBFS
+        </text>
+        <text className="axis vert" x="10" y={PAD_T + 4} textAnchor="middle">
+          OUT
+        </text>
+        <text className="caption" x={PAD_L + PLOT_W} y={PAD_T - 5} textAnchor="end">
+          {params.power ? 'TRANSFER' : 'BYPASSED'}
+        </text>
+      </svg>
+    </div>
+  )
+}

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/Knob.tsx
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/Knob.tsx
@@ -1,0 +1,334 @@
+/**
+ * Machined aluminum knob: engraved scale collar, knurled skirt, value plate.
+ *
+ * Drawing and hit-testing share one transform — the pointer angle is derived
+ * from the same normalised value the collar arc is drawn from, so what the user
+ * sees and what the gesture reports can never disagree.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
+import { KNOB_START_DEG, KNOB_SWEEP_DEG, KNOB_TRAVEL_PX } from './device'
+import { clamp } from './meter'
+import type { ParamSpec } from './params'
+
+type KnobProps = {
+  spec: ParamSpec
+  value: number
+  display: (value: number) => string
+  onChange: (value: number) => void
+  size?: 'lg' | 'sm'
+  disabled?: boolean
+  disabledReadout?: string
+  /** Engraved end-of-travel legends, e.g. `['-60', '0']`. */
+  scale?: readonly [string, string]
+}
+
+const VIEW = 120
+const CENTRE = VIEW / 2
+const COLLAR_R = 52
+const SKIRT_R = 37
+const CAP_R = 30
+
+function polar(angleDeg: number, radius: number) {
+  const rad = ((angleDeg - 90) * Math.PI) / 180
+  return {
+    x: CENTRE + Math.cos(rad) * radius,
+    y: CENTRE + Math.sin(rad) * radius,
+  }
+}
+
+function arc(fromDeg: number, toDeg: number, radius: number) {
+  const a = polar(fromDeg, radius)
+  const b = polar(toDeg, radius)
+  const large = Math.abs(toDeg - fromDeg) > 180 ? 1 : 0
+  return `M ${a.x.toFixed(2)} ${a.y.toFixed(2)} A ${radius} ${radius} 0 ${large} 1 ${b.x.toFixed(2)} ${b.y.toFixed(2)}`
+}
+
+/** Eleven engraved marks around the collar, every fifth one major. */
+const TICKS = Array.from({ length: 11 }, (_, i) => i / 10)
+
+/** Knurling: 44 flutes cut into the skirt, rotating with the knob. */
+const FLUTES = Array.from({ length: 44 }, (_, i) => (i * 360) / 44)
+
+export function Knob({
+  spec,
+  value,
+  display,
+  onChange,
+  size = 'lg',
+  disabled = false,
+  disabledReadout,
+  scale,
+}: KnobProps) {
+  const uid = useId().replace(/:/g, '')
+  const gesture = useRef<{ y: number; norm: number } | null>(null)
+  const [dragging, setDragging] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { min, max, step, label, unit, defaultValue } = spec
+  const norm = clamp((value - min) / Math.max(max - min, 1e-9), 0, 1)
+  const angle = KNOB_START_DEG + KNOB_SWEEP_DEG * norm
+
+  const fromNorm = useCallback(
+    (n: number) => {
+      const raw = min + clamp(n, 0, 1) * (max - min)
+      return clamp(Math.round(raw / step) * step, min, max)
+    },
+    [max, min, step],
+  )
+
+  useEffect(() => {
+    if (!editing) return
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [editing])
+
+  const flutes = useMemo(
+    () =>
+      FLUTES.map((deg) => {
+        const outer = polar(deg, SKIRT_R)
+        const inner = polar(deg, SKIRT_R - 5)
+        return { deg, outer, inner }
+      }),
+    [],
+  )
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (disabled || editing || event.button !== 0) return
+    gesture.current = { y: event.clientY, norm }
+    event.currentTarget.setPointerCapture(event.pointerId)
+    setDragging(true)
+    event.preventDefault()
+  }
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!gesture.current || disabled) return
+    // Shift is the fine-adjust gesture everywhere in Futureboard.
+    const travel = event.shiftKey ? KNOB_TRAVEL_PX * 5 : KNOB_TRAVEL_PX
+    onChange(
+      fromNorm(gesture.current.norm + (gesture.current.y - event.clientY) / travel),
+    )
+  }
+
+  const endGesture = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!gesture.current) return
+    gesture.current = null
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    setDragging(false)
+  }
+
+  const readout =
+    disabled && disabledReadout ? (
+      <span className="auto">{disabledReadout}</span>
+    ) : (
+      <>
+        {display(value)}
+        <span className="unit">{unit}</span>
+      </>
+    )
+
+  return (
+    <div className={`knob ${size}${disabled ? ' is-disabled' : ''}`}>
+      <div
+        className={`cap${dragging ? ' is-dragging' : ''}`}
+        role="slider"
+        aria-label={label}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-valuetext={
+          disabled && disabledReadout ? disabledReadout : `${display(value)} ${unit}`
+        }
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
+        title={
+          disabled
+            ? (disabledReadout ?? `${label} is programmed by the circuit`)
+            : `${label} — drag to set, Shift for fine, double-click to reset`
+        }
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endGesture}
+        onPointerCancel={endGesture}
+        onLostPointerCapture={() => {
+          gesture.current = null
+          setDragging(false)
+        }}
+        onDoubleClick={() => !disabled && onChange(defaultValue)}
+        onWheel={(event) => {
+          if (disabled) return
+          const delta = event.shiftKey ? step / 5 : step
+          onChange(clamp(value + (event.deltaY < 0 ? delta : -delta), min, max))
+        }}
+        onKeyDown={(event) => {
+          if (disabled) return
+          const delta = event.shiftKey ? step / 5 : step
+          if (event.key === 'ArrowUp' || event.key === 'ArrowRight') {
+            event.preventDefault()
+            onChange(clamp(value + delta, min, max))
+          } else if (event.key === 'ArrowDown' || event.key === 'ArrowLeft') {
+            event.preventDefault()
+            onChange(clamp(value - delta, min, max))
+          } else if (event.key === 'Home') {
+            event.preventDefault()
+            onChange(defaultValue)
+          }
+        }}
+      >
+        <svg viewBox={`0 0 ${VIEW} ${VIEW}`} aria-hidden="true">
+          <defs>
+            <linearGradient id={`${uid}-skirt`} x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0" stopColor="#5c6472" />
+              <stop offset="0.45" stopColor="#2b313a" />
+              <stop offset="1" stopColor="#13171d" />
+            </linearGradient>
+            <linearGradient id={`${uid}-cap`} x1="0.15" x2="0.85" y1="0" y2="1">
+              <stop offset="0" stopColor="#e4e9f1" />
+              <stop offset="0.28" stopColor="#a8b1bf" />
+              <stop offset="0.52" stopColor="#6e7684" />
+              <stop offset="0.74" stopColor="#99a2b0" />
+              <stop offset="1" stopColor="#4a515c" />
+            </linearGradient>
+            <radialGradient id={`${uid}-dish`} cx="0.35" cy="0.3" r="0.8">
+              <stop offset="0" stopColor="rgba(255,255,255,0.35)" />
+              <stop offset="0.6" stopColor="rgba(255,255,255,0.04)" />
+              <stop offset="1" stopColor="rgba(0,0,0,0.35)" />
+            </radialGradient>
+          </defs>
+
+          {/* Engraved collar: travel track, live value, tick marks. */}
+          <path
+            className="collar-track"
+            d={arc(KNOB_START_DEG, KNOB_START_DEG + KNOB_SWEEP_DEG, COLLAR_R)}
+          />
+          {norm > 0.001 ? (
+            <path
+              className="collar-value"
+              d={arc(KNOB_START_DEG, angle, COLLAR_R)}
+            />
+          ) : null}
+          {TICKS.map((t) => {
+            const deg = KNOB_START_DEG + KNOB_SWEEP_DEG * t
+            const major = Math.round(t * 10) % 5 === 0
+            const outer = polar(deg, COLLAR_R + 6)
+            const inner = polar(deg, COLLAR_R + (major ? 1 : 3))
+            return (
+              <line
+                key={t}
+                className={`tick${major ? ' major' : ''}`}
+                x1={inner.x}
+                y1={inner.y}
+                x2={outer.x}
+                y2={outer.y}
+              />
+            )
+          })}
+
+          {/* Knob body. Everything inside rotates as one rigid part. */}
+          <g
+            style={{
+              transform: `rotate(${angle}deg)`,
+              transformOrigin: `${CENTRE}px ${CENTRE}px`,
+            }}
+          >
+            <circle
+              className="skirt"
+              cx={CENTRE}
+              cy={CENTRE}
+              r={SKIRT_R}
+              fill={`url(#${uid}-skirt)`}
+            />
+            <g className="flutes">
+              {flutes.map((flute) => (
+                <line
+                  key={flute.deg}
+                  x1={flute.inner.x}
+                  y1={flute.inner.y}
+                  x2={flute.outer.x}
+                  y2={flute.outer.y}
+                />
+              ))}
+            </g>
+            <circle
+              className="face"
+              cx={CENTRE}
+              cy={CENTRE}
+              r={CAP_R}
+              fill={`url(#${uid}-cap)`}
+            />
+            <circle
+              cx={CENTRE}
+              cy={CENTRE}
+              r={CAP_R}
+              fill={`url(#${uid}-dish)`}
+              pointerEvents="none"
+            />
+            <rect
+              className="pointer"
+              x={CENTRE - 1.7}
+              y={CENTRE - CAP_R - 1}
+              width="3.4"
+              height="17"
+              rx="1.7"
+            />
+            <circle className="hub" cx={CENTRE} cy={CENTRE} r="3.6" />
+          </g>
+        </svg>
+
+        {scale ? (
+          <>
+            <span className="scale-min">{scale[0]}</span>
+            <span className="scale-max">{scale[1]}</span>
+          </>
+        ) : null}
+      </div>
+
+      <div className="legend">{label}</div>
+
+      {editing && !disabled ? (
+        <input
+          ref={inputRef}
+          className="entry"
+          value={draft}
+          aria-label={`${label} value`}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={() => {
+            const parsed = Number(draft.replace(/[^\d.+-]/g, ''))
+            if (Number.isFinite(parsed)) onChange(clamp(parsed, min, max))
+            setEditing(false)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') (event.target as HTMLInputElement).blur()
+            if (event.key === 'Escape') setEditing(false)
+          }}
+        />
+      ) : (
+        <button
+          type="button"
+          className="plate"
+          disabled={disabled}
+          title={disabled ? disabledReadout : 'Click to type a value'}
+          onClick={() => {
+            if (disabled) return
+            setDraft(String(Number(value.toFixed(2))))
+            setEditing(true)
+          }}
+        >
+          {readout}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/MeterBay.tsx
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/MeterBay.tsx
@@ -1,9 +1,10 @@
 /**
- * Hardware meter bay: IN ladder · enamel VU · OUT ladder.
+ * Meter bay: IN ladder · enamel VU movement · OUT ladder.
  *
- * Host telemetry is consumed via a ref so App knobs never re-render at meter
- * rate. One RAF loop advances ballistics, paints both LED canvases, and rotates
- * the needle with a transform — no React setState on the hot path.
+ * Host telemetry is consumed through a ref, so the faceplate never re-renders
+ * at meter rate. One RAF loop advances the ballistics, paints both LED
+ * canvases, rotates the needle by attribute, and writes the numeric readouts at
+ * a fixed 15 Hz — no React state on the hot path.
  */
 
 import {
@@ -33,15 +34,22 @@ import {
   type PeakHold,
 } from './meter'
 
+/** 0 VU is referenced to −18 dBFS, the usual digital alignment. */
 const OUTPUT_REF_DBFS = -18
-const PIVOT_X = 100
-const PIVOT_Y = 134
-const NEEDLE_R = 100
-const SCALE_R = 104
-const LABEL_R = 86
-const TICK_MAJOR = 9
-const TICK_MINOR = 5
+
+const FACE_W = 260
+const FACE_H = 140
+const PIVOT_X = 130
+const PIVOT_Y = 158
+const NEEDLE_R = 124
+const SCALE_R = 128
+const LABEL_R = 110
+const TICK_MAJOR = 10
+const TICK_MINOR = 6
 const READOUT_HZ = 15
+
+/** Engraved legend beside the LED ladders (dBFS). */
+const LADDER_LEGEND = [0, -6, -12, -20, -30, -45, -60]
 
 type Props = {
   metersRef: MutableRefObject<MeterFrame | null>
@@ -95,14 +103,14 @@ function paintLadder(
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
   ctx.clearRect(0, 0, cssW, cssH)
 
-  const gap = 1.15
+  const gap = 1.4
   const segH = (cssH - gap * (LADDER_SEGMENTS - 1)) / LADDER_SEGMENTS
   const peakSeg = Math.round(peakNorm * LADDER_SEGMENTS)
   const rmsSeg = Math.round(rmsNorm * LADDER_SEGMENTS)
   const holdSeg = Math.round(hold * LADDER_SEGMENTS)
 
   for (let i = 0; i < LADDER_SEGMENTS; i++) {
-    // i = 0 at top (hot), matching hardware LED strips.
+    // i = 0 at the top (hot end), matching hardware LED strips.
     const fromTop = LADDER_SEGMENTS - i
     const y = i * (segH + gap)
     const lit = fromTop <= peakSeg
@@ -112,28 +120,25 @@ function paintLadder(
     let fill = colors.idle
     if (lit) {
       const t = fromTop / LADDER_SEGMENTS
-      if (t > 0.88) fill = colors.hot
-      else if (t > 0.68) fill = colors.warm
+      if (t > 0.9) fill = colors.hot
+      else if (t > 0.72) fill = colors.warm
       else fill = colors.cool
     }
 
-    ctx.globalAlpha = lit ? (rmsLit ? 1 : 0.72) : 0.22
+    ctx.globalAlpha = lit ? (rmsLit ? 1 : 0.62) : 0.2
     ctx.fillStyle = fill
-    const inset = lit ? 0 : 0.5
-    const x = inset
-    const ww = cssW - inset * 2
+    ctx.beginPath()
     if (typeof ctx.roundRect === 'function') {
-      ctx.beginPath()
-      ctx.roundRect(x, y, ww, segH, 1)
-      ctx.fill()
+      ctx.roundRect(0, y, cssW, segH, 1.5)
     } else {
-      ctx.fillRect(x, y, ww, segH)
+      ctx.rect(0, y, cssW, segH)
     }
+    ctx.fill()
 
     if (isHold) {
       ctx.globalAlpha = 1
       ctx.fillStyle = colors.hold
-      ctx.fillRect(0, y, cssW, Math.max(1.2, segH * 0.55))
+      ctx.fillRect(0, y, cssW, Math.max(1.4, segH * 0.5))
     }
   }
   ctx.globalAlpha = 1
@@ -160,99 +165,111 @@ function VuFace({
 
   return (
     <svg
-      viewBox="0 0 200 120"
+      viewBox={`0 0 ${FACE_W} ${FACE_H}`}
       role="img"
       aria-label={mode === 'reduction' ? 'Gain reduction meter' : 'Output level meter'}
     >
       <defs>
-        <linearGradient id={`${faceId}-face`} x1="0" x2="0" y1="0" y2="1">
+        <linearGradient id={`${faceId}-face`} x1="0.2" x2="0.8" y1="0" y2="1">
           <stop offset="0" stopColor="var(--meter-face-hi)" />
-          <stop offset="0.55" stopColor="var(--meter-face)" />
+          <stop offset="0.5" stopColor="var(--meter-face)" />
           <stop offset="1" stopColor="var(--meter-face-lo)" />
         </linearGradient>
-        <linearGradient id={`${faceId}-glass`} x1="0" x2="0" y1="0" y2="1">
-          <stop offset="0" stopColor="rgba(255,255,255,0.22)" />
-          <stop offset="0.35" stopColor="rgba(255,255,255,0.05)" />
-          <stop offset="1" stopColor="rgba(0,0,0,0.12)" />
+        <radialGradient id={`${faceId}-vignette`} cx="0.5" cy="0.15" r="0.95">
+          <stop offset="0" stopColor="rgba(255,255,255,0.16)" />
+          <stop offset="0.65" stopColor="rgba(0,0,0,0)" />
+          <stop offset="1" stopColor="rgba(0,0,0,0.28)" />
+        </radialGradient>
+        <linearGradient id={`${faceId}-glass`} x1="0" x2="1" y1="0" y2="1">
+          <stop offset="0" stopColor="rgba(255,255,255,0.20)" />
+          <stop offset="0.42" stopColor="rgba(255,255,255,0.05)" />
+          <stop offset="0.43" stopColor="rgba(255,255,255,0.01)" />
+          <stop offset="1" stopColor="rgba(0,0,0,0.14)" />
         </linearGradient>
+        <clipPath id={`${faceId}-clip`}>
+          <rect x="0" y="0" width={FACE_W} height={FACE_H} rx="4" />
+        </clipPath>
         <filter id={`${faceId}-needle`} x="-40%" y="-40%" width="180%" height="180%">
-          <feDropShadow dx="0.4" dy="1.1" stdDeviation="0.7" floodOpacity="0.45" />
+          <feDropShadow dx="0.6" dy="1.6" stdDeviation="0.9" floodOpacity="0.4" />
         </filter>
       </defs>
 
-      <rect x="0" y="0" width="200" height="120" rx="7" fill={`url(#${faceId}-face)`} />
-      <path className="arc" d={arcPath(arcStart, arcEnd)} />
-      {hotA && hotB ? <path className="arc hot" d={arcPath(hotA, hotB)} /> : null}
+      <g clipPath={`url(#${faceId}-clip)`}>
+        <rect x="0" y="0" width={FACE_W} height={FACE_H} fill={`url(#${faceId}-face)`} />
 
-      {ticks.map((tick) => {
-        const outer = polar(tick.norm, SCALE_R)
-        const inner = polar(tick.norm, SCALE_R - (tick.major ? TICK_MAJOR : TICK_MINOR))
-        const labelAt = polar(tick.norm, LABEL_R)
-        return (
-          <g key={`${mode}-${tick.norm}-${tick.label}`}>
-            <line
-              className={`tick${tick.major ? ' major' : ''}${tick.hot ? ' hot' : ''}`}
-              x1={inner.x}
-              y1={inner.y}
-              x2={outer.x}
-              y2={outer.y}
-            />
-            {tick.label ? (
-              <text
-                className={`label${tick.hot ? ' hot' : ''}`}
-                x={labelAt.x}
-                y={labelAt.y}
-              >
-                {tick.label}
-              </text>
-            ) : null}
-          </g>
-        )
-      })}
+        <path className="arc" d={arcPath(arcStart, arcEnd)} />
+        {hotA && hotB ? <path className="arc hot" d={arcPath(hotA, hotB)} /> : null}
 
-      <text className="caption" x="100" y="18">
-        {mode === 'reduction' ? 'GAIN REDUCTION' : 'OUTPUT'}
-      </text>
-      <text className="unit" x="100" y="88">
-        {mode === 'reduction' ? 'dB' : 'VU'}
-      </text>
+        {ticks.map((tick) => {
+          const outer = polar(tick.norm, SCALE_R)
+          const inner = polar(tick.norm, SCALE_R - (tick.major ? TICK_MAJOR : TICK_MINOR))
+          const labelAt = polar(tick.norm, LABEL_R)
+          return (
+            <g key={`${mode}-${tick.norm}-${tick.label}`}>
+              <line
+                className={`tick${tick.major ? ' major' : ''}${tick.hot ? ' hot' : ''}`}
+                x1={inner.x}
+                y1={inner.y}
+                x2={outer.x}
+                y2={outer.y}
+              />
+              {tick.label ? (
+                <text
+                  className={`label${tick.hot ? ' hot' : ''}`}
+                  x={labelAt.x}
+                  y={labelAt.y}
+                >
+                  {tick.label}
+                </text>
+              ) : null}
+            </g>
+          )
+        })}
 
-      <g
-        ref={needleRef}
-        className="needle-g"
-        transform={`rotate(${restAngle.toFixed(3)} ${PIVOT_X} ${PIVOT_Y})`}
-        filter={`url(#${faceId}-needle)`}
-      >
-        <line
-          className="needle"
-          x1={PIVOT_X}
-          y1={PIVOT_Y}
-          x2={PIVOT_X}
-          y2={PIVOT_Y - NEEDLE_R}
+        <text className="caption" x={FACE_W / 2} y="20">
+          {mode === 'reduction' ? 'GAIN REDUCTION' : 'OUTPUT LEVEL'}
+        </text>
+        <text className="unit" x={FACE_W / 2} y="98">
+          {mode === 'reduction' ? 'dB' : 'VU'}
+        </text>
+        <text className="brand" x="16" y="130" textAnchor="start">
+          Z—COMP
+        </text>
+        <text className="brand" x={FACE_W - 16} y="130" textAnchor="end">
+          {mode === 'reduction' ? 'VU BALLISTICS' : '0 VU = −18 dBFS'}
+        </text>
+
+        <g
+          ref={needleRef}
+          transform={`rotate(${restAngle.toFixed(3)} ${PIVOT_X} ${PIVOT_Y})`}
+          filter={`url(#${faceId}-needle)`}
+        >
+          <polygon
+            className="needle"
+            points={`${PIVOT_X - 2.6},${PIVOT_Y} ${PIVOT_X - 0.7},${PIVOT_Y - NEEDLE_R} ${PIVOT_X + 0.7},${PIVOT_Y - NEEDLE_R} ${PIVOT_X + 2.6},${PIVOT_Y}`}
+          />
+        </g>
+
+        <rect
+          x="0"
+          y="0"
+          width={FACE_W}
+          height={FACE_H}
+          fill={`url(#${faceId}-vignette)`}
+          pointerEvents="none"
         />
-        <circle className="hub" cx={PIVOT_X} cy={PIVOT_Y} r="4.2" />
+        <rect
+          x="0"
+          y="0"
+          width={FACE_W}
+          height={FACE_H * 0.52}
+          fill={`url(#${faceId}-glass)`}
+          pointerEvents="none"
+        />
+        <text ref={parkedRef} className="parked" x={FACE_W / 2} y="118" style={{ display: 'none' }}>
+          no signal
+        </text>
       </g>
-
-      <rect
-        className="bezel"
-        x="0.7"
-        y="0.7"
-        width="198.6"
-        height="118.6"
-        rx="6.4"
-      />
-      <rect
-        x="2"
-        y="2"
-        width="196"
-        height="52"
-        rx="5"
-        fill={`url(#${faceId}-glass)`}
-        pointerEvents="none"
-      />
-      <text ref={parkedRef} className="parked" x="100" y="108" style={{ display: 'none' }}>
-        no signal
-      </text>
     </svg>
   )
 }
@@ -276,16 +293,8 @@ export function MeterBay({ metersRef, live, mode, onClearOutClip }: Props) {
   liveRef.current = live
 
   useEffect(() => {
-    const inState: LadderState = {
-      peak: 0,
-      rms: 0,
-      hold: createPeakHold(),
-    }
-    const outState: LadderState = {
-      peak: 0,
-      rms: 0,
-      hold: createPeakHold(),
-    }
+    const inState: LadderState = { peak: 0, rms: 0, hold: createPeakHold() }
+    const outState: LadderState = { peak: 0, rms: 0, hold: createPeakHold() }
     let needle = normFor(modeRef.current, modeRef.current === 'reduction' ? 0 : -20)
     let last = performance.now()
     let readoutAcc = 0
@@ -298,14 +307,15 @@ export function MeterBay({ metersRef, live, mode, onClearOutClip }: Props) {
       cool: '#4a9a8c',
       warm: '#c9a35a',
       hot: '#c43a28',
-      idle: 'rgba(255,255,255,0.06)',
+      idle: 'rgba(255,255,255,0.05)',
       hold: 'rgba(245,240,230,0.95)',
     }
 
     const syncColors = () => {
       const root = rootRef.current
       if (!root) return
-      colors.cool = readCssColor(root, '--btn-on', colors.cool)
+      colors.cool = readCssColor(root, '--led-cool', colors.cool)
+      colors.warm = readCssColor(root, '--led-warm', colors.warm)
       colors.hot = readCssColor(root, '--clip', colors.hot)
     }
     syncColors()
@@ -366,24 +376,18 @@ export function MeterBay({ metersRef, live, mode, onClearOutClip }: Props) {
         outState.hold.age = PEAK_HOLD_SECONDS
       }
 
-      const target =
-        isLive
-          ? normFor(
-              meterMode,
-              meterMode === 'reduction'
-                ? grDb
-                : linearToDb(outRmsLin) - OUTPUT_REF_DBFS,
-            )
-          : normFor(meterMode, meterMode === 'reduction' ? 0 : -20)
+      const target = isLive
+        ? normFor(
+            meterMode,
+            meterMode === 'reduction' ? grDb : linearToDb(outRmsLin) - OUTPUT_REF_DBFS,
+          )
+        : normFor(meterMode, meterMode === 'reduction' ? 0 : -20)
 
       needle = advance(needle, target, dt)
-      const angle = angleFor(needle)
-      if (needleRef.current) {
-        needleRef.current.setAttribute(
-          'transform',
-          `rotate(${angle.toFixed(3)} ${PIVOT_X} ${PIVOT_Y})`,
-        )
-      }
+      needleRef.current?.setAttribute(
+        'transform',
+        `rotate(${angleFor(needle).toFixed(3)} ${PIVOT_X} ${PIVOT_Y})`,
+      )
 
       if (inCanvasRef.current) {
         paintLadder(
@@ -410,12 +414,8 @@ export function MeterBay({ metersRef, live, mode, onClearOutClip }: Props) {
       if (clipBtnRef.current) {
         clipBtnRef.current.hidden = !outClip
       }
-      if (inClipRef.current) {
-        inClipRef.current.classList.toggle('is-on', inClip)
-      }
-      if (outClipRef.current) {
-        outClipRef.current.classList.toggle('is-on', outClip)
-      }
+      inClipRef.current?.classList.toggle('is-on', inClip)
+      outClipRef.current?.classList.toggle('is-on', outClip)
 
       if (readoutAcc >= 1 / READOUT_HZ) {
         readoutAcc = 0
@@ -451,12 +451,9 @@ export function MeterBay({ metersRef, live, mode, onClearOutClip }: Props) {
     }
   }, [metersRef])
 
-  // Resync needle rest + cool LED color when the model skin changes.
+  // A skin change repaints the LED colours on the next RAF; drop the backing
+  // stores so the canvases also pick up any new device pixel ratio.
   useEffect(() => {
-    const root = rootRef.current
-    if (!root) return
-    // Force a color pull on next paint by toggling a data attr the loop reads
-    // via getComputedStyle when visibility fires; also poke canvases size.
     for (const canvas of [inCanvasRef.current, outCanvasRef.current]) {
       if (canvas) {
         canvas.width = 0
@@ -466,48 +463,59 @@ export function MeterBay({ metersRef, live, mode, onClearOutClip }: Props) {
   }, [live, mode])
 
   return (
-    <div
-      ref={rootRef}
-      className={`meter-bay${!live ? ' is-dark' : ''}`}
-      aria-label="Level meters"
-    >
-      <div className="io-strip">
-        <span className="io-label">In</span>
-        <span ref={inClipRef} className="clip-led" aria-hidden="true" />
-        <canvas ref={inCanvasRef} className="io-ladder" aria-hidden="true" />
-        <output ref={inReadoutRef}>—</output>
-      </div>
-
-      <div className="meter-well">
-        <div className="meter">
+    <div ref={rootRef} className="meter-bay" aria-label="Level meters">
+      <div className="movement">
+        <div className={`glass${live ? '' : ' is-dark'}`}>
           <VuFace
             mode={mode}
             faceId={faceId}
             needleRef={needleRef}
             parkedRef={parkedRef}
           />
+          <span className="screw tl" aria-hidden="true" />
+          <span className="screw tr" aria-hidden="true" />
+          <span className="screw bl" aria-hidden="true" />
+          <span className="screw br" aria-hidden="true" />
           <button
             ref={clipBtnRef}
             type="button"
             className="clip-flag"
             hidden
+            title="Output clipped — click to clear"
             onClick={onClearOutClip}
           >
             CLIP
           </button>
         </div>
-        <div className="gr-readout" aria-live="polite">
-          <span>GR</span>
-          <output ref={grReadoutRef}>—</output>
+        <div className="gr-strip">
+          <span className="tag">Reduction</span>
+          <output ref={grReadoutRef} aria-live="off">
+            —
+          </output>
           <small>dB</small>
         </div>
       </div>
 
-      <div className="io-strip">
-        <span className="io-label">Out</span>
-        <span ref={outClipRef} className="clip-led" aria-hidden="true" />
-        <canvas ref={outCanvasRef} className="io-ladder" aria-hidden="true" />
-        <output ref={outReadoutRef}>—</output>
+      <div className="ladders">
+        <div className="io">
+          <span className="io-tag">In</span>
+          <span ref={inClipRef} className="clip-led" aria-hidden="true" />
+          <canvas ref={inCanvasRef} className="ladder" aria-hidden="true" />
+          <output ref={inReadoutRef}>—</output>
+        </div>
+
+        <div className="io-scale" aria-hidden="true">
+          {LADDER_LEGEND.map((db) => (
+            <span key={db}>{db}</span>
+          ))}
+        </div>
+
+        <div className="io">
+          <span className="io-tag">Out</span>
+          <span ref={outClipRef} className="clip-led" aria-hidden="true" />
+          <canvas ref={outCanvasRef} className="ladder" aria-hidden="true" />
+          <output ref={outReadoutRef}>—</output>
+        </div>
       </div>
     </div>
   )

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/bridge.ts
@@ -25,6 +25,7 @@ export type ZcompParams = {
   stereoLink: number
   color: number
   autoRelease: boolean
+  scListen: boolean
 }
 
 export type MeterFrame = {
@@ -65,6 +66,7 @@ export const defaults: ZcompParams = {
   stereoLink: 100,
   color: 18,
   autoRelease: true,
+  scListen: false,
 }
 
 type Binding = {
@@ -166,6 +168,8 @@ function parseParams(state: unknown): ZcompParams | null {
   const raw = params as unknown as ZcompParams
   return {
     ...raw,
+    // Added after the first release: a state blob without it is still valid.
+    scListen: typeof params.scListen === 'boolean' ? params.scListen : false,
     thresholdDb: Math.min(0, Math.max(-60, raw.thresholdDb)),
     ratio: Math.min(20, Math.max(1, raw.ratio)),
     attackMs: Math.min(120, Math.max(0.01, raw.attackMs)),

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/device.ts
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/device.ts
@@ -1,0 +1,112 @@
+/**
+ * Faceplate geometry and the display-side mirror of the Rust gain computer.
+ *
+ * The panel is laid out once at a fixed design size and scaled to whatever
+ * client rectangle the native host gives the browser. Every coordinate below is
+ * in *design pixels*: one layout owner, no percentage heights, no circular
+ * sizing, and identical proportions at any window size or DPI.
+ */
+
+import type { CompModel, ZcompParams } from './bridge'
+import { clamp } from './meter'
+
+/** Design canvas. 900 x 620 is the editor window minimum, minus native chrome. */
+export const DEVICE_WIDTH = 1020
+export const DEVICE_HEIGHT = 600
+
+/** Beyond this the faceplate stops growing and simply centres. */
+export const MAX_SCALE = 1.7
+
+/** Knob pointer travel: 300 degrees, resting at 7 o'clock like real hardware. */
+export const KNOB_START_DEG = -150
+export const KNOB_SWEEP_DEG = 300
+
+/** Vertical drag distance (px) for the full range of a knob. */
+export const KNOB_TRAVEL_PX = 260
+
+/**
+ * Static gain-computer constants for one model.
+ *
+ * Mirrors `zcomp::dsp::model_coeffs` for the four values that shape the
+ * transfer curve. Rust stays authoritative for what the audio actually does —
+ * this exists so the curve window can draw the cell the user is hearing
+ * instead of a generic textbook knee.
+ */
+export type CircuitCurve = {
+  thresholdDb: number
+  ratio: number
+  kneeDb: number
+  /** Overshoot (dB) at which an optical cell is halfway to its ratio. */
+  overEasyDb: number
+}
+
+export function circuitCurve(params: ZcompParams): CircuitCurve {
+  const color = clamp(params.color, 0, 100) / 100
+  const ratio = Math.max(params.ratio, 1)
+  const knee = Math.max(params.kneeDb, 0)
+
+  switch (params.model) {
+    case 'comp2500':
+      return {
+        thresholdDb: params.thresholdDb,
+        ratio,
+        kneeDb: Math.min(knee + 3 + color * 3, 24),
+        overEasyDb: 0,
+      }
+    case 'distressor':
+      return {
+        thresholdDb: params.thresholdDb - color * 1.5,
+        ratio: Math.min(ratio * (1 + color * 0.5), 40),
+        kneeDb: Math.max(knee * (1 - color * 0.6), 0.3),
+        overEasyDb: 0,
+      }
+    case 'avalon':
+      return {
+        thresholdDb: params.thresholdDb,
+        ratio: clamp(2 + (ratio - 1) * 0.55, 1.5, 8),
+        kneeDb: Math.min(knee + 6 + color * 4, 24),
+        overEasyDb: 8,
+      }
+    case 'ssl':
+    default:
+      return {
+        thresholdDb: params.thresholdDb,
+        ratio: clamp(ratio, 1.5, 10),
+        kneeDb: clamp(knee + 3, 2, 18),
+        overEasyDb: 0,
+      }
+  }
+}
+
+/** Reduction the cell would apply to a steady level. Mirrors `target_gr_db`. */
+export function targetGrDb(curve: CircuitCurve, levelDb: number) {
+  const over = levelDb - curve.thresholdDb
+  const halfKnee = curve.kneeDb * 0.5
+  if (over <= -halfKnee) return 0
+
+  let curved: number
+  if (over >= halfKnee || curve.kneeDb <= 1e-4) {
+    curved = Math.max(over, 0)
+  } else {
+    const t = over + halfKnee
+    curved = (t * t) / (2 * curve.kneeDb)
+  }
+
+  const ratio =
+    curve.overEasyDb > 0
+      ? 1 + (curve.ratio - 1) * (curved / (curved + curve.overEasyDb))
+      : curve.ratio
+
+  return curved * (1 - 1 / ratio)
+}
+
+/** Engraved plate text for each circuit. */
+export const CIRCUIT_INFO: Record<
+  CompModel,
+  { name: string; topology: string }
+> = {
+  comp2500: { name: '2500', topology: 'VCA · feed-forward · thrust sidechain' },
+  distressor: { name: 'Distress', topology: 'FET · feedback loop · British grit' },
+  avalon: { name: 'Avalon', topology: 'Opto · Class-A · over-easy ratio' },
+  ssl: { name: 'SSL', topology: 'Bus VCA · dual time-constant release' },
+}

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/params.ts
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/params.ts
@@ -3,7 +3,7 @@
  * Rust remains authoritative — this only keeps knobs and sanitization honest.
  */
 
-import { defaults, type CompModel, type ZcompParams } from './bridge'
+import { defaults, type ZcompParams } from './bridge'
 
 export type ParamSpec = {
   id: keyof ZcompParams
@@ -13,6 +13,8 @@ export type ParamSpec = {
   step: number
   unit: string
   defaultValue: number
+  /** Engraved end-of-travel legends on the knob collar. */
+  scale?: readonly [string, string]
 }
 
 export const PARAM_SPECS = {
@@ -24,6 +26,7 @@ export const PARAM_SPECS = {
     step: 0.1,
     unit: 'dB',
     defaultValue: defaults.thresholdDb,
+    scale: ['-60', '0'],
   },
   ratio: {
     id: 'ratio',
@@ -33,6 +36,7 @@ export const PARAM_SPECS = {
     step: 0.1,
     unit: ':1',
     defaultValue: defaults.ratio,
+    scale: ['1', '20'],
   },
   attackMs: {
     id: 'attackMs',
@@ -42,6 +46,7 @@ export const PARAM_SPECS = {
     step: 0.01,
     unit: 'ms',
     defaultValue: defaults.attackMs,
+    scale: ['0.01', '120'],
   },
   releaseMs: {
     id: 'releaseMs',
@@ -51,6 +56,7 @@ export const PARAM_SPECS = {
     step: 1,
     unit: 'ms',
     defaultValue: defaults.releaseMs,
+    scale: ['10', '2.5k'],
   },
   kneeDb: {
     id: 'kneeDb',
@@ -60,6 +66,7 @@ export const PARAM_SPECS = {
     step: 0.1,
     unit: 'dB',
     defaultValue: defaults.kneeDb,
+    scale: ['0', '24'],
   },
   makeupDb: {
     id: 'makeupDb',
@@ -69,6 +76,7 @@ export const PARAM_SPECS = {
     step: 0.1,
     unit: 'dB',
     defaultValue: defaults.makeupDb,
+    scale: ['-24', '+24'],
   },
   mix: {
     id: 'mix',
@@ -78,6 +86,7 @@ export const PARAM_SPECS = {
     step: 1,
     unit: '%',
     defaultValue: defaults.mix,
+    scale: ['0', '100'],
   },
   sidechainHpfHz: {
     id: 'sidechainHpfHz',
@@ -87,6 +96,7 @@ export const PARAM_SPECS = {
     step: 1,
     unit: 'Hz',
     defaultValue: defaults.sidechainHpfHz,
+    scale: ['20', '500'],
   },
   stereoLink: {
     id: 'stereoLink',
@@ -96,6 +106,7 @@ export const PARAM_SPECS = {
     step: 1,
     unit: '%',
     defaultValue: defaults.stereoLink,
+    scale: ['0', '100'],
   },
   color: {
     id: 'color',
@@ -105,32 +116,11 @@ export const PARAM_SPECS = {
     step: 1,
     unit: '%',
     defaultValue: defaults.color,
+    scale: ['0', '100'],
   },
 } as const satisfies Record<string, ParamSpec>
 
 /** Matches `CompModel` / `model_coeffs` character in Rust — engraved, not marketing. */
-export const MODEL_CIRCUIT: Record<
-  CompModel,
-  { title: string; topology: string }
-> = {
-  comp2500: {
-    title: '2500',
-    topology: 'VCA feed-forward · soft dual knee · THD colour',
-  },
-  distressor: {
-    title: 'Distress',
-    topology: 'Aggressive detector · British grit · hard ratios',
-  },
-  avalon: {
-    title: 'Avalon',
-    topology: 'Class-A optical feedback · slow musical recovery',
-  },
-  ssl: {
-    title: 'SSL',
-    topology: 'Bus glue · soft knee · program auto-release',
-  },
-}
-
 export function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value))
 }

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/presets.ts
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/presets.ts
@@ -21,7 +21,8 @@ export type FactoryPreset = {
 function preset(name: string, patch: Partial<ZcompParams>): FactoryPreset {
   return {
     name,
-    params: { ...defaults, ...patch, power: true },
+    // Sidechain listen is an audition mode, never something a preset leaves on.
+    params: { ...defaults, ...patch, power: true, scListen: false },
   }
 }
 
@@ -148,7 +149,8 @@ export function paramsMatch(left: ZcompParams, right: ZcompParams) {
   if (
     left.power !== right.power ||
     left.model !== right.model ||
-    left.autoRelease !== right.autoRelease
+    left.autoRelease !== right.autoRelease ||
+    left.scListen !== right.scListen
   ) {
     return false
   }
@@ -170,6 +172,7 @@ export function postAllParams(params: ZcompParams) {
   postParam('power', params.power ? 1 : 0)
   postParam('model', MODEL_WIRE[params.model as CompModel])
   postParam('autoRelease', params.autoRelease ? 1 : 0)
+  postParam('scListen', params.scListen ? 1 : 0)
   for (const key of NUMERIC_KEYS) {
     postParam(key, params[key] as number)
   }

--- a/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/styles.css
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/editor/src/styles.css
@@ -1,171 +1,107 @@
 /*
- * Z-Comp — multi-circuit compressor faceplate in the FA family language.
+ * Z-Comp — 2U multi-circuit dynamics processor faceplate.
  *
- * Craft comes from materials (painted metal, aluminum knobs, enamel VU), not
- * glow / glassmorphism. Switching Model retints the panel enamel and meter
- * face — the colour change stays, but it reads as different hardware skins.
+ * Character comes from materials: painted steel, brushed aluminum, enamel
+ * meter, engraved silkscreen, lamp-lit pushbuttons. No glow, no glass panes, no
+ * decorative gradients — every colour on this panel either is a material or
+ * reports a real value.
+ *
+ * Geometry contract
+ *   layout owner   .device (fixed design pixels, see device.ts)
+ *   scale owner    .stage via useDeviceScale — transform only, never layout
+ *   clip owner     .stage
+ *   state owner    App (params) / MeterBay + CurveDisplay (telemetry refs)
+ *   coordinates    design px inside .device; SVG user units inside each part
  */
 
-@property --panel-hi {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #2e343c;
-}
-@property --panel {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #1f242b;
-}
-@property --panel-lo {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #15191e;
-}
-@property --meter-face-hi {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #3a6fad;
-}
-@property --meter-face {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #2a5f9a;
-}
-@property --meter-face-lo {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #1a4574;
-}
-@property --meter-ink {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #f0f4f8;
-}
-@property --meter-hot {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #d4452e;
-}
-@property --btn-on {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #d8b35a;
-}
-@property --btn-on-ink {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #1a160e;
-}
-@property --focus {
-  syntax: '<color>';
-  inherits: true;
-  initial-value: #c9a24a;
-}
-
 :root {
-  --panel-hi: #2e343c;
-  --panel: #1f242b;
-  --panel-lo: #15191e;
-  --base: #0e1013;
-  --chassis: #0a0b0d;
+  /* Chassis and faceplate. */
+  --chassis: #08090b;
+  --panel-hi: #363d47;
+  --panel: #262c34;
+  --panel-lo: #171b21;
+  --panel-edge: #0d1013;
+  --inset: #0e1116;
+  --inset-deep: #07080b;
 
-  --inset: #101317;
-  --bezel: #4a5563;
-  --bezel-hi: #8a96a6;
-
-  --border: rgba(0, 0, 0, 0.55);
+  --border: rgba(0, 0, 0, 0.62);
   --border-hi: rgba(255, 255, 255, 0.1);
-  --border-soft: rgba(255, 255, 255, 0.06);
+  --border-soft: rgba(255, 255, 255, 0.055);
 
-  --engrave: #e6e9ee;
-  --engrave-muted: rgba(220, 226, 234, 0.58);
-  --readout: #c5ced8;
+  /* Silkscreen. */
+  --engrave: #e8ecf2;
+  --engrave-muted: rgba(224, 230, 238, 0.56);
+  --engrave-faint: rgba(224, 230, 238, 0.3);
+  --readout: #d6dee8;
 
-  --focus: #c9a24a;
-  --lamp: #e8a83a;
-  --lamp-soft: rgba(232, 168, 58, 0.4);
-  --clip: #c43a28;
+  /* Lamps and status. */
+  --lamp: #f0ad3c;
+  --lamp-soft: rgba(240, 173, 60, 0.4);
+  --clip: #d1402c;
+  --led-cool: #4fb08f;
+  --led-warm: #d8a84a;
 
-  --meter-face-hi: #3a6fad;
-  --meter-face: #2a5f9a;
-  --meter-face-lo: #1a4574;
-  --meter-ink: #f0f4f8;
-  --meter-hot: #d4452e;
+  /* Meter enamel — retinted per circuit. */
+  --meter-face-hi: #4076b4;
+  --meter-face: #2c6099;
+  --meter-face-lo: #17406e;
+  --meter-ink: #f2f6fa;
+  --meter-hot: #d8492f;
 
-  --btn: #1a1e24;
-  --btn-hi: #323942;
-  --btn-on: #d8b35a;
-  --btn-on-ink: #1a160e;
-  --drive: 0;
+  /* Circuit accent: lamp caps, value collars, curve trace. */
+  --accent: #8ec6e4;
+  --accent-ink: #0a1219;
 
-  --knob-lg: clamp(5.25rem, 10vw, 6.75rem);
-  --knob-sm: clamp(3rem, 5.5vw, 3.75rem);
-
-  --radius: 0.55rem;
-  --radius-sm: 0.4rem;
-  --radius-panel: 0.85rem;
-  --radius-well: 0.7rem;
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-
-  --skin-ease: 320ms cubic-bezier(0.22, 0.8, 0.28, 1);
+  --radius: 4px;
+  --radius-sm: 3px;
 
   color-scheme: dark;
 }
 
-/* Model skins — enamel + VU face, not neon accents. */
-.unit[data-model='ssl'] {
-  --panel-hi: #2e343c;
-  --panel: #1f242b;
-  --panel-lo: #15191e;
-  --meter-face-hi: #3a6fad;
-  --meter-face: #2a5f9a;
-  --meter-face-lo: #1a4574;
-  --btn-on: #7eb8d4;
-  --btn-on-ink: #0e1820;
-  --focus: #7eb8d4;
+/* Circuit skins. Each unit is a different painted panel and meter enamel. */
+.device[data-model='ssl'] {
+  --accent: #8ec6e4;
+  --accent-ink: #0a1219;
 }
 
-.unit[data-model='comp2500'] {
-  --panel-hi: #2a3338;
-  --panel: #1c2428;
-  --panel-lo: #13191c;
-  --meter-face-hi: #4aa8b4;
-  --meter-face: #2f8794;
-  --meter-face-lo: #1c5e68;
-  --btn-on: #5ec4d4;
-  --btn-on-ink: #0c1a1c;
-  --focus: #5ec4d4;
+.device[data-model='comp2500'] {
+  --panel-hi: #2f3b40;
+  --panel: #222c31;
+  --panel-lo: #151c20;
+  --meter-face-hi: #4bb0bb;
+  --meter-face: #2f8b98;
+  --meter-face-lo: #1a5a65;
+  --accent: #63cddb;
+  --accent-ink: #06171a;
+  --led-cool: #4ec0b4;
 }
 
-.unit[data-model='distressor'] {
-  --panel-hi: #3a322c;
-  --panel: #28221e;
-  --panel-lo: #1a1613;
-  --meter-face-hi: #e0b56a;
-  --meter-face: #c9923e;
-  --meter-face-lo: #8a6024;
-  --meter-ink: #1c140a;
-  --meter-hot: #8a2418;
-  --btn-on: #d4a05e;
-  --btn-on-ink: #1a1208;
-  --focus: #d4a05e;
+.device[data-model='distressor'] {
+  --panel-hi: #423a31;
+  --panel: #2e2822;
+  --panel-lo: #1d1915;
+  --meter-face-hi: #e4bd74;
+  --meter-face: #cd9743;
+  --meter-face-lo: #8c6326;
+  --meter-ink: #1d1509;
+  --meter-hot: #8f2517;
+  --accent: #e0a95f;
+  --accent-ink: #1a1206;
+  --led-warm: #e0a95f;
 }
 
-.unit[data-model='avalon'] {
-  --panel-hi: #2e3832;
-  --panel: #1f2823;
-  --panel-lo: #141a16;
-  --meter-face-hi: #8fbf96;
-  --meter-face: #6a9a72;
-  --meter-face-lo: #43664a;
-  --meter-ink: #101610;
-  --meter-hot: #8a3218;
-  --btn-on: #7eb68a;
-  --btn-on-ink: #0e1610;
-  --focus: #7eb68a;
+.device[data-model='avalon'] {
+  --panel-hi: #313d36;
+  --panel: #222b26;
+  --panel-lo: #151b17;
+  --meter-face-hi: #97c69d;
+  --meter-face: #6d9f76;
+  --meter-face-lo: #446a4c;
+  --meter-ink: #101710;
+  --meter-hot: #8d3419;
+  --accent: #8cc898;
+  --accent-ink: #08130b;
+  --led-cool: #7fc08c;
 }
 
 * {
@@ -176,9 +112,7 @@ html,
 body,
 #root {
   width: 100%;
-  min-width: 760px;
   height: 100%;
-  min-height: 460px;
   margin: 0;
   overflow: hidden;
 }
@@ -186,8 +120,9 @@ body,
 body {
   background: var(--chassis);
   color: var(--engrave);
-  font-family: 'Helvetica Neue', Helvetica, Arial, 'Segoe UI', sans-serif;
-  font-size: 12px;
+  font-family:
+    'IBM Plex Sans', 'Helvetica Neue', Helvetica, Arial, 'Segoe UI', sans-serif;
+  font-size: 13px;
   font-variant-numeric: tabular-nums;
   font-synthesis: none;
   line-height: 1.2;
@@ -214,710 +149,237 @@ button {
 button:focus-visible,
 [role='slider']:focus-visible,
 [role='switch']:focus-visible,
-[role='radio']:focus-visible {
-  outline: 2px solid var(--focus);
+[role='radio']:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
-.unit {
-  display: grid;
-  place-items: center;
+/* ── Stage and chassis ─────────────────────────────────────────────────── */
+
+.stage {
+  position: relative;
   width: 100%;
   height: 100%;
-  padding: var(--space-3);
-  background: var(--chassis);
-  transition:
-    --panel-hi var(--skin-ease),
-    --panel var(--skin-ease),
-    --panel-lo var(--skin-ease),
-    --meter-face-hi var(--skin-ease),
-    --meter-face var(--skin-ease),
-    --meter-face-lo var(--skin-ease),
-    --meter-ink var(--skin-ease),
-    --meter-hot var(--skin-ease),
-    --btn-on var(--skin-ease),
-    --btn-on-ink var(--skin-ease),
-    --focus var(--skin-ease);
+  overflow: hidden;
+  background:
+    radial-gradient(120% 90% at 50% 0%, #14171c 0%, var(--chassis) 70%);
 }
 
-.unit.is-skin-pulse .panel {
-  animation: skin-bloom 420ms cubic-bezier(0.2, 0.85, 0.25, 1);
+.device {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  transform-origin: 50% 50%;
+  filter: drop-shadow(0 18px 34px rgba(0, 0, 0, 0.55));
 }
 
-.unit.is-skin-pulse .meter-well {
-  animation: well-glow 420ms cubic-bezier(0.2, 0.85, 0.25, 1);
+.device.is-off .face > *:not(.head),
+.device.is-off .meter-bay,
+.device.is-off .curve {
+  filter: grayscale(0.5) brightness(0.72);
 }
 
-@keyframes skin-bloom {
-  0% {
-    filter: brightness(1);
-  }
-  35% {
-    filter: brightness(1.08);
-  }
-  100% {
-    filter: brightness(1);
-  }
-}
-
-@keyframes well-glow {
-  0% {
-    box-shadow:
-      inset 0 2px 5px rgba(0, 0, 0, 0.7),
-      0 1px 0 var(--border-hi);
-  }
-  40% {
-    box-shadow:
-      inset 0 2px 5px rgba(0, 0, 0, 0.7),
-      0 0 0 1px color-mix(in srgb, var(--btn-on) 35%, transparent),
-      0 0 18px color-mix(in srgb, var(--btn-on) 22%, transparent);
-  }
-  100% {
-    box-shadow:
-      inset 0 2px 5px rgba(0, 0, 0, 0.7),
-      0 1px 0 var(--border-hi);
-  }
-}
-
-.panel {
+/* Rack ears: folded steel with recessed hardware. */
+.ear {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
-  width: min(100%, 58rem);
-  padding: clamp(0.85rem, 2vw, 1.25rem);
+  justify-content: space-between;
+  align-items: center;
+  width: 36px;
+  padding: 22px 0;
   border: 1px solid var(--border);
-  border-radius: var(--radius-panel);
-  background: linear-gradient(
-    180deg,
-    var(--panel-hi) 0%,
-    var(--panel) 42%,
-    var(--panel-lo) 100%
-  );
+  background: linear-gradient(90deg, #22272e, #171b20 55%, #0f1216);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.ear:first-child {
+  border-radius: 5px 0 0 5px;
+}
+
+.ear:last-child {
+  border-radius: 0 5px 5px 0;
+}
+
+.screw {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.22), rgba(0, 0, 0, 0.5)),
+    #4a525c;
   box-shadow:
-    inset 0 1px 0 var(--border-hi),
-    0 14px 32px rgba(0, 0, 0, 0.5);
-  transition:
-    background var(--skin-ease),
-    filter 160ms ease,
-    opacity 160ms ease,
-    box-shadow var(--skin-ease);
+    inset 0 0 0 1px rgba(0, 0, 0, 0.5),
+    0 1px 0 rgba(255, 255, 255, 0.07);
+  position: relative;
 }
 
-.panel.is-off .knobs,
-.panel.is-off .extras,
-.panel.is-off .models .bank,
-.panel.is-off .meter-well {
-  filter: grayscale(0.45) brightness(0.78);
-  opacity: 0.62;
+.screw::after {
+  position: absolute;
+  inset: 3px 1.5px;
+  content: '';
+  border-top: 1.5px solid rgba(0, 0, 0, 0.6);
+  transform: rotate(35deg);
+  transform-origin: center;
 }
 
-.top {
+/* Painted faceplate: vertical paint gradient over a fine brushed grain. */
+.face {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+  padding: 14px 16px 16px;
+  border-top: 1px solid var(--border-hi);
+  border-bottom: 1px solid var(--panel-edge);
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.022) 0 1px,
+      rgba(0, 0, 0, 0.02) 1px 3px
+    ),
+    linear-gradient(
+      180deg,
+      var(--panel-hi) 0%,
+      var(--panel) 46%,
+      var(--panel-lo) 100%
+    );
+}
+
+/* ── Header ───────────────────────────────────────────────────────────── */
+
+.head {
   display: grid;
-  grid-template-columns: minmax(7.5rem, 11rem) minmax(0, 1fr) auto;
-  gap: var(--space-3);
-  align-items: start;
+  grid-template-columns: 206px minmax(0, 1fr) 208px 92px;
+  gap: 8px;
+  height: 202px;
 }
 
 .identity {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 10px;
   min-width: 0;
 }
 
-.wordmark {
+.nameplate {
   display: flex;
+  gap: 10px;
   align-items: center;
-  gap: 0.65rem;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, #2c333b, #1a1f25);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.09),
+    0 1px 2px rgba(0, 0, 0, 0.4);
 }
 
-.wordmark .z {
+.nameplate .mark {
   display: grid;
   place-items: center;
-  width: 2.1rem;
-  height: 2.1rem;
-  border: 1px solid var(--border-hi);
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(0, 0, 0, 0.6);
   border-radius: var(--radius-sm);
-  background: var(--inset);
-  color: var(--btn-on);
-  font-size: 0.95rem;
+  background: linear-gradient(180deg, #3b434d, #171b21);
+  color: var(--accent);
+  font-size: 17px;
   font-weight: 700;
-  letter-spacing: 0.02em;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
-  transition: color var(--skin-ease), border-color var(--skin-ease);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
-.wordmark strong {
-  display: block;
-  font-size: 0.95rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.wordmark em {
-  display: block;
-  margin-top: 0.15rem;
-  color: var(--engrave-muted);
-  font-size: 0.58rem;
-  font-style: normal;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-}
-
-.meter-bay {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 0.55rem;
-  align-items: stretch;
-  justify-self: center;
-  width: min(100%, 28rem);
-}
-
-.meter-well {
-  display: grid;
-  gap: 0.35rem;
-  justify-self: stretch;
-  width: 100%;
-  padding: 0.45rem;
-  border-radius: var(--radius-well);
-  background:
-    radial-gradient(
-      120% 80% at 50% 0%,
-      color-mix(in srgb, var(--btn-on) calc(var(--drive) * 18%), transparent),
-      transparent 62%
-    ),
-    #0c0e11;
-  box-shadow:
-    inset 0 2px 5px rgba(0, 0, 0, 0.7),
-    0 1px 0 var(--border-hi);
-  transition: box-shadow var(--skin-ease), background var(--skin-ease);
-}
-
-.gr-readout {
-  display: flex;
-  align-items: baseline;
-  gap: 0.35rem;
-  padding: 0 0.15rem 0.1rem;
-}
-
-.gr-readout span,
-.gr-readout small {
-  color: var(--engrave-muted);
-  font-size: 0.58rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.gr-readout output {
-  margin-left: auto;
-  color: var(--btn-on);
-  font-size: 1.05rem;
-  font-weight: 650;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.02em;
-  transition: color var(--skin-ease);
-}
-
-.io-strip {
-  display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
-  justify-items: center;
-  gap: 0.28rem;
-  min-width: 1.85rem;
-  padding: 0.15rem 0;
-}
-
-.io-label {
-  color: var(--engrave-muted);
-  font-size: 0.55rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.clip-led {
-  width: 0.38rem;
-  height: 0.38rem;
-  border-radius: 50%;
-  background: #2a3038;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.55);
-}
-
-.clip-led.is-on {
-  background: var(--clip);
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--clip) 40%, transparent),
-    0 0 8px color-mix(in srgb, var(--clip) 55%, transparent);
-}
-
-.io-ladder {
-  display: block;
-  width: 0.78rem;
-  height: 100%;
-  min-height: 6.8rem;
-  border-radius: 2px;
-  background: #07090c;
-  box-shadow:
-    inset 0 1px 3px rgba(0, 0, 0, 0.75),
-    0 1px 0 rgba(255, 255, 255, 0.04);
-}
-
-.io-strip output {
-  color: var(--engrave-muted);
-  font-size: 0.58rem;
-  font-weight: 650;
-  font-variant-numeric: tabular-nums;
-}
-
-.io-strip:has(.clip-led.is-on) output {
-  color: var(--clip);
-}
-
-.circuit {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  justify-content: center;
-  gap: 0.45rem 0.7rem;
-  margin: -0.15rem 0 0;
-  color: var(--engrave-muted);
-  font-size: 0.62rem;
-  font-weight: 650;
-  letter-spacing: 0.06em;
-  text-align: center;
-}
-
-.circuit strong {
-  color: var(--engrave);
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.circuit span {
-  color: var(--engrave-muted);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: none;
-}
-
-.link {
-  width: 0.45rem;
-  height: 0.45rem;
-  margin: 0.15rem auto 0;
-  border-radius: 50%;
-  background: #3a4550;
-}
-
-.link.is-live {
-  background: var(--btn-on);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--btn-on) 28%, transparent);
-  transition: background var(--skin-ease), box-shadow var(--skin-ease);
-}
-
-.knob.is-disabled {
-  opacity: 0.48;
-}
-
-.knob.is-disabled .cap {
-  cursor: default;
-  filter: none;
-}
-
-.knob.is-disabled .readout {
-  color: var(--btn-on);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.side {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  align-items: stretch;
-}
-
-.meter-switch {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.2rem;
-  padding: 0.18rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--inset);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.45);
-}
-
-.meter-switch button,
-.auto,
-.models .bank button {
-  height: 1.7rem;
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  background: var(--btn);
-  color: var(--engrave-muted);
-  font-size: 0.62rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
-  transition:
-    background var(--skin-ease),
-    color var(--skin-ease),
-    border-color var(--skin-ease),
-    box-shadow 140ms ease;
-}
-
-.meter-switch button.is-on,
-.auto.is-on,
-.models .bank button.is-on {
-  border-color: rgba(0, 0, 0, 0.35);
-  background: linear-gradient(180deg, color-mix(in srgb, var(--btn-on) 88%, #fff), var(--btn-on));
-  color: var(--btn-on-ink);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.35),
-    0 1px 2px rgba(0, 0, 0, 0.35);
-}
-
-.power {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  height: 2rem;
-  padding: 0 0.7rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: linear-gradient(180deg, var(--btn-hi), var(--btn));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
-}
-
-.power .lamp {
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 50%;
-  background: #2a2e34;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.6);
-}
-
-.power.is-on .lamp {
-  background: var(--lamp);
-  box-shadow:
-    0 0 0 2px var(--lamp-soft),
-    0 0 8px var(--lamp-soft);
-}
-
-.power .legend {
-  color: var(--engrave-muted);
-  font-size: 0.62rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.power.is-on .legend {
-  color: var(--engrave);
-}
-
-.models {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: var(--space-2);
-  align-items: center;
-}
-
-.bank-label {
-  color: var(--engrave-muted);
-  font-size: 0.62rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.bank {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.28rem;
-}
-
-.auto {
-  min-width: 5.2rem;
-  padding: 0 0.55rem;
-}
-
-.knobs,
-.extras {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: clamp(0.55rem, 1.8vw, 1.35rem);
-}
-
-.extras {
-  padding-top: var(--space-2);
-  border-top: 1px solid var(--border-soft);
-}
-
-/* Aluminum knob — FA-76 language */
-.knob {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.35rem;
+.nameplate .titles {
   min-width: 0;
 }
 
-.cap {
-  width: var(--knob-lg);
-  height: var(--knob-lg);
-  cursor: ns-resize;
-  touch-action: none;
-  outline: none;
-  filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.55));
-}
-
-.knob.sm .cap {
-  width: var(--knob-sm);
-  height: var(--knob-sm);
-}
-
-.cap.is-dragging {
-  filter: drop-shadow(0 5px 8px rgba(0, 0, 0, 0.65));
-}
-
-.cap svg {
+.nameplate strong {
   display: block;
-  width: 100%;
-  height: 100%;
-  overflow: visible;
-}
-
-.cap .rim {
-  stroke: rgba(0, 0, 0, 0.55);
-  stroke-width: 1;
-}
-
-.cap .body {
-  stroke: rgba(20, 24, 32, 0.7);
-  stroke-width: 1;
-}
-
-.cap .gloss {
-  fill: none;
-  stroke: rgba(255, 255, 255, 0.35);
-  stroke-width: 2;
-  stroke-linecap: round;
-}
-
-.cap .pointer {
-  fill: #11151c;
-}
-
-.plate {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.1rem;
-}
-
-.plate .name {
   color: var(--engrave);
-  font-size: 0.68rem;
+  font-size: 15px;
   font-weight: 700;
   letter-spacing: 0.14em;
-  text-align: center;
-  text-transform: uppercase;
+  text-shadow:
+    0 -1px 0 rgba(0, 0, 0, 0.65),
+    0 1px 0 rgba(255, 255, 255, 0.14);
 }
 
-.plate .readout {
-  padding: 0.08rem 0.35rem;
-  border-radius: var(--radius-sm);
-  color: var(--readout);
-  font-size: 0.78rem;
-  font-weight: 600;
-  cursor: text;
-}
-
-.plate .readout:hover {
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.plate .unit {
-  margin-left: 0.1rem;
-  font-size: 0.58rem;
-  opacity: 0.65;
-}
-
-.plate .input {
-  width: 3.6rem;
-  padding: 0.06rem 0.2rem;
-  border: 1px solid var(--border-hi);
-  border-radius: var(--radius-sm);
-  outline: none;
-  background: #0c1016;
-  color: var(--engrave);
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-align: center;
-  user-select: text;
-}
-
-/* VU face — FA cream/blue enamel family */
-.meter-bay.is-dark .meter {
-  filter: brightness(0.82) saturate(0.85);
-}
-
-.meter {
-  position: relative;
-}
-
-.meter svg {
+.nameplate em {
   display: block;
-  width: 100%;
-  height: auto;
-  border-radius: calc(var(--radius-sm) + 0.1rem);
+  margin-top: 3px;
   overflow: hidden;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 0 0 1px rgba(0, 0, 0, 0.55);
+  color: var(--engrave-muted);
+  font-size: 8.5px;
+  font-style: normal;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
-.meter .arc {
-  fill: none;
-  stroke: var(--meter-ink);
-  stroke-width: 1.4;
-  opacity: 0.55;
-  transition: stroke var(--skin-ease);
-}
-
-.meter .arc.hot {
-  stroke: var(--meter-hot);
-  opacity: 0.9;
-  stroke-width: 2.1;
-}
-
-.meter .tick {
-  stroke: var(--meter-ink);
-  stroke-width: 1.05;
-  stroke-linecap: round;
-  opacity: 0.75;
-  transition: stroke var(--skin-ease);
-}
-
-.meter .tick.major {
-  stroke-width: 1.65;
-  opacity: 0.9;
-}
-
-.meter .tick.hot {
-  stroke: var(--meter-hot);
-}
-
-.meter .label {
-  fill: var(--meter-ink);
-  font-size: 7.5px;
-  font-weight: 700;
-  text-anchor: middle;
-  dominant-baseline: middle;
-  transition: fill var(--skin-ease);
-}
-
-.meter .label.hot {
-  fill: var(--meter-hot);
-}
-
-.meter .needle {
-  stroke: #1a120c;
-  stroke-width: 1.7;
-  stroke-linecap: round;
-}
-
-.meter .hub {
-  fill: #2a241c;
-  stroke: #0c0a08;
-  stroke-width: 0.8;
-}
-
-.meter .caption {
-  fill: var(--meter-ink);
-  font-size: 7px;
+.maker {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 0 2px;
+  color: var(--engrave-faint);
+  font-size: 9px;
   font-weight: 700;
   letter-spacing: 0.18em;
-  text-anchor: middle;
-  opacity: 0.72;
-  transition: fill var(--skin-ease);
-}
-
-.meter .unit {
-  fill: var(--meter-ink);
-  font-size: 6.4px;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-anchor: middle;
-  opacity: 0.45;
-  transition: fill var(--skin-ease);
-}
-
-.meter .bezel {
-  fill: none;
-  stroke: rgba(0, 0, 0, 0.35);
-  stroke-width: 1.35;
-  pointer-events: none;
-}
-
-.meter .parked {
-  fill: var(--meter-ink);
-  font-size: 8px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-anchor: middle;
   text-transform: uppercase;
-  opacity: 0.45;
 }
 
-.clip-flag {
-  position: absolute;
-  right: 0.4rem;
-  bottom: 0.35rem;
-  height: 1.15rem;
-  padding: 0 0.4rem;
-  border: 1px solid rgba(0, 0, 0, 0.35);
-  border-radius: var(--radius-sm);
-  background: var(--clip);
-  color: #fff4ef;
-  font-size: 0.55rem;
-  font-weight: 750;
+.maker .link {
+  display: inline-flex;
+  gap: 5px;
+  align-items: center;
   letter-spacing: 0.1em;
-  cursor: pointer;
-  box-shadow: 0 0 10px color-mix(in srgb, var(--clip) 45%, transparent);
 }
 
-/* Preset stepper — FA-76 language */
+.maker .link i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #333c45;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.6);
+}
+
+.maker .link.is-live {
+  color: var(--engrave-muted);
+}
+
+.maker .link.is-live i {
+  background: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 26%, transparent);
+}
+
+/* Preset stepper. */
 .preset {
   display: grid;
-  grid-template-columns: 1.55rem minmax(0, 1fr) 1.55rem;
+  grid-template-columns: 24px minmax(0, 1fr) 24px;
   align-items: stretch;
-  width: 100%;
-  max-width: 11rem;
-  height: 1.85rem;
+  height: 28px;
   overflow: hidden;
-  border: 1px solid rgba(0, 0, 0, 0.55);
+  border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: linear-gradient(180deg, #2a3038, #161a20);
+  background: linear-gradient(180deg, #2b323a, #14181d);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 1px 2px rgba(0, 0, 0, 0.35);
+    0 1px 2px rgba(0, 0, 0, 0.4);
 }
 
 .preset .step {
   color: var(--engrave-muted);
-  font-size: 0.95rem;
+  font-size: 15px;
 }
 
 .preset .step:hover {
+  background: rgba(255, 255, 255, 0.05);
   color: var(--engrave);
-  background: rgba(255, 255, 255, 0.04);
 }
 
 .preset .select {
@@ -925,17 +387,16 @@ button:focus-visible,
   display: grid;
   place-items: center;
   min-width: 0;
-  border-inline: 1px solid rgba(0, 0, 0, 0.4);
+  border-inline: 1px solid rgba(0, 0, 0, 0.45);
 }
 
 .preset .select > span {
   overflow: hidden;
   width: 100%;
-  padding: 0 0.35rem;
-  color: var(--engrave);
-  font-size: 0.68rem;
-  font-weight: 650;
-  letter-spacing: 0.02em;
+  padding: 0 6px;
+  color: var(--readout);
+  font-size: 11px;
+  font-weight: 600;
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -946,30 +407,790 @@ button:focus-visible,
   inset: 0;
   width: 100%;
   border: 0;
-  opacity: 0;
+  background: #191d23;
+  color: var(--engrave);
   cursor: pointer;
-  background: #1a1e24;
+  opacity: 0;
+}
+
+/* Engraved signal-path legend: the chain the DSP actually runs. */
+.signal-path {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px 4px;
+  margin: 4px 0 0;
+  padding: 0 2px;
+  color: var(--engrave-faint);
+  font-size: 8.5px;
+  font-weight: 650;
+  letter-spacing: 0.12em;
+  list-style: none;
+  text-transform: uppercase;
+}
+
+.signal-path li:not(:last-child)::after {
+  margin-left: 6px;
+  content: '›';
+}
+
+/* ── Meter bay ────────────────────────────────────────────────────────── */
+
+.meter-bay {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 104px;
+  gap: 8px;
+  min-width: 0;
+}
+
+.movement {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.glass {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  padding: 7px;
+  border: 1px solid #0a0c0f;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #23282f, #0e1115);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.09),
+    inset 0 -2px 6px rgba(0, 0, 0, 0.65);
+}
+
+.glass.is-dark svg {
+  filter: brightness(0.8) saturate(0.8);
+}
+
+.glass svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.6);
+}
+
+.glass .screw {
+  position: absolute;
+  width: 7px;
+  height: 7px;
+}
+
+.glass .screw.tl {
+  top: 3px;
+  left: 3px;
+}
+.glass .screw.tr {
+  top: 3px;
+  right: 3px;
+}
+.glass .screw.bl {
+  bottom: 3px;
+  left: 3px;
+}
+.glass .screw.br {
+  bottom: 3px;
+  right: 3px;
+}
+
+.clip-flag {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  height: 17px;
+  padding: 0 6px;
+  border: 1px solid rgba(0, 0, 0, 0.4);
+  border-radius: var(--radius-sm);
+  background: var(--clip);
+  color: #fff2ee;
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: 0.12em;
+}
+
+/* Meter face internals. */
+.movement .arc {
+  fill: none;
+  stroke: var(--meter-ink);
+  stroke-width: 1.3;
+  opacity: 0.5;
+}
+
+.movement .arc.hot {
+  stroke: var(--meter-hot);
+  stroke-width: 2.2;
+  opacity: 0.92;
+}
+
+.movement .tick {
+  stroke: var(--meter-ink);
+  stroke-linecap: round;
+  stroke-width: 1;
+  opacity: 0.72;
+}
+
+.movement .tick.major {
+  stroke-width: 1.7;
+  opacity: 0.92;
+}
+
+.movement .tick.hot {
+  stroke: var(--meter-hot);
+}
+
+.movement .label {
+  fill: var(--meter-ink);
+  dominant-baseline: middle;
+  font-size: 8px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.movement .label.hot {
+  fill: var(--meter-hot);
+}
+
+.movement .caption {
+  fill: var(--meter-ink);
+  font-size: 7.5px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  opacity: 0.75;
+  text-anchor: middle;
+}
+
+.movement .unit {
+  fill: var(--meter-ink);
+  font-size: 7px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  opacity: 0.5;
+  text-anchor: middle;
+}
+
+.movement .brand {
+  fill: var(--meter-ink);
+  font-size: 5.6px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  opacity: 0.42;
+}
+
+.movement .needle {
+  fill: #16100a;
+}
+
+.movement .parked {
+  fill: var(--meter-ink);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  opacity: 0.42;
+  text-anchor: middle;
+  text-transform: uppercase;
+}
+
+/* Reduction readout below the movement. */
+.gr-strip {
+  display: flex;
+  gap: 7px;
+  align-items: baseline;
+  height: 26px;
+  padding: 0 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--inset-deep);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.7);
+}
+
+.gr-strip .tag,
+.gr-strip small {
+  color: var(--engrave-faint);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.gr-strip output {
+  margin-left: auto;
+  color: var(--accent);
+  font-size: 16px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+/* IN / OUT LED ladders with an engraved dB scale between them. */
+.ladders {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 6px;
+  min-width: 0;
+}
+
+.io {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 4px;
+  justify-items: center;
+}
+
+.io-tag {
+  color: var(--engrave-muted);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.clip-led {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #2b3138;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+.clip-led.is-on {
+  background: var(--clip);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--clip) 40%, transparent);
+}
+
+.ladder {
+  display: block;
+  width: 14px;
+  height: 100%;
+  min-height: 0;
+  border-radius: 2px;
+  background: var(--inset-deep);
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.7),
+    0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.io output {
+  color: var(--engrave-muted);
+  font-size: 9.5px;
+  font-weight: 650;
+}
+
+.io:has(.clip-led.is-on) output {
+  color: var(--clip);
+}
+
+.io-scale {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 22px 0 20px;
+  color: var(--engrave-faint);
+  font-size: 7.5px;
+  font-weight: 650;
+  text-align: center;
+}
+
+/* ── Master column ────────────────────────────────────────────────────── */
+
+.master {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.switchbank {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--inset);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.55);
+}
+
+.switchbank button {
+  height: 22px;
+  border: 1px solid rgba(0, 0, 0, 0.45);
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, #333b45, #1c2128);
+  color: var(--engrave-muted);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.switchbank button.is-on {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent) 82%, #fff),
+    var(--accent)
+  );
+  color: var(--accent-ink);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.rocker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+  justify-content: center;
+  height: 62px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, #10141a 0%, #2a313a 46%, #1a1f26 100%);
+  box-shadow:
+    inset 0 2px 4px rgba(0, 0, 0, 0.55),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.rocker .lamp {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #2a2f36;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.65);
+}
+
+.rocker.is-on {
+  background: linear-gradient(180deg, #2c343d 0%, #1b2027 54%, #10141a 100%);
+}
+
+.rocker.is-on .lamp {
+  background: var(--lamp);
+  box-shadow:
+    0 0 0 2px var(--lamp-soft),
+    0 0 7px var(--lamp-soft);
+}
+
+.rocker .legend {
+  color: var(--engrave-muted);
+  font-size: 9.5px;
+  font-weight: 750;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.rocker.is-on .legend {
   color: var(--engrave);
 }
 
-@media (max-width: 880px) {
-  .top {
-    grid-template-columns: 1fr;
-    justify-items: center;
-  }
+.master-tag {
+  color: var(--engrave-faint);
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-align: center;
+  text-transform: uppercase;
+}
 
-  .identity,
-  .side,
-  .meter-bay {
-    width: min(100%, 28rem);
-  }
+/* ── Circuit bay ──────────────────────────────────────────────────────── */
 
-  .models {
-    grid-template-columns: 1fr;
-    justify-items: stretch;
-  }
+.circuit {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  height: 46px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, #1d222a, #12161b);
+  box-shadow:
+    inset 0 1px 0 var(--border-soft),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.45);
+}
 
-  .auto {
-    width: 100%;
+.bay-label,
+.modes {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.bay-label {
+  color: var(--engrave-muted);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.bank {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 5px;
+}
+
+.lamp-button {
+  display: inline-flex;
+  gap: 7px;
+  align-items: center;
+  height: 26px;
+  padding: 0 11px;
+  border: 1px solid rgba(0, 0, 0, 0.55);
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, #39414c, #1d222a);
+  color: var(--engrave-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.lamp-button i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #23282f;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.7);
+}
+
+.lamp-button:hover {
+  color: var(--engrave);
+}
+
+.lamp-button.is-on {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent) 84%, #fff),
+    var(--accent)
+  );
+  color: var(--accent-ink);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.42),
+    0 1px 2px rgba(0, 0, 0, 0.42);
+}
+
+.lamp-button.is-on i {
+  background: var(--accent-ink);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.35);
+}
+
+/* Sidechain listen is an audition mode: it reads as armed, not as selected. */
+.lamp-button.alert.is-on {
+  background: linear-gradient(180deg, #f5c163, var(--lamp));
+  color: #201502;
+}
+
+.lamp-button.alert.is-on i {
+  background: #201502;
+}
+
+.engraved {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.engraved strong {
+  color: var(--engrave);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.engraved span {
+  overflow: hidden;
+  color: var(--engrave-faint);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-overflow: ellipsis;
+}
+
+/* ── Control rows ─────────────────────────────────────────────────────── */
+
+.controls {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 6px;
+  justify-content: space-evenly;
+  min-height: 0;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  align-items: start;
+  justify-items: center;
+}
+
+.row.trim {
+  padding-top: 8px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.knob {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  align-items: center;
+  min-width: 0;
+}
+
+.knob .cap {
+  position: relative;
+  width: 104px;
+  height: 104px;
+  cursor: ns-resize;
+  outline: none;
+  touch-action: none;
+  filter: drop-shadow(0 4px 5px rgba(0, 0, 0, 0.5));
+}
+
+.knob.sm .cap {
+  width: 70px;
+  height: 70px;
+}
+
+.knob .cap.is-dragging {
+  filter: drop-shadow(0 6px 8px rgba(0, 0, 0, 0.6));
+}
+
+.knob .cap svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.knob.is-disabled {
+  opacity: 0.5;
+}
+
+.knob.is-disabled .cap {
+  cursor: default;
+}
+
+/* Engraved collar. */
+.knob .collar-track {
+  fill: none;
+  stroke: rgba(0, 0, 0, 0.55);
+  stroke-linecap: round;
+  stroke-width: 3.4;
+}
+
+.knob .collar-value {
+  fill: none;
+  stroke: var(--accent);
+  stroke-linecap: round;
+  stroke-width: 3.4;
+  opacity: 0.9;
+}
+
+.knob .tick {
+  stroke: var(--engrave-faint);
+  stroke-linecap: round;
+  stroke-width: 1.2;
+}
+
+.knob .tick.major {
+  stroke: var(--engrave-muted);
+  stroke-width: 1.8;
+}
+
+/* Machined body. */
+.knob .skirt {
+  stroke: rgba(0, 0, 0, 0.65);
+  stroke-width: 1;
+}
+
+.knob .flutes line {
+  stroke: rgba(0, 0, 0, 0.42);
+  stroke-width: 0.9;
+}
+
+.knob .face {
+  stroke: rgba(10, 13, 18, 0.75);
+  stroke-width: 1;
+}
+
+.knob .pointer {
+  fill: #0f1319;
+}
+
+.knob .hub {
+  fill: rgba(255, 255, 255, 0.16);
+}
+
+.knob .scale-min,
+.knob .scale-max {
+  position: absolute;
+  bottom: 4px;
+  color: var(--engrave-faint);
+  font-size: 8px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+}
+
+.knob .scale-min {
+  left: -1px;
+}
+
+.knob .scale-max {
+  right: -1px;
+}
+
+.knob .legend {
+  color: var(--engrave);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  text-shadow:
+    0 -1px 0 rgba(0, 0, 0, 0.6),
+    0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+/* Recessed value plate under each knob. */
+.knob .plate {
+  min-width: 66px;
+  height: 20px;
+  padding: 0 8px;
+  border: 1px solid rgba(0, 0, 0, 0.55);
+  border-radius: var(--radius-sm);
+  background: var(--inset-deep);
+  color: var(--readout);
+  font-size: 11.5px;
+  font-weight: 650;
+  cursor: text;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.7);
+}
+
+.knob .plate:hover:not(:disabled) {
+  color: #fff;
+}
+
+.knob .plate:disabled {
+  cursor: default;
+}
+
+.knob .plate .unit {
+  margin-left: 3px;
+  color: var(--engrave-faint);
+  font-size: 9px;
+}
+
+.knob .plate .auto {
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.knob .entry {
+  width: 66px;
+  height: 20px;
+  padding: 0 6px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  outline: none;
+  background: #0a0e13;
+  color: var(--engrave);
+  font-size: 11.5px;
+  font-weight: 650;
+  text-align: center;
+  user-select: text;
+}
+
+/* ── Transfer-curve window ────────────────────────────────────────────── */
+
+.curve {
+  display: flex;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: linear-gradient(180deg, #20252c, #0e1116);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -2px 5px rgba(0, 0, 0, 0.6);
+}
+
+.curve svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.curve .screen {
+  fill: #070a0d;
+  stroke: rgba(0, 0, 0, 0.8);
+}
+
+.curve .grid {
+  stroke: rgba(255, 255, 255, 0.07);
+  stroke-width: 0.6;
+}
+
+.curve .grid.edge {
+  stroke: rgba(255, 255, 255, 0.14);
+}
+
+.curve .unity {
+  stroke: rgba(255, 255, 255, 0.18);
+  stroke-dasharray: 2 3;
+  stroke-width: 0.8;
+}
+
+.curve .threshold {
+  stroke: var(--engrave-faint);
+  stroke-dasharray: 3 3;
+  stroke-width: 0.8;
+}
+
+.curve .transfer {
+  fill: none;
+  stroke: var(--accent);
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.curve .trace {
+  stroke: color-mix(in srgb, var(--accent) 45%, transparent);
+  stroke-width: 0.8;
+}
+
+.curve .dot {
+  fill: #fff;
+  stroke: var(--accent);
+  stroke-width: 1.4;
+}
+
+.curve .axis {
+  fill: var(--engrave-faint);
+  font-size: 7px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+}
+
+.curve .caption {
+  fill: var(--engrave-muted);
+  font-size: 7px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .device {
+    transition: none;
   }
 }

--- a/crates/BuiltinAudioPlugins/crates/zcomp/src/dsp.rs
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/src/dsp.rs
@@ -1,0 +1,1024 @@
+//! Z-Comp gain-cell algorithm.
+//!
+//! One realtime-safe cell serves all four circuit models. Everything that
+//! differs between them is a coefficient resolved on the control thread by
+//! [`model_coeffs`]; the per-sample path below never branches on the model,
+//! allocates, locks, formats, or calls into the host.
+//!
+//! # Signal flow (per sample, per channel)
+//!
+//! ```txt
+//! in ──┬───────────────────────────────────────────────► gain cell ─► colour ─► out
+//!      │                                                    ▲
+//!      └─► detector tap ─► topology mix (FF/FB) ─► SC HPF ──┤
+//!                                    │                      │
+//!                                    ├─► thrust tilt        │
+//!                                    ├─► peak / RMS blend   │
+//!                                    ├─► static curve (dB)  │
+//!                                    └─► ballistics ────────┘
+//! ```
+//!
+//! Four design decisions carry most of the character:
+//!
+//! 1. **One smoothing stage.** The detector produces a level, the static curve
+//!    turns it into a target reduction in dB, and exactly one attack/release
+//!    stage follows that target. Smoothing the level *and* the reduction with
+//!    the same constants — the previous shape here — makes the effective attack
+//!    roughly twice the dialled value and rounds off every transient edge.
+//! 2. **Program-dependent release.** Release interpolates between a fast and a
+//!    slow time constant using a slow integrator of the reduction itself
+//!    (`memory_db`). That is what the SSL auto-release network, the optical
+//!    cell's LDR memory, and the Distressor's second stage all do physically.
+//! 3. **Real feedback topology.** Feedback models detect the cell's own output
+//!    (one sample old), not the input scaled by the previous reduction. The
+//!    loop gain is what makes optical/FET units ease into their ratio.
+//! 4. **Anti-aliased colour.** The harmonic stage is a soft clipper evaluated
+//!    through its first antiderivative (ADAA), so drive adds harmonics instead
+//!    of folding them back down the spectrum.
+
+use builtin_dsp_core::{clamp, db_to_linear, flush_denormal, linear_to_db, mix, time_constant};
+
+use crate::{CompModel, Params};
+
+/// Reduction depth (dB) at which program-dependent release reaches its slow
+/// end. Chosen so bus-glue amounts (2–4 dB) stay quick and limiting amounts
+/// (10 dB+) breathe.
+pub const PROGRAM_REFERENCE_DB: f32 = 10.0;
+
+/// Time constant of the reduction integrator that drives program dependence.
+const MEMORY_SECONDS: f32 = 0.320;
+
+/// Fixed tilt frequency of the 2500-style "thrust" sidechain shelf.
+const THRUST_HZ: f32 = 170.0;
+
+/// Gain/mix smoothing so a moved knob cannot step the output.
+const SMOOTH_SECONDS: f32 = 0.020;
+
+/// Amplitude (≈ −10 dBFS) the colour stage is level-matched at, so Colour
+/// changes the harmonic content and not the fader.
+const COLOUR_MATCH_LEVEL: f32 = 0.32;
+
+/// Below this sidechain cutoff the filter is bypassed instead of running at a
+/// frequency that changes nothing but costs state.
+const HPF_BYPASS_HZ: f32 = 20.5;
+
+/// Resolved runtime coefficients for the selected circuit model.
+///
+/// Times are seconds, levels dB, blends 0..1. Everything here is computed off
+/// the audio thread in [`model_coeffs`].
+#[derive(Debug, Clone, Copy)]
+pub struct ModelCoeffs {
+    pub threshold_db: f32,
+    pub ratio: f32,
+    pub knee_db: f32,
+    /// Overshoot (dB) at which the cell reaches half of its dialled ratio.
+    /// `0` = fixed ratio, `> 0` = optical "over-easy" rise.
+    pub over_easy_db: f32,
+    pub attack_sec: f32,
+    pub release_fast_sec: f32,
+    pub release_slow_sec: f32,
+    /// How far program dependence may push release toward the slow constant.
+    pub program_depth: f32,
+    /// Extra program dependence applied when Auto Release is engaged.
+    pub program_auto_bias: f32,
+    /// Detector averaging window; sets how much the RMS half of the blend
+    /// smooths.
+    pub rms_window_sec: f32,
+    /// Detector blend, 0 = peak, 1 = RMS.
+    pub rms_blend: f32,
+    /// 0 = pure feed-forward, 1 = pure feedback.
+    pub feedback: f32,
+    /// Sidechain sensitivity multiplier.
+    pub detector_boost: f32,
+    /// Amount of the fixed high-pass tilt mixed into the sidechain.
+    pub thrust: f32,
+    /// Harmonic drive after the gain cell.
+    pub drive: f32,
+    /// 0 = symmetric (odd harmonics, FET/VCA), 1 = fully biased (even
+    /// harmonics, Class-A).
+    pub asymmetry: f32,
+}
+
+/// Map the user-facing parameters onto one model's circuit constants.
+///
+/// Control thread only: this is the single place a model's character lives.
+pub fn model_coeffs(params: &Params) -> ModelCoeffs {
+    let color = clamp(params.color, 0.0, 100.0) / 100.0;
+    let ratio = params.ratio.max(1.0);
+    let knee = params.knee_db.max(0.0);
+    let attack_ms = params.attack_ms.max(0.01);
+    let release_ms = params.release_ms.max(10.0);
+    let auto = params.auto_release;
+
+    match params.model {
+        // API 2500 style: feed-forward VCA, wide soft knee, thrust-shaped
+        // sidechain, low-order THD from the output amp.
+        CompModel::Comp2500 => ModelCoeffs {
+            threshold_db: params.threshold_db,
+            ratio,
+            knee_db: (knee + 3.0 + color * 3.0).min(24.0),
+            over_easy_db: 0.0,
+            attack_sec: (attack_ms * 0.001).clamp(0.0002, 0.080),
+            release_fast_sec: (release_ms * 0.001).clamp(0.020, 1.200),
+            release_slow_sec: (release_ms * 0.001 * 2.6).clamp(0.060, 2.400),
+            program_depth: 0.45,
+            program_auto_bias: if auto { 0.25 } else { 0.0 },
+            rms_window_sec: 0.010,
+            rms_blend: 0.30,
+            feedback: 0.0,
+            detector_boost: 1.0,
+            // Thrust is the 2500's own sidechain tilt, so it tracks Colour.
+            thrust: color * 0.85,
+            drive: color * 0.45,
+            asymmetry: 0.15,
+        },
+
+        // Distressor style: FET cell in a feedback loop, hard ratios, fast
+        // detector, British-mode grit as Colour rises.
+        CompModel::Distressor => {
+            let british = color;
+            ModelCoeffs {
+                threshold_db: params.threshold_db - british * 1.5,
+                ratio: (ratio * (1.0 + british * 0.5)).min(40.0),
+                knee_db: (knee * (1.0 - british * 0.6)).max(0.3),
+                over_easy_db: 0.0,
+                attack_sec: (attack_ms * 0.001 * (1.0 - british * 0.35)).clamp(0.00005, 0.050),
+                release_fast_sec: (release_ms * 0.001).clamp(0.010, 1.500),
+                release_slow_sec: (release_ms * 0.001 * (3.0 + british * 2.0)).clamp(0.040, 3.000),
+                program_depth: 0.55,
+                program_auto_bias: if auto { 0.30 } else { 0.0 },
+                rms_window_sec: 0.003,
+                rms_blend: 0.08,
+                feedback: 0.35 + british * 0.20,
+                detector_boost: 1.15 + british * 0.85,
+                thrust: british * 0.35,
+                drive: 0.20 + british * 0.95,
+                asymmetry: 0.05,
+            }
+        }
+
+        // Avalon style: Class-A optical leveller. The LDR eases into its ratio
+        // and remembers how hard it has been working, so release is the slowest
+        // and the most program dependent of the four.
+        CompModel::Avalon => ModelCoeffs {
+            threshold_db: params.threshold_db,
+            ratio: (2.0 + (ratio - 1.0) * 0.55).clamp(1.5, 8.0),
+            knee_db: (knee + 6.0 + color * 4.0).min(24.0),
+            // Optical cells only reach their nominal ratio well past the knee.
+            over_easy_db: 8.0,
+            attack_sec: (attack_ms * 0.001).clamp(0.008, 0.080),
+            release_fast_sec: (release_ms * 0.001).clamp(0.060, 1.800),
+            release_slow_sec: (release_ms * 0.001 * 4.0 + 0.8 + color * 1.2).clamp(0.400, 5.000),
+            program_depth: 0.85,
+            program_auto_bias: if auto { 0.35 } else { 0.0 },
+            rms_window_sec: 0.025,
+            rms_blend: 0.60,
+            feedback: 0.85,
+            detector_boost: 1.0,
+            thrust: 0.0,
+            drive: color * 0.30,
+            // Class-A stage is single-ended: even harmonics dominate.
+            asymmetry: 0.85,
+        },
+
+        // SSL bus style: gentle VCA glue with the dual time-constant automatic
+        // release network.
+        CompModel::Ssl => ModelCoeffs {
+            threshold_db: params.threshold_db,
+            ratio: ratio.clamp(1.5, 10.0),
+            knee_db: (knee + 3.0).clamp(2.0, 18.0),
+            over_easy_db: 0.0,
+            attack_sec: (attack_ms * 0.001).clamp(0.0001, 0.030),
+            release_fast_sec: if auto {
+                0.100
+            } else {
+                (release_ms * 0.001).clamp(0.050, 1.200)
+            },
+            release_slow_sec: if auto {
+                1.200 + color * 0.400
+            } else {
+                (release_ms * 0.001 * 2.4).clamp(0.100, 2.400)
+            },
+            program_depth: 0.60,
+            program_auto_bias: if auto { 0.40 } else { 0.0 },
+            rms_window_sec: 0.015,
+            rms_blend: 0.40 + color * 0.15,
+            feedback: 0.10,
+            detector_boost: 1.0,
+            thrust: color * 0.25,
+            drive: color * 0.30,
+            asymmetry: 0.25,
+        },
+    }
+}
+
+/// Shared coefficients for a 12 dB/oct topology-preserving state-variable
+/// high-pass. TPT form stays stable when the cutoff is changed while running.
+#[derive(Debug, Clone, Copy)]
+struct HpfCoeffs {
+    active: bool,
+    k: f32,
+    a1: f32,
+    a2: f32,
+    a3: f32,
+}
+
+impl HpfCoeffs {
+    fn bypass() -> Self {
+        Self {
+            active: false,
+            k: 0.0,
+            a1: 0.0,
+            a2: 0.0,
+            a3: 0.0,
+        }
+    }
+
+    fn new(sample_rate: f32, cutoff_hz: f32) -> Self {
+        if cutoff_hz <= HPF_BYPASS_HZ {
+            return Self::bypass();
+        }
+        let nyquist_limit = sample_rate * 0.45;
+        let fc = clamp(
+            cutoff_hz,
+            HPF_BYPASS_HZ,
+            nyquist_limit.max(HPF_BYPASS_HZ + 1.0),
+        );
+        let g = (std::f32::consts::PI * fc / sample_rate).tan();
+        // Butterworth Q keeps the corner flat — a sidechain filter that rings
+        // would pump on its own resonance.
+        let k = std::f32::consts::SQRT_2;
+        let a1 = 1.0 / (1.0 + g * (g + k));
+        Self {
+            active: true,
+            k,
+            a1,
+            a2: g * a1,
+            a3: g * (g * a1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct HpfState {
+    ic1: f32,
+    ic2: f32,
+}
+
+impl HpfState {
+    #[inline]
+    fn process(&mut self, coeffs: &HpfCoeffs, input: f32) -> f32 {
+        if !coeffs.active {
+            return input;
+        }
+        let v3 = input - self.ic2;
+        let v1 = coeffs.a1 * self.ic1 + coeffs.a2 * v3;
+        let v2 = self.ic2 + coeffs.a2 * self.ic1 + coeffs.a3 * v3;
+        self.ic1 = flush_denormal(2.0 * v1 - self.ic1);
+        self.ic2 = flush_denormal(2.0 * v2 - self.ic2);
+        input - coeffs.k * v1 - v2
+    }
+
+    fn reset(&mut self) {
+        self.ic1 = 0.0;
+        self.ic2 = 0.0;
+    }
+}
+
+/// First-order high-pass used for the thrust tilt, kept separate from the
+/// user's sidechain filter so the two are independently auditable.
+#[derive(Debug, Clone, Copy, Default)]
+struct TiltState {
+    x1: f32,
+    y1: f32,
+}
+
+impl TiltState {
+    #[inline]
+    fn process(&mut self, coeff: f32, input: f32) -> f32 {
+        let y = coeff * (self.y1 + input - self.x1);
+        self.x1 = input;
+        self.y1 = flush_denormal(y);
+        self.y1
+    }
+
+    fn reset(&mut self) {
+        self.x1 = 0.0;
+        self.y1 = 0.0;
+    }
+}
+
+/// Cubic soft clipper, the shape every analogue output stage approaches.
+#[inline]
+fn clip_shape(x: f32) -> f32 {
+    if x >= 1.0 {
+        2.0 / 3.0
+    } else if x <= -1.0 {
+        -2.0 / 3.0
+    } else {
+        x - (x * x * x) / 3.0
+    }
+}
+
+/// Antiderivative of [`clip_shape`], used for first-order ADAA.
+#[inline]
+fn clip_antiderivative(x: f32) -> f32 {
+    let a = x.abs();
+    if a >= 1.0 {
+        5.0 / 12.0 + (2.0 / 3.0) * (a - 1.0)
+    } else {
+        let x2 = x * x;
+        0.5 * x2 - (x2 * x2) / 12.0
+    }
+}
+
+/// Anti-aliased saturator state (one per channel).
+///
+/// Naive waveshaping folds every harmonic above Nyquist back into the band.
+/// Evaluating the shaper as the average of its antiderivative over the sample
+/// interval suppresses that fold-back by roughly 10–20 dB for the cost of one
+/// extra evaluation and two stored floats.
+#[derive(Debug, Clone, Copy, Default)]
+struct SaturatorState {
+    last_x: f32,
+    last_anti: f32,
+}
+
+impl SaturatorState {
+    #[inline]
+    fn process(&mut self, x: f32) -> f32 {
+        let anti = clip_antiderivative(x);
+        let dx = x - self.last_x;
+        let y = if dx.abs() > 1.0e-4 {
+            (anti - self.last_anti) / dx
+        } else {
+            clip_shape(0.5 * (x + self.last_x))
+        };
+        self.last_x = x;
+        self.last_anti = anti;
+        y
+    }
+
+    fn reset(&mut self) {
+        self.last_x = 0.0;
+        self.last_anti = 0.0;
+    }
+}
+
+/// What the cell produced for one stereo frame.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CellFrame {
+    pub left: f32,
+    pub right: f32,
+    /// Post-filter sidechain, so the editor's Sidechain Listen switch auditions
+    /// exactly what the detector hears.
+    pub sidechain_left: f32,
+    pub sidechain_right: f32,
+}
+
+/// Stereo gain cell shared by every model.
+#[derive(Debug, Clone)]
+pub struct GainCell {
+    sample_rate: f32,
+
+    // Static curve.
+    threshold_db: f32,
+    ratio: f32,
+    knee_db: f32,
+    over_easy_db: f32,
+
+    // Ballistics.
+    attack_coeff: f32,
+    release_fast_coeff: f32,
+    release_slow_coeff: f32,
+    program_depth: f32,
+    program_base: f32,
+    memory_coeff: f32,
+
+    // Detector.
+    rms_coeff: f32,
+    rms_blend: f32,
+    feedback: f32,
+    detector_boost: f32,
+    thrust: f32,
+    thrust_coeff: f32,
+    hpf: HpfCoeffs,
+    stereo_link: f32,
+
+    // Colour.
+    drive_gain: f32,
+    drive_bias: f32,
+    drive_bias_offset: f32,
+    drive_norm: f32,
+    drive_mix: f32,
+
+    // Per-channel state.
+    hpf_state: [HpfState; 2],
+    tilt_state: [TiltState; 2],
+    saturator: [SaturatorState; 2],
+    mean_square: [f32; 2],
+    gr_db: [f32; 2],
+    memory_db: [f32; 2],
+    feedback_sample: [f32; 2],
+}
+
+impl GainCell {
+    pub fn new(sample_rate: f32, coeffs: ModelCoeffs, sidechain_hz: f32, stereo_link: f32) -> Self {
+        let sr = sample_rate.max(1.0);
+        let mut cell = Self {
+            sample_rate: sr,
+            threshold_db: -18.0,
+            ratio: 4.0,
+            knee_db: 6.0,
+            over_easy_db: 0.0,
+            attack_coeff: 0.0,
+            release_fast_coeff: 0.0,
+            release_slow_coeff: 0.0,
+            program_depth: 0.0,
+            program_base: 0.0,
+            memory_coeff: time_constant(sr, MEMORY_SECONDS),
+            rms_coeff: time_constant(sr, 0.010),
+            rms_blend: 0.0,
+            feedback: 0.0,
+            detector_boost: 1.0,
+            thrust: 0.0,
+            thrust_coeff: (-2.0 * std::f32::consts::PI * THRUST_HZ / sr).exp(),
+            hpf: HpfCoeffs::bypass(),
+            stereo_link: 1.0,
+            drive_gain: 1.0,
+            drive_bias: 0.0,
+            drive_bias_offset: 0.0,
+            drive_norm: 1.0,
+            drive_mix: 0.0,
+            hpf_state: [HpfState::default(); 2],
+            tilt_state: [TiltState::default(); 2],
+            saturator: [SaturatorState::default(); 2],
+            mean_square: [0.0; 2],
+            gr_db: [0.0; 2],
+            memory_db: [0.0; 2],
+            feedback_sample: [0.0; 2],
+        };
+        cell.set_model(coeffs, sidechain_hz, stereo_link);
+        cell
+    }
+
+    pub fn set_sample_rate(&mut self, sample_rate: f32) {
+        self.sample_rate = sample_rate.max(1.0);
+        self.memory_coeff = time_constant(self.sample_rate, MEMORY_SECONDS);
+        self.thrust_coeff = (-2.0 * std::f32::consts::PI * THRUST_HZ / self.sample_rate).exp();
+    }
+
+    /// Resolve one model's constants into per-sample coefficients.
+    ///
+    /// Control thread only. Every `exp`, `tan`, and division in the algorithm
+    /// happens here so the audio path stays arithmetic.
+    pub fn set_model(&mut self, coeffs: ModelCoeffs, sidechain_hz: f32, stereo_link: f32) {
+        let sr = self.sample_rate;
+
+        self.threshold_db = clamp(coeffs.threshold_db, -80.0, 12.0);
+        self.ratio = coeffs.ratio.max(1.0);
+        self.knee_db = coeffs.knee_db.max(0.0);
+        self.over_easy_db = coeffs.over_easy_db.max(0.0);
+
+        self.attack_coeff = time_constant(sr, coeffs.attack_sec);
+        let fast = coeffs.release_fast_sec.max(0.001);
+        let slow = coeffs.release_slow_sec.max(fast);
+        self.release_fast_coeff = time_constant(sr, fast);
+        self.release_slow_coeff = time_constant(sr, slow);
+        self.program_depth = clamp(coeffs.program_depth, 0.0, 1.0);
+        self.program_base = clamp(coeffs.program_auto_bias, 0.0, 1.0);
+
+        self.rms_coeff = time_constant(sr, coeffs.rms_window_sec.max(0.0005));
+        self.rms_blend = clamp(coeffs.rms_blend, 0.0, 1.0);
+        self.feedback = clamp(coeffs.feedback, 0.0, 0.95);
+        self.detector_boost = coeffs.detector_boost.max(0.1);
+        self.thrust = clamp(coeffs.thrust, 0.0, 1.0);
+        self.hpf = HpfCoeffs::new(sr, sidechain_hz);
+        self.stereo_link = clamp(stereo_link, 0.0, 100.0) / 100.0;
+
+        let drive = coeffs.drive.max(0.0);
+        self.drive_gain = 1.0 + drive * 2.0;
+        self.drive_bias = clamp(coeffs.asymmetry, 0.0, 1.0) * drive * 0.35;
+        self.drive_bias_offset = clip_shape(self.drive_bias);
+        // Level-match the colour stage at a nominal operating amplitude rather
+        // than at zero. Normalising on the small-signal slope would leave a
+        // heavily driven cell several dB quieter, which turns Colour into a
+        // volume control; matching at −10 dBFS keeps the knob about harmonics.
+        let shaped = clip_shape(COLOUR_MATCH_LEVEL * self.drive_gain + self.drive_bias)
+            - self.drive_bias_offset;
+        self.drive_norm = if shaped.abs() > 1.0e-6 {
+            COLOUR_MATCH_LEVEL / shaped
+        } else {
+            1.0
+        };
+        self.drive_mix = clamp(drive, 0.0, 0.85);
+    }
+
+    pub fn reset(&mut self) {
+        for channel in 0..2 {
+            self.hpf_state[channel].reset();
+            self.tilt_state[channel].reset();
+            self.saturator[channel].reset();
+            self.mean_square[channel] = 0.0;
+            self.gr_db[channel] = 0.0;
+            self.memory_db[channel] = 0.0;
+            self.feedback_sample[channel] = 0.0;
+        }
+    }
+
+    /// Reduction currently applied, in positive dB — the louder channel, which
+    /// is what a hardware GR meter shows.
+    #[inline]
+    pub fn gain_reduction_db(&self) -> f32 {
+        self.gr_db[0].max(self.gr_db[1])
+    }
+
+    /// Static gain-computer curve: level in dB → reduction in dB.
+    ///
+    /// Quadratic soft knee (Giannoulis/Reiss) with an optional optical
+    /// "over-easy" term that only reaches the dialled ratio well past the knee.
+    #[inline]
+    fn target_gr_db(&self, level_db: f32) -> f32 {
+        let over = level_db - self.threshold_db;
+        let half_knee = self.knee_db * 0.5;
+        let curved = if over <= -half_knee {
+            return 0.0;
+        } else if over >= half_knee || self.knee_db <= 1.0e-4 {
+            over.max(0.0)
+        } else {
+            let t = over + half_knee;
+            t * t / (2.0 * self.knee_db)
+        };
+
+        let ratio = if self.over_easy_db > 0.0 {
+            // Saturating rise: half the dialled ratio at `over_easy_db` of
+            // overshoot, asymptotically all of it. No transcendental needed.
+            let t = curved / (curved + self.over_easy_db);
+            1.0 + (self.ratio - 1.0) * t
+        } else {
+            self.ratio
+        };
+
+        curved * (1.0 - 1.0 / ratio)
+    }
+
+    /// Detector level for one channel, returning `(detector, sidechain)`.
+    #[inline]
+    fn detect(&mut self, channel: usize, input: f32) -> (f32, f32) {
+        let sense = mix(input, self.feedback_sample[channel], self.feedback);
+        let mut sidechain = self.hpf_state[channel].process(&self.hpf, sense);
+        if self.thrust > 0.0 {
+            // Thrust tilts the sidechain away from low-frequency energy so a
+            // kick stops ducking the whole mix.
+            let tilted = self.tilt_state[channel].process(self.thrust_coeff, sidechain);
+            sidechain = mix(sidechain, tilted, self.thrust);
+        }
+        let driven = sidechain * self.detector_boost;
+
+        let square = driven * driven;
+        self.mean_square[channel] = flush_denormal(
+            self.rms_coeff * self.mean_square[channel] + (1.0 - self.rms_coeff) * square,
+        );
+
+        let peak = driven.abs();
+        let rms = self.mean_square[channel].max(0.0).sqrt();
+        (mix(peak, rms, self.rms_blend), sidechain)
+    }
+
+    /// Advance one channel's reduction toward its target.
+    ///
+    /// Attack is a fixed constant. Release interpolates between the fast and
+    /// slow constants by how much reduction the cell has been holding — the
+    /// program dependence that makes these circuits sound different from a
+    /// textbook compressor.
+    #[inline]
+    fn follow(&mut self, channel: usize, detector: f32) -> f32 {
+        let target = self.target_gr_db(linear_to_db(detector.max(1.0e-9)));
+        let current = self.gr_db[channel];
+
+        let coeff = if target > current {
+            self.attack_coeff
+        } else {
+            let depth = clamp(self.memory_db[channel] / PROGRAM_REFERENCE_DB, 0.0, 1.0);
+            let blend = clamp(self.program_base + self.program_depth * depth, 0.0, 1.0);
+            self.release_fast_coeff + (self.release_slow_coeff - self.release_fast_coeff) * blend
+        };
+
+        let next = flush_denormal(coeff * current + (1.0 - coeff) * target);
+        self.gr_db[channel] = next;
+        self.memory_db[channel] = flush_denormal(
+            self.memory_coeff * self.memory_db[channel] + (1.0 - self.memory_coeff) * next,
+        );
+        next
+    }
+
+    /// Harmonic colour stage: anti-aliased soft clip, blended back by drive.
+    #[inline]
+    fn colour(&mut self, channel: usize, sample: f32) -> f32 {
+        if self.drive_mix <= 0.0 {
+            return sample;
+        }
+        let shaped = self.saturator[channel].process(sample * self.drive_gain + self.drive_bias);
+        let wet = (shaped - self.drive_bias_offset) * self.drive_norm;
+        mix(sample, wet, self.drive_mix)
+    }
+
+    /// One stereo frame through the whole cell.
+    #[inline]
+    pub fn process_stereo(&mut self, left: f32, right: f32) -> CellFrame {
+        let (det_l, sc_l) = self.detect(0, left);
+        let (det_r, sc_r) = self.detect(1, right);
+
+        // Stereo link is a detector-side sum, exactly as the hardware ties the
+        // two control voltages together — not a post-hoc average of two
+        // independently computed reductions.
+        let link = self.stereo_link;
+        let linked = det_l.max(det_r);
+        let use_l = mix(det_l, linked, link);
+        let use_r = mix(det_r, linked, link);
+
+        let gr_l = self.follow(0, use_l);
+        let gr_r = self.follow(1, use_r);
+
+        let out_l = self.colour(0, left * db_to_linear(-gr_l));
+        let out_r = self.colour(1, right * db_to_linear(-gr_r));
+
+        // Feedback models detect this sample on the next one.
+        self.feedback_sample[0] = flush_denormal(out_l);
+        self.feedback_sample[1] = flush_denormal(out_r);
+
+        CellFrame {
+            left: out_l,
+            right: out_r,
+            sidechain_left: sc_l,
+            sidechain_right: sc_r,
+        }
+    }
+}
+
+/// One-pole parameter smoother: keeps gain and mix moves click-free.
+#[derive(Debug, Clone, Copy)]
+pub struct Smoothed {
+    value: f32,
+    target: f32,
+    coeff: f32,
+}
+
+impl Smoothed {
+    pub fn new(sample_rate: f32, value: f32) -> Self {
+        Self {
+            value,
+            target: value,
+            coeff: time_constant(sample_rate.max(1.0), SMOOTH_SECONDS),
+        }
+    }
+
+    pub fn set_sample_rate(&mut self, sample_rate: f32) {
+        self.coeff = time_constant(sample_rate.max(1.0), SMOOTH_SECONDS);
+    }
+
+    pub fn set_target(&mut self, target: f32) {
+        self.target = target;
+    }
+
+    /// Jump to the target: used on reset, never mid-stream.
+    pub fn snap(&mut self, target: f32) {
+        self.target = target;
+        self.value = target;
+    }
+
+    #[inline]
+    pub fn next(&mut self) -> f32 {
+        self.value = flush_denormal(self.coeff * self.value + (1.0 - self.coeff) * self.target);
+        self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::default_params;
+
+    const SR: f32 = 48_000.0;
+
+    fn cell_for(params: &Params) -> GainCell {
+        GainCell::new(
+            SR,
+            model_coeffs(params),
+            params.sidechain_hpf_hz,
+            params.stereo_link,
+        )
+    }
+
+    /// A model with no over-easy term, no feedback, and no colour, so the
+    /// static curve can be checked against the textbook formula.
+    fn plain_params() -> Params {
+        let mut params = default_params();
+        params.model = CompModel::Comp2500;
+        params.color = 0.0;
+        params.knee_db = 0.0;
+        params.ratio = 4.0;
+        params.threshold_db = -30.0;
+        params
+    }
+
+    #[test]
+    fn static_curve_matches_the_dialled_ratio_above_the_knee() {
+        let params = plain_params();
+        let cell = cell_for(&params);
+        let knee = cell.knee_db;
+
+        // Well below threshold the cell is transparent.
+        assert_eq!(cell.target_gr_db(params.threshold_db - knee), 0.0);
+
+        for over in [6.0_f32, 12.0, 24.0] {
+            let expected = over * (1.0 - 1.0 / params.ratio);
+            let actual = cell.target_gr_db(params.threshold_db + over);
+            assert!(
+                (actual - expected).abs() < 1.0e-3,
+                "{over} dB over: expected {expected} dB, got {actual} dB"
+            );
+        }
+    }
+
+    #[test]
+    fn soft_knee_is_continuous_and_monotonic() {
+        let mut params = plain_params();
+        params.knee_db = 12.0;
+        let cell = cell_for(&params);
+
+        let mut previous = 0.0_f32;
+        let mut level = params.threshold_db - cell.knee_db;
+        while level <= params.threshold_db + 24.0 {
+            let gr = cell.target_gr_db(level);
+            assert!(gr >= previous - 1.0e-4, "curve dipped at {level} dB");
+            assert!(gr - previous < 1.0, "curve stepped at {level} dB");
+            previous = gr;
+            level += 0.25;
+        }
+        assert!(previous > 10.0, "24 dB over should still reduce hard");
+    }
+
+    #[test]
+    fn optical_over_easy_eases_into_its_ratio() {
+        let mut params = default_params();
+        params.model = CompModel::Avalon;
+        params.ratio = 8.0;
+        params.knee_db = 0.0;
+        let mut cell = cell_for(&params);
+
+        let easy_near = cell.target_gr_db(cell.threshold_db + 2.0);
+        let easy_far = cell.target_gr_db(cell.threshold_db + 40.0);
+
+        // Same curve with the optical term removed: a fixed-ratio reference.
+        cell.over_easy_db = 0.0;
+        let fixed_near = cell.target_gr_db(cell.threshold_db + 2.0);
+        let fixed_far = cell.target_gr_db(cell.threshold_db + 40.0);
+
+        assert!(
+            easy_near < fixed_near * 0.7,
+            "just past the knee the cell should barely be at its ratio: {easy_near} vs {fixed_near}"
+        );
+        assert!(
+            easy_far > fixed_far * 0.85,
+            "deep overshoot should approach the dialled ratio: {easy_far} vs {fixed_far}"
+        );
+    }
+
+    #[test]
+    fn attack_reaches_63_percent_in_one_time_constant() {
+        let mut params = plain_params();
+        params.attack_ms = 10.0;
+        let mut cell = cell_for(&params);
+
+        let detector = db_to_linear(params.threshold_db + 12.0);
+        let target = cell.target_gr_db(linear_to_db(detector));
+        let mut samples = 0usize;
+        while cell.gr_db[0] < target * 0.632 && samples < SR as usize {
+            cell.follow(0, detector);
+            samples += 1;
+        }
+
+        let seconds = samples as f32 / SR;
+        assert!(
+            (seconds - 0.010).abs() < 0.002,
+            "attack took {seconds} s, expected ~0.010 s"
+        );
+    }
+
+    #[test]
+    fn release_slows_down_after_sustained_reduction() {
+        let mut params = default_params();
+        params.model = CompModel::Ssl;
+        params.auto_release = true;
+        params.attack_ms = 1.0;
+        let loud = db_to_linear(params.threshold_db + 15.0);
+
+        let recovery = |hold_samples: usize| {
+            let mut cell = cell_for(&params);
+            for _ in 0..hold_samples {
+                cell.follow(0, loud);
+            }
+            let from = cell.gr_db[0];
+            let mut samples = 0usize;
+            while cell.gr_db[0] > from * 0.368 && samples < SR as usize * 4 {
+                cell.follow(0, 0.0);
+                samples += 1;
+            }
+            samples as f32 / SR
+        };
+
+        // A 5 ms tick and a 1 s hold both reach the same reduction; only the
+        // program-dependent network makes the long one recover slower.
+        let brief = recovery((SR * 0.005) as usize);
+        let sustained = recovery(SR as usize);
+        assert!(
+            sustained > brief * 1.5,
+            "brief {brief} s vs sustained {sustained} s"
+        );
+    }
+
+    #[test]
+    fn feedback_topology_reduces_less_than_feed_forward() {
+        let mut params = plain_params();
+        params.threshold_db = -30.0;
+        params.ratio = 6.0;
+
+        let mut forward = cell_for(&params);
+        forward.feedback = 0.0;
+        let mut looped = cell_for(&params);
+        looped.feedback = 0.85;
+
+        for n in 0..(SR as usize / 2) {
+            let x = (n as f32 * 0.1).sin() * 0.7;
+            forward.process_stereo(x, x);
+            looped.process_stereo(x, x);
+        }
+
+        assert!(
+            looped.gain_reduction_db() < forward.gain_reduction_db(),
+            "feedback {} dB vs feed-forward {} dB",
+            looped.gain_reduction_db(),
+            forward.gain_reduction_db()
+        );
+        assert!(looped.gain_reduction_db() > 0.5, "feedback cell went inert");
+    }
+
+    #[test]
+    fn saturator_tracks_the_shaper_and_stays_bounded() {
+        let mut state = SaturatorState::default();
+        let mut worst = 0.0_f32;
+        for n in 0..4_000 {
+            // Slow sweep: ADAA converges on the plain shaper when the input
+            // barely moves between samples.
+            let x = (n as f32 * 0.001).sin() * 2.5;
+            let y = state.process(x);
+            assert!(y.is_finite());
+            assert!(y.abs() <= 0.7, "shaper exceeded its bound: {y}");
+            worst = worst.max((y - clip_shape(x)).abs());
+        }
+        assert!(worst < 0.01, "ADAA drifted from the shaper by {worst}");
+    }
+
+    #[test]
+    fn colour_adds_harmonics_without_moving_the_fader() {
+        for model in [
+            CompModel::Comp2500,
+            CompModel::Distressor,
+            CompModel::Avalon,
+            CompModel::Ssl,
+        ] {
+            let mut params = default_params();
+            params.model = model;
+            params.color = 100.0;
+            let mut cell = cell_for(&params);
+
+            // Drive a tone at the level the stage is matched at and compare the
+            // colour stage in isolation against its own input.
+            let step = 2.0 * std::f32::consts::PI * 220.0 / SR;
+            let mut dry_peak = 0.0_f32;
+            let mut wet_peak = 0.0_f32;
+            for n in 0..(SR as usize / 8) {
+                let x = (n as f32 * step).sin() * COLOUR_MATCH_LEVEL;
+                let y = cell.colour(0, x);
+                assert!(y.is_finite());
+                if n > SR as usize / 16 {
+                    dry_peak = dry_peak.max(x.abs());
+                    wet_peak = wet_peak.max(y.abs());
+                }
+            }
+
+            let shift_db = linear_to_db(wet_peak) - linear_to_db(dry_peak);
+            assert!(
+                shift_db.abs() < 1.5,
+                "{model:?} colour moved the level by {shift_db} dB"
+            );
+        }
+    }
+
+    #[test]
+    fn sidechain_high_pass_rejects_lows_and_passes_highs() {
+        let mut params = default_params();
+        params.sidechain_hpf_hz = 200.0;
+        let mut cell = cell_for(&params);
+
+        let level_at = |cell: &mut GainCell, hz: f32| {
+            cell.hpf_state = [HpfState::default(); 2];
+            let step = 2.0 * std::f32::consts::PI * hz / SR;
+            let mut peak = 0.0_f32;
+            for n in 0..(SR as usize / 2) {
+                let x = (n as f32 * step).sin() * 0.5;
+                let out = cell.hpf_state[0].process(&cell.hpf, x);
+                if n > SR as usize / 4 {
+                    peak = peak.max(out.abs());
+                }
+            }
+            peak
+        };
+
+        let low = level_at(&mut cell, 30.0);
+        let high = level_at(&mut cell, 2_000.0);
+        assert!(high > 0.45, "passband lost level: {high}");
+        // 12 dB/oct, ~2.7 octaves below the corner: at least 30 dB down.
+        assert!(low < high * 0.03, "low {low} vs high {high}");
+    }
+
+    #[test]
+    fn sidechain_filter_at_the_minimum_is_bypassed() {
+        let mut params = default_params();
+        params.sidechain_hpf_hz = 20.0;
+        let cell = cell_for(&params);
+        assert!(!cell.hpf.active);
+    }
+
+    #[test]
+    fn every_model_stays_finite_under_full_scale_input() {
+        for model in [
+            CompModel::Comp2500,
+            CompModel::Distressor,
+            CompModel::Avalon,
+            CompModel::Ssl,
+        ] {
+            let mut params = default_params();
+            params.model = model;
+            params.color = 100.0;
+            params.threshold_db = -40.0;
+            params.ratio = 20.0;
+            let mut cell = cell_for(&params);
+            for n in 0..(SR as usize / 4) {
+                let x = (n as f32 * 0.37).sin();
+                let frame = cell.process_stereo(x, -x);
+                assert!(frame.left.is_finite() && frame.right.is_finite());
+                assert!(frame.left.abs() < 4.0, "{model:?} ran away: {}", frame.left);
+            }
+            assert!(cell.gain_reduction_db() > 1.0, "{model:?} did not reduce");
+        }
+    }
+
+    #[test]
+    fn stereo_link_ties_the_two_control_voltages_together() {
+        let mut params = plain_params();
+        params.stereo_link = 100.0;
+        let mut linked = cell_for(&params);
+        params.stereo_link = 0.0;
+        let mut split = cell_for(&params);
+
+        for n in 0..(SR as usize / 4) {
+            // Loud left, quiet right.
+            let x = (n as f32 * 0.11).sin();
+            linked.process_stereo(x * 0.9, x * 0.02);
+            split.process_stereo(x * 0.9, x * 0.02);
+        }
+
+        assert!(
+            (linked.gr_db[0] - linked.gr_db[1]).abs() < 0.05,
+            "linked channels drifted: {} vs {}",
+            linked.gr_db[0],
+            linked.gr_db[1]
+        );
+        assert!(
+            split.gr_db[0] > split.gr_db[1] + 3.0,
+            "unlinked channels tracked together: {} vs {}",
+            split.gr_db[0],
+            split.gr_db[1]
+        );
+    }
+
+    #[test]
+    fn smoothed_gain_never_steps() {
+        let mut smoothed = Smoothed::new(SR, 1.0);
+        smoothed.set_target(4.0);
+        let mut previous = 1.0_f32;
+        // 0.2 s is ten smoothing time constants: long enough to have arrived.
+        for _ in 0..(SR as usize / 5) {
+            let value = smoothed.next();
+            assert!(
+                (value - previous).abs() < 0.01,
+                "step of {}",
+                value - previous
+            );
+            previous = value;
+        }
+        assert!((previous - 4.0).abs() < 0.01, "never arrived: {previous}");
+    }
+}

--- a/crates/BuiltinAudioPlugins/crates/zcomp/src/ipc.rs
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/src/ipc.rs
@@ -7,7 +7,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{CompModel, Params, clamp, default_params};
+use builtin_dsp_core::clamp;
+
+use crate::{CompModel, Params, default_params};
 
 pub const PROTOCOL_VERSION: u32 = 1;
 pub const STATE_VERSION: u32 = 1;
@@ -25,8 +27,9 @@ pub const SIDECHAIN_INDEX: u32 = 9;
 pub const STEREO_LINK_INDEX: u32 = 10;
 pub const COLOR_INDEX: u32 = 11;
 pub const AUTO_RELEASE_INDEX: u32 = 12;
+pub const SC_LISTEN_INDEX: u32 = 13;
 
-pub const PARAM_COUNT: usize = 13;
+pub const PARAM_COUNT: usize = 14;
 
 /// Wire index *is* the position in this table. Append only.
 pub const UI_PARAM_IDS: [&str; PARAM_COUNT] = [
@@ -43,6 +46,7 @@ pub const UI_PARAM_IDS: [&str; PARAM_COUNT] = [
     "stereoLink",
     "color",
     "autoRelease",
+    "scListen",
 ];
 
 const RANGES: [(f32, f32); PARAM_COUNT] = [
@@ -59,6 +63,7 @@ const RANGES: [(f32, f32); PARAM_COUNT] = [
     (0.0, 100.0),   // stereoLink
     (0.0, 100.0),   // color
     (0.0, 0.0),     // autoRelease
+    (0.0, 0.0),     // scListen
 ];
 
 #[inline]
@@ -139,6 +144,7 @@ pub fn apply_wire_param(params: &mut Params, index: u32, value: f32) -> bool {
         STEREO_LINK_INDEX => params.stereo_link = clamp_wire(index, value),
         COLOR_INDEX => params.color = clamp_wire(index, value),
         AUTO_RELEASE_INDEX => params.auto_release = value >= 0.5,
+        SC_LISTEN_INDEX => params.sc_listen = value >= 0.5,
         _ => return false,
     }
     true
@@ -166,6 +172,7 @@ pub fn ui_values(params: &Params) -> Vec<(&'static str, f32)> {
         ("stereoLink", params.stereo_link),
         ("color", params.color),
         ("autoRelease", f32::from(params.auto_release)),
+        ("scListen", f32::from(params.sc_listen)),
     ]
 }
 

--- a/crates/BuiltinAudioPlugins/crates/zcomp/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/zcomp/src/lib.rs
@@ -2,21 +2,28 @@
 //!
 //! Four circuit models share one realtime-safe gain computer and colour stage:
 //!
-//! - **Comp 2500** — feed-forward VCA with soft dual-slope knee and THD colour
-//! - **Distressor** — aggressive detector with British-mode grit and hard ratios
-//! - **Avalon** — feedback Class-A optical leveling with slow musical recovery
-//! - **SSL** — bus-compressor glue with program-dependent auto-release
+//! - **Comp 2500** — feed-forward VCA, wide soft knee, thrust sidechain, THD
+//! - **Distressor** — FET feedback cell, hard ratios, British-mode grit
+//! - **Avalon** — Class-A optical leveller with over-easy ratio and LDR memory
+//! - **SSL** — bus glue with the dual time-constant auto-release network
+//!
+//! The algorithm itself lives in [`dsp`]; this module owns the parameter
+//! schema, metering, and the [`StereoEffect`] wiring the host sees.
 
 use builtin_dsp_core::{
-    ParamDescriptor, PluginCategory, PluginDescriptor, StereoEffect, clamp, db_to_linear,
-    flush_denormal, linear_to_db, mix, time_constant,
+    ParamDescriptor, PluginCategory, PluginDescriptor, StereoEffect, db_to_linear, mix,
+    time_constant,
 };
 use serde::{Deserialize, Serialize};
 
+pub mod dsp;
 pub mod ipc;
 pub mod ui;
 
+pub use dsp::{CellFrame, ModelCoeffs, model_coeffs};
 pub use ipc::{UI_PARAM_IDS, ui_param_id, ui_param_index};
+
+use dsp::{GainCell, Smoothed};
 
 pub const PLUGIN_ID: &str = "futureboard.zcomp";
 
@@ -176,6 +183,10 @@ pub struct Params {
     pub stereo_link: f32,
     pub color: f32,
     pub auto_release: bool,
+    /// Audition the post-filter sidechain instead of the compressed signal, so
+    /// the HPF and thrust settings can be heard while they are dialled.
+    #[serde(default)]
+    pub sc_listen: bool,
 }
 
 pub fn default_params() -> Params {
@@ -193,107 +204,7 @@ pub fn default_params() -> Params {
         stereo_link: 100.0,
         color: 18.0,
         auto_release: true,
-    }
-}
-
-/// Resolved runtime coefficients for the selected circuit model.
-#[derive(Debug, Clone, Copy)]
-struct ModelCoeffs {
-    threshold_db: f32,
-    ratio: f32,
-    knee_db: f32,
-    attack_sec: f32,
-    release_sec: f32,
-    release_tail_sec: f32,
-    /// 0 = pure feed-forward, 1 = pure feedback.
-    feedback: f32,
-    /// Detector RMS blend (0 = peak, 1 = RMS).
-    rms_blend: f32,
-    /// Soft clip / harmonic drive after the gain cell.
-    drive: f32,
-    /// Extra detector boost (Distressor British / 2500 THD sense).
-    detector_boost: f32,
-}
-
-fn model_coeffs(params: &Params) -> ModelCoeffs {
-    let color = clamp(params.color, 0.0, 100.0) / 100.0;
-    let ratio = params.ratio.max(1.0);
-    let knee = params.knee_db.max(0.0);
-    let attack_ms = params.attack_ms.max(0.01);
-    let release_ms = params.release_ms.max(10.0);
-
-    match params.model {
-        CompModel::Comp2500 => {
-            // API 2500: feed-forward VCA, dual soft knee, THD colouring.
-            ModelCoeffs {
-                threshold_db: params.threshold_db,
-                ratio: ratio * (1.0 + color * 0.08),
-                knee_db: (knee + 4.0 + color * 4.0).min(24.0),
-                attack_sec: (attack_ms * 0.001).clamp(0.0002, 0.080),
-                release_sec: (release_ms * 0.001).clamp(0.020, 1.200),
-                release_tail_sec: (release_ms * 0.001 * 1.8).clamp(0.050, 2.0),
-                feedback: 0.08,
-                rms_blend: 0.25,
-                drive: color * 0.55,
-                detector_boost: 1.0 + color * 0.22,
-            }
-        }
-        CompModel::Distressor => {
-            // Distressor: punchy detector, hard ratios, British grit.
-            let british = color;
-            ModelCoeffs {
-                threshold_db: params.threshold_db - british * 1.5,
-                ratio: (ratio * (1.0 + british * 0.45)).min(40.0),
-                knee_db: (knee * (1.0 - british * 0.55)).max(0.5),
-                attack_sec: (attack_ms * 0.001 * (1.0 - british * 0.35)).clamp(0.00005, 0.050),
-                release_sec: (release_ms * 0.001).clamp(0.010, 1.500),
-                release_tail_sec: (release_ms * 0.001 * (2.4 + british)).clamp(0.040, 3.0),
-                feedback: 0.18 + british * 0.22,
-                rms_blend: 0.10,
-                drive: 0.20 + british * 0.95,
-                detector_boost: 1.15 + british * 0.85,
-            }
-        }
-        CompModel::Avalon => {
-            // Avalon: Class-A optical leveling — soft, slow, musical.
-            ModelCoeffs {
-                threshold_db: params.threshold_db,
-                ratio: (2.0 + (ratio - 1.0) * 0.55).clamp(1.5, 8.0),
-                knee_db: (knee + 8.0 + color * 4.0).min(24.0),
-                attack_sec: (attack_ms * 0.001).max(0.008).clamp(0.008, 0.080),
-                release_sec: (release_ms * 0.001).max(0.080).clamp(0.080, 1.800),
-                release_tail_sec: (release_ms * 0.001 * 3.5 + color * 1.2).clamp(0.400, 5.0),
-                feedback: 0.82,
-                rms_blend: 0.55,
-                drive: color * 0.28,
-                detector_boost: 1.0 + color * 0.08,
-            }
-        }
-        CompModel::Ssl => {
-            // SSL bus compressor: soft knee glue, optional auto-release.
-            let auto = params.auto_release;
-            let release_base = if auto {
-                0.120
-            } else {
-                (release_ms * 0.001).clamp(0.050, 1.200)
-            };
-            ModelCoeffs {
-                threshold_db: params.threshold_db,
-                ratio: ratio.clamp(1.5, 10.0),
-                knee_db: (knee + 3.0).clamp(2.0, 18.0),
-                attack_sec: (attack_ms * 0.001).clamp(0.0001, 0.030),
-                release_sec: release_base,
-                release_tail_sec: if auto {
-                    0.850 + color * 0.4
-                } else {
-                    release_base * 2.2
-                },
-                feedback: 0.12,
-                rms_blend: 0.35 + color * 0.15,
-                drive: color * 0.32,
-                detector_boost: 1.0 + color * 0.12,
-            }
-        }
+        sc_listen: false,
     }
 }
 
@@ -409,266 +320,15 @@ pub fn descriptor() -> PluginDescriptor {
                 max: 1.0,
                 unit: "bool",
             },
+            ParamDescriptor {
+                id: "scListen",
+                name: "Sidechain Listen",
+                default_value: 0.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
         ],
-    }
-}
-
-/// Multi-model stereo gain cell. Topology (FF/FB blend), detector ballistics,
-/// and colour are all coefficient-driven so model changes stay allocation-free.
-#[derive(Debug, Clone)]
-struct GainCell {
-    sample_rate: f32,
-    threshold_db: f32,
-    ratio: f32,
-    knee_db: f32,
-    attack_coeff: f32,
-    release_fast_coeff: f32,
-    release_tail_coeff: f32,
-    feedback: f32,
-    rms_blend: f32,
-    drive: f32,
-    detector_boost: f32,
-    envelope_l: f32,
-    envelope_r: f32,
-    envelope_linked: f32,
-    rms_l: f32,
-    rms_r: f32,
-    rms_linked: f32,
-    gr_l_db: f32,
-    gr_r_db: f32,
-    gr_linked_db: f32,
-    sidechain_coeff: f32,
-    sidechain_x1: [f32; 2],
-    sidechain_y1: [f32; 2],
-    rms_coeff: f32,
-    stereo_link: f32,
-    auto_release: bool,
-}
-
-impl GainCell {
-    fn new(sample_rate: f32) -> Self {
-        let sr = sample_rate.max(1.0);
-        let mut cell = Self {
-            sample_rate: sr,
-            threshold_db: -18.0,
-            ratio: 4.0,
-            knee_db: 6.0,
-            attack_coeff: 0.0,
-            release_fast_coeff: 0.0,
-            release_tail_coeff: 0.0,
-            feedback: 0.0,
-            rms_blend: 0.0,
-            drive: 0.0,
-            detector_boost: 1.0,
-            envelope_l: 0.0,
-            envelope_r: 0.0,
-            envelope_linked: 0.0,
-            rms_l: 0.0,
-            rms_r: 0.0,
-            rms_linked: 0.0,
-            gr_l_db: 0.0,
-            gr_r_db: 0.0,
-            gr_linked_db: 0.0,
-            sidechain_coeff: 0.0,
-            sidechain_x1: [0.0; 2],
-            sidechain_y1: [0.0; 2],
-            rms_coeff: time_constant(sr, 0.012),
-            stereo_link: 1.0,
-            auto_release: true,
-        };
-        cell.set_model(
-            model_coeffs(&default_params()),
-            default_params().sidechain_hpf_hz,
-            default_params().stereo_link,
-            default_params().auto_release,
-        );
-        cell
-    }
-
-    fn set_sample_rate(&mut self, sample_rate: f32) {
-        self.sample_rate = sample_rate.max(1.0);
-        self.rms_coeff = time_constant(self.sample_rate, 0.012);
-    }
-
-    fn set_model(
-        &mut self,
-        coeffs: ModelCoeffs,
-        sidechain_cutoff_hz: f32,
-        stereo_link: f32,
-        auto_release: bool,
-    ) {
-        self.threshold_db = coeffs.threshold_db;
-        self.ratio = coeffs.ratio.max(1.0);
-        self.knee_db = coeffs.knee_db.max(0.0);
-        self.attack_coeff = time_constant(self.sample_rate, coeffs.attack_sec);
-        self.release_fast_coeff = time_constant(self.sample_rate, coeffs.release_sec);
-        self.release_tail_coeff = time_constant(self.sample_rate, coeffs.release_tail_sec);
-        self.feedback = clamp(coeffs.feedback, 0.0, 1.0);
-        self.rms_blend = clamp(coeffs.rms_blend, 0.0, 1.0);
-        self.drive = coeffs.drive.max(0.0);
-        self.detector_boost = coeffs.detector_boost.max(1.0);
-        self.stereo_link = clamp(stereo_link, 0.0, 100.0) / 100.0;
-        self.auto_release = auto_release;
-
-        let cutoff = clamp(sidechain_cutoff_hz, 20.0, self.sample_rate * 0.45);
-        self.sidechain_coeff = (-2.0 * std::f32::consts::PI * cutoff / self.sample_rate).exp();
-    }
-
-    fn reset(&mut self) {
-        self.envelope_l = 0.0;
-        self.envelope_r = 0.0;
-        self.envelope_linked = 0.0;
-        self.rms_l = 0.0;
-        self.rms_r = 0.0;
-        self.rms_linked = 0.0;
-        self.gr_l_db = 0.0;
-        self.gr_r_db = 0.0;
-        self.gr_linked_db = 0.0;
-        self.sidechain_x1 = [0.0; 2];
-        self.sidechain_y1 = [0.0; 2];
-    }
-
-    #[inline]
-    fn gain_reduction_db(&self) -> f32 {
-        let link = self.stereo_link;
-        let dual = self.gr_l_db.max(self.gr_r_db);
-        dual * (1.0 - link) + self.gr_linked_db * link
-    }
-
-    #[inline]
-    fn high_pass(&mut self, input: f32, channel: usize) -> f32 {
-        let output = self.sidechain_coeff
-            * (self.sidechain_y1[channel] + input - self.sidechain_x1[channel]);
-        self.sidechain_x1[channel] = input;
-        self.sidechain_y1[channel] = flush_denormal(output);
-        self.sidechain_y1[channel]
-    }
-
-    #[inline]
-    fn soft_knee_gr_db(&self, level_db: f32) -> f32 {
-        let over = level_db - self.threshold_db;
-        let half_knee = self.knee_db * 0.5;
-        let curved_over = if over <= -half_knee {
-            0.0
-        } else if over >= half_knee {
-            over
-        } else {
-            let t = over + half_knee;
-            t * t / (2.0 * self.knee_db.max(1.0e-6))
-        };
-        // Feed-forward slope; feedback path scales this further via topology.
-        curved_over * (1.0 - 1.0 / self.ratio)
-    }
-
-    #[inline]
-    fn follow_gr(current: f32, target: f32, attack: f32, release: f32) -> f32 {
-        let coeff = if target > current { attack } else { release };
-        flush_denormal(coeff * current + (1.0 - coeff) * target)
-    }
-
-    #[inline]
-    fn follow_env(current: f32, target: f32, attack: f32, release: f32) -> f32 {
-        let coeff = if target > current { attack } else { release };
-        flush_denormal(coeff * current + (1.0 - coeff) * target)
-    }
-
-    #[inline]
-    fn colour(&self, sample: f32) -> f32 {
-        if self.drive <= 0.0 {
-            return sample;
-        }
-        // Odd-harmonic soft saturation. Amount scales with model colour.
-        let x = sample * (1.0 + self.drive * 0.85);
-        let soft = x - (x * x * x) / (3.0 + self.drive * 2.0);
-        let wet = soft / (1.0 + self.drive * 0.35);
-        mix(sample, wet, clamp(self.drive, 0.0, 1.0))
-    }
-
-    #[inline]
-    fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32) {
-        // Feedback path observes post-cell signal via previous GR.
-        let prev_gain_l = db_to_linear(-self.gr_l_db);
-        let prev_gain_r = db_to_linear(-self.gr_r_db);
-
-        let ff_l = left;
-        let ff_r = right;
-        let fb_l = left * prev_gain_l;
-        let fb_r = right * prev_gain_r;
-
-        let sense_l = mix(ff_l, fb_l, self.feedback);
-        let sense_r = mix(ff_r, fb_r, self.feedback);
-
-        let sc_l = self.high_pass(sense_l, 0).abs() * self.detector_boost;
-        let sc_r = self.high_pass(sense_r, 1).abs() * self.detector_boost;
-        // Linked detector from the louder filtered channel (no second HPF pass).
-        let sc_link = sc_l.max(sc_r);
-
-        // Peak / RMS hybrid detector.
-        let rms_coeff = self.rms_coeff;
-        self.rms_l = flush_denormal(rms_coeff * self.rms_l + (1.0 - rms_coeff) * (sc_l * sc_l));
-        self.rms_r = flush_denormal(rms_coeff * self.rms_r + (1.0 - rms_coeff) * (sc_r * sc_r));
-        self.rms_linked =
-            flush_denormal(rms_coeff * self.rms_linked + (1.0 - rms_coeff) * (sc_link * sc_link));
-
-        let peak_l = sc_l;
-        let peak_r = sc_r;
-        let peak_link = sc_link;
-        let det_l = mix(peak_l, self.rms_l.max(0.0).sqrt(), self.rms_blend);
-        let det_r = mix(peak_r, self.rms_r.max(0.0).sqrt(), self.rms_blend);
-        let det_link = mix(peak_link, self.rms_linked.max(0.0).sqrt(), self.rms_blend);
-
-        self.envelope_l = Self::follow_env(
-            self.envelope_l,
-            det_l,
-            self.attack_coeff,
-            self.release_fast_coeff,
-        );
-        self.envelope_r = Self::follow_env(
-            self.envelope_r,
-            det_r,
-            self.attack_coeff,
-            self.release_fast_coeff,
-        );
-        self.envelope_linked = Self::follow_env(
-            self.envelope_linked,
-            det_link,
-            self.attack_coeff,
-            self.release_fast_coeff,
-        );
-
-        let target_l = self.soft_knee_gr_db(linear_to_db(self.envelope_l.max(1.0e-12)));
-        let target_r = self.soft_knee_gr_db(linear_to_db(self.envelope_r.max(1.0e-12)));
-        let target_link = self.soft_knee_gr_db(linear_to_db(self.envelope_linked.max(1.0e-12)));
-
-        // Program-dependent release: deeper GR stretches the tail (SSL Auto /
-        // Distressor / Avalon optical memory).
-        let depth = clamp(
-            self.gr_linked_db.max(self.gr_l_db).max(self.gr_r_db) / 12.0,
-            0.0,
-            1.0,
-        );
-        let release = if self.auto_release {
-            self.release_fast_coeff
-                + (self.release_tail_coeff - self.release_fast_coeff) * (0.35 + depth * 0.65)
-        } else {
-            self.release_fast_coeff
-                + (self.release_tail_coeff - self.release_fast_coeff) * depth * 0.45
-        };
-
-        self.gr_l_db = Self::follow_gr(self.gr_l_db, target_l, self.attack_coeff, release);
-        self.gr_r_db = Self::follow_gr(self.gr_r_db, target_r, self.attack_coeff, release);
-        self.gr_linked_db =
-            Self::follow_gr(self.gr_linked_db, target_link, self.attack_coeff, release);
-
-        let link = self.stereo_link;
-        let gr_l = self.gr_l_db * (1.0 - link) + self.gr_linked_db * link;
-        let gr_r = self.gr_r_db * (1.0 - link) + self.gr_linked_db * link;
-        let gain_l = db_to_linear(-gr_l);
-        let gain_r = db_to_linear(-gr_r);
-
-        let wet_l = self.colour(left * gain_l);
-        let wet_r = self.colour(right * gain_r);
-        (wet_l, wet_r)
     }
 }
 
@@ -676,18 +336,26 @@ impl GainCell {
 pub struct Dsp {
     params: Params,
     cell: GainCell,
-    makeup_gain: f32,
+    makeup: Smoothed,
+    mix_amount: Smoothed,
     meters: Meters,
 }
 
 impl Dsp {
     pub fn new(sample_rate: f32) -> Self {
         let sr = sample_rate.max(1.0);
+        let params = default_params();
         let mut dsp = Self {
-            params: default_params(),
-            cell: GainCell::new(sr),
-            makeup_gain: 1.0,
+            cell: GainCell::new(
+                sr,
+                model_coeffs(&params),
+                params.sidechain_hpf_hz,
+                params.stereo_link,
+            ),
+            makeup: Smoothed::new(sr, db_to_linear(params.makeup_db)),
+            mix_amount: Smoothed::new(sr, params.mix / 100.0),
             meters: Meters::new(sr),
+            params,
         };
         dsp.apply_params();
         dsp
@@ -743,19 +411,22 @@ impl Dsp {
         }
     }
 
+    /// No lookahead: the cell reacts to the sample it is given, so the graph
+    /// needs no delay compensation for this plugin.
     pub fn latency_samples(&self) -> usize {
         0
     }
 
+    /// Control-thread work: resolve the model, retune the cell, and retarget
+    /// the smoothed output gains. Never called from the audio callback.
     fn apply_params(&mut self) {
-        let coeffs = model_coeffs(&self.params);
         self.cell.set_model(
-            coeffs,
+            model_coeffs(&self.params),
             self.params.sidechain_hpf_hz,
             self.params.stereo_link,
-            self.params.auto_release,
         );
-        self.makeup_gain = db_to_linear(self.params.makeup_db);
+        self.makeup.set_target(db_to_linear(self.params.makeup_db));
+        self.mix_amount.set_target(self.params.mix / 100.0);
     }
 }
 
@@ -763,11 +434,15 @@ impl StereoEffect for Dsp {
     fn reset(&mut self) {
         self.cell.reset();
         self.meters.reset();
+        self.makeup.snap(db_to_linear(self.params.makeup_db));
+        self.mix_amount.snap(self.params.mix / 100.0);
     }
 
     fn set_sample_rate(&mut self, sample_rate: f32) {
         let sr = sample_rate.max(1.0);
         self.cell.set_sample_rate(sr);
+        self.makeup.set_sample_rate(sr);
+        self.mix_amount.set_sample_rate(sr);
         self.meters = Meters::new(sr);
         self.apply_params();
     }
@@ -777,12 +452,27 @@ impl StereoEffect for Dsp {
             self.meters.push((left, right), (left, right));
             return (left, right);
         }
-        let (mut wet_l, mut wet_r) = self.cell.process_stereo(left, right);
-        wet_l *= self.makeup_gain;
-        wet_r *= self.makeup_gain;
-        let amount = self.params.mix / 100.0;
-        let out_l = mix(left, wet_l, amount);
-        let out_r = mix(right, wet_r, amount);
+
+        let frame = self.cell.process_stereo(left, right);
+        // Both smoothers advance every sample so a branch cannot desynchronise
+        // them from the audio they scale.
+        let makeup = self.makeup.next();
+        let amount = self.mix_amount.next();
+
+        let (out_l, out_r) = if self.params.sc_listen {
+            // Auditioning the detector feed: the gain cell still runs so the
+            // reduction meter keeps telling the truth about what it would do.
+            (
+                frame.sidechain_left * makeup,
+                frame.sidechain_right * makeup,
+            )
+        } else {
+            (
+                mix(left, frame.left * makeup, amount),
+                mix(right, frame.right * makeup, amount),
+            )
+        };
+
         self.meters.push((left, right), (out_l, out_r));
         (out_l, out_r)
     }
@@ -912,7 +602,7 @@ mod tests {
     }
 
     #[test]
-    fn model_coeffs_ssl_auto_uses_program_release() {
+    fn model_coeffs_ssl_auto_uses_a_dual_time_constant_network() {
         let mut params = default_params();
         params.model = CompModel::Ssl;
         params.auto_release = true;
@@ -920,6 +610,88 @@ mod tests {
         params.auto_release = false;
         params.release_ms = 50.0;
         let manual = model_coeffs(&params);
-        assert!(auto.release_tail_sec > manual.release_sec);
+
+        assert!(auto.release_slow_sec > auto.release_fast_sec);
+        assert!(auto.release_slow_sec > manual.release_fast_sec);
+        assert!(auto.program_auto_bias > manual.program_auto_bias);
+    }
+
+    #[test]
+    fn steady_state_reduction_tracks_the_dialled_ratio() {
+        // Feed-forward VCA with no colour: the only things between the input
+        // peak and the meter are the detector blend and the ballistics ripple.
+        let mut params = default_params();
+        params.model = CompModel::Comp2500;
+        params.color = 0.0;
+        params.knee_db = 0.0;
+        params.ratio = 4.0;
+        params.threshold_db = -30.0;
+        params.mix = 100.0;
+        params.makeup_db = 0.0;
+
+        let mut dsp = Dsp::new(48_000.0);
+        dsp.set_params(params);
+        // -10 dBFS peak is 20 dB over threshold; 4:1 asks for 15 dB off.
+        let frame = run_tone(&mut dsp, 0.3162, 48_000);
+
+        assert!(
+            (frame.gain_reduction_db - 15.0).abs() < 2.5,
+            "expected ~15 dB of reduction, got {}",
+            frame.gain_reduction_db
+        );
+    }
+
+    #[test]
+    fn sidechain_listen_outputs_the_detector_feed() {
+        let mut params = default_params();
+        params.model = CompModel::Comp2500;
+        params.color = 0.0;
+        params.sidechain_hpf_hz = 500.0;
+        params.sc_listen = true;
+        params.makeup_db = 0.0;
+
+        let mut dsp = Dsp::new(48_000.0);
+        dsp.set_params(params);
+
+        // 30 Hz is far below the sidechain corner, so auditioning the detector
+        // feed should be near silent while the cell still reports its work.
+        let step = 2.0 * std::f32::consts::PI * 30.0 / 48_000.0;
+        let mut peak = 0.0_f32;
+        for n in 0..24_000 {
+            let x = (n as f32 * step).sin() * 0.8;
+            let (l, r) = dsp.process_stereo(x, x);
+            assert!(l.is_finite() && r.is_finite());
+            if n > 12_000 {
+                peak = peak.max(l.abs());
+            }
+        }
+        assert!(peak < 0.08, "sidechain listen passed the lows: {peak}");
+    }
+
+    #[test]
+    fn makeup_changes_do_not_step_the_output() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.mix = 100.0;
+        params.makeup_db = 0.0;
+        params.color = 0.0;
+        dsp.set_params(params.clone());
+        for n in 0..4_800 {
+            dsp.process_stereo((n as f32 * 0.05).sin() * 0.2, 0.0);
+        }
+
+        params.makeup_db = 18.0;
+        dsp.set_params(params);
+
+        let mut previous = dsp.process_stereo(0.2, 0.0).0;
+        for _ in 0..4_800 {
+            let (out, _) = dsp.process_stereo(0.2, 0.0);
+            assert!(
+                (out - previous).abs() < 0.02,
+                "makeup stepped by {}",
+                out - previous
+            );
+            previous = out;
+        }
     }
 }

--- a/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
+++ b/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
@@ -784,6 +784,20 @@ impl BuiltinHostProcessor {
                     out_clip: f.out_clip,
                 })
             }
+            BuiltinDsp::Transient(dsp) => {
+                let f = dsp.meter_frame();
+                Some(SpherePluginHost::audio_bridge::BuiltinMeterFrame {
+                    in_peak: f.in_peak,
+                    in_rms: f.in_rms,
+                    out_peak: f.out_peak,
+                    out_rms: f.out_rms,
+                    // Transient shaping is a gain change in either direction;
+                    // the frame carries its magnitude.
+                    gain_reduction_db: f.gain_reduction_db,
+                    in_clip: f.in_clip,
+                    out_clip: f.out_clip,
+                })
+            }
             BuiltinDsp::Equz8(_)
             | BuiltinDsp::Verbspace(_)
             | BuiltinDsp::Echospace(_)


### PR DESCRIPTION
DSP (crates/BuiltinAudioPlugins/crates/zcomp/src/dsp.rs)

Move the algorithm into its own module and rework it around four decisions, all still allocation-free and branch-free on the audio path:

- One smoothing stage. The detector produces a level, the static curve turns it into a target reduction, and a single attack/release stage follows it. Smoothing the level and the reduction with the same constants made the effective attack roughly twice the dialled value.
- Program-dependent release. Release interpolates between a fast and a slow constant using a slow integrator of the reduction itself, which is what the SSL auto-release network, the optical cell's LDR memory, and the Distressor's second stage do physically.
- Real feedback topology. Feedback models now detect the cell's own output one sample late instead of the input scaled by the previous reduction, and the optical model gets an over-easy ratio that only reaches its nominal slope well past the knee.
- Anti-aliased colour. The harmonic stage is a soft clipper evaluated through its first antiderivative, level-matched at a nominal operating amplitude so Colour changes harmonics, not the fader.

Also: a 12 dB/oct TPT state-variable sidechain high-pass (bypassed at the minimum) with a 2500-style thrust tilt, stereo link tied at the detector rather than after the fact, and smoothed makeup/mix so a knob move cannot step the output. New `scListen` parameter (wire index 13, append-only) auditions the filtered detector feed.

Editor

Rebuild the faceplate as a fixed-geometry 2U device scaled to the host's client rectangle, replacing a layout whose percentage heights resolved circularly and pushed every knob out of view. Machined knobs with engraved collars and value plates, an enamel VU movement in a screwed bezel, IN/OUT LED ladders with a dB legend, lamp-lit circuit pushbuttons, and a transfer-curve window that plots the running circuit with a live operating point from host telemetry.

Plugin host

Publish Transient's meter frame; its variant was missing from the match, which left the host binary failing to compile.


Claude-Session: https://claude.ai/code/session_01FMPqcGAotMaGQU1R24fsTV