### PR TITLE
perf(ui)+fix(transport): Display Sync refresh & Space play/pause from plugin editors

### DIFF
--- a/crates/SphereUIComponents/src/components/timeline/render/wgpu_renderer.rs
+++ b/crates/SphereUIComponents/src/components/timeline/render/wgpu_renderer.rs
@@ -146,34 +146,42 @@ pub fn list_available_gpu_devices() -> Vec<GpuDeviceInfo> {
 /// Classify this machine from the adapters wgpu can see, for the UI's
 /// render-cost profile (see [`crate::perf::GpuClass`]).
 ///
-/// Only the presence of a discrete adapter matters. Enumeration is the same
-/// call the Settings GPU list uses — a few milliseconds, once, at startup — and
-/// a driver that cannot enumerate yields `Unknown`, which never slows the UI
-/// down on a guess.
+/// A discrete adapter is always enough. Apple Silicon is integrated silicon
+/// but has the memory bandwidth the LowEnd / 60 Hz DisplaySync profile was
+/// written *against* leaving free — so it is treated as capable rather than
+/// low-end. Enumeration is the same call the Settings GPU list uses — a few
+/// milliseconds, once, at startup — and a driver that cannot enumerate yields
+/// `Unknown`, which never slows the UI down on a guess.
 pub fn detect_gpu_class() -> crate::perf::GpuClass {
-    use crate::perf::GpuClass;
     let result = std::panic::catch_unwind(|| {
         let instance = wgpu::Instance::default();
         let adapters: Vec<wgpu::Adapter> =
             pollster::block_on(instance.enumerate_adapters(wgpu::Backends::all()));
         adapters
             .into_iter()
-            .map(|adapter| adapter.get_info().device_type)
+            .map(|adapter| {
+                let info = adapter.get_info();
+                (info.device_type, info.name)
+            })
             .collect::<Vec<_>>()
     });
-    let Ok(types) = result else {
-        return GpuClass::Unknown;
+    let Ok(adapters) = result else {
+        return crate::perf::GpuClass::Unknown;
     };
-    if types.is_empty() {
-        return GpuClass::Unknown;
-    }
-    if types
-        .iter()
-        .any(|kind| matches!(kind, wgpu::DeviceType::DiscreteGpu))
-    {
-        GpuClass::Discrete
-    } else {
-        GpuClass::IntegratedOnly
+    crate::perf::classify_gpu_adapters(
+        adapters
+            .iter()
+            .map(|(kind, name)| (device_type_class(*kind), name.as_str())),
+    )
+}
+
+fn device_type_class(kind: wgpu::DeviceType) -> crate::perf::GpuDeviceKind {
+    match kind {
+        wgpu::DeviceType::DiscreteGpu => crate::perf::GpuDeviceKind::Discrete,
+        wgpu::DeviceType::IntegratedGpu => crate::perf::GpuDeviceKind::Integrated,
+        wgpu::DeviceType::VirtualGpu => crate::perf::GpuDeviceKind::Virtual,
+        wgpu::DeviceType::Cpu => crate::perf::GpuDeviceKind::Cpu,
+        wgpu::DeviceType::Other => crate::perf::GpuDeviceKind::Other,
     }
 }
 

--- a/crates/SphereUIComponents/src/frame_scheduler.rs
+++ b/crates/SphereUIComponents/src/frame_scheduler.rs
@@ -15,9 +15,14 @@
 //! Idle is unchanged: the poll loop only notifies on state change, so when
 //! nothing is dirty no frames are scheduled regardless of the configured rate.
 //!
-//! The refresh rate is queried once from the OS and cached. On Windows that is
-//! `EnumDisplaySettingsW(...).dmDisplayFrequency`; everywhere else (and on any
-//! query failure) it falls back to 60 Hz. The detected value is clamped to
+//! The refresh rate is queried once from the OS and cached:
+//! * Windows — `EnumDisplaySettingsW(...).dmDisplayFrequency`
+//! * macOS — `CGDisplayModeGetRefreshRate`, then CoreVideo's nominal output
+//!   period when the mode reports `0` (common on LCD / ProMotion panels)
+//! * Linux — XRandR current rate (native X11 and XWayland); pure Wayland without
+//!   XWayland falls back like any other query failure
+//!
+//! On any query failure it falls back to 60 Hz. The detected value is clamped to
 //! `30..=240` Hz.
 
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -180,7 +185,7 @@ pub fn frame_interval(mode: FrameRateMode, refresh_hz: u32, class: FrameClass) -
 }
 
 /// Query the primary monitor refresh rate once and cache it. Clamped to
-/// `30..=240`; falls back to 60 Hz on non-Windows or any query failure.
+/// `30..=240`; falls back to 60 Hz on any query failure.
 pub fn detect_refresh_hz() -> u32 {
     static CACHED: OnceLock<u32> = OnceLock::new();
     *CACHED.get_or_init(|| {
@@ -191,6 +196,19 @@ pub fn detect_refresh_hz() -> u32 {
         }
         hz
     })
+}
+
+/// Round a floating OS-reported refresh rate to an integer Hz. Values under
+/// 1.0 (Windows "hardware default", CGDisplay LCD sentinel, XRandR zero) are
+/// treated as unavailable so callers can try the next source.
+pub fn round_refresh_hz(raw: f64) -> Option<u32> {
+    if !raw.is_finite() || raw < 1.0 {
+        None
+    } else {
+        // 59.94 / 119.88 must map to 60 / 120 so DisplaySync intervals land on
+        // whole-frame boundaries rather than drifting.
+        Some(raw.round() as u32)
+    }
 }
 
 #[cfg(windows)]
@@ -211,10 +229,193 @@ fn query_refresh_hz_os() -> Option<u32> {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(target_os = "macos")]
 fn query_refresh_hz_os() -> Option<u32> {
-    // TODO(non-windows): query via the platform display API when available.
-    // Until then the 60 Hz fallback applies.
+    // Prefer the active display mode when it reports a real rate. LCD and
+    // ProMotion panels often return 0 from CGDisplayModeGetRefreshRate, so
+    // fall through to CoreVideo's nominal output period which still yields a
+    // usable cadence for DisplaySync.
+    type CGDirectDisplayID = u32;
+    type CGDisplayModeRef = *mut std::ffi::c_void;
+    type CVDisplayLinkRef = *mut std::ffi::c_void;
+
+    #[repr(C)]
+    struct CVTime {
+        time_value: i64,
+        time_scale: i32,
+        flags: i32,
+    }
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGMainDisplayID() -> CGDirectDisplayID;
+        fn CGDisplayCopyDisplayMode(display: CGDirectDisplayID) -> CGDisplayModeRef;
+        fn CGDisplayModeGetRefreshRate(mode: CGDisplayModeRef) -> f64;
+        fn CGDisplayModeRelease(mode: CGDisplayModeRef);
+    }
+
+    #[link(name = "CoreVideo", kind = "framework")]
+    extern "C" {
+        fn CVDisplayLinkCreateWithCGDisplay(
+            display_id: CGDirectDisplayID,
+            display_link_out: *mut CVDisplayLinkRef,
+        ) -> i32;
+        fn CVDisplayLinkGetNominalOutputVideoRefreshPeriod(display_link: CVDisplayLinkRef)
+        -> CVTime;
+        fn CVDisplayLinkRelease(display_link: CVDisplayLinkRef);
+    }
+
+    unsafe {
+        let display = CGMainDisplayID();
+        let mode = CGDisplayCopyDisplayMode(display);
+        if !mode.is_null() {
+            let rate = CGDisplayModeGetRefreshRate(mode);
+            CGDisplayModeRelease(mode);
+            if let Some(hz) = round_refresh_hz(rate) {
+                return Some(hz);
+            }
+        }
+
+        let mut link: CVDisplayLinkRef = std::ptr::null_mut();
+        // kCVReturnSuccess == 0
+        if CVDisplayLinkCreateWithCGDisplay(display, &mut link) != 0 || link.is_null() {
+            return None;
+        }
+        let period = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(link);
+        CVDisplayLinkRelease(link);
+        if period.time_value <= 0 || period.time_scale <= 0 {
+            return None;
+        }
+        let hz = period.time_scale as f64 / period.time_value as f64;
+        round_refresh_hz(hz)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn query_refresh_hz_os() -> Option<u32> {
+    // XRandR covers native X11 and Wayland sessions that still expose XWayland
+    // (`DISPLAY` set). Pure Wayland without XWayland returns None → 60 Hz
+    // fallback, matching the BPM cursor path.
+    use x11_dl::xlib::{self, Display};
+    use x11_dl::xrandr;
+
+    let xlib = xlib::Xlib::open().ok()?;
+    let xrandr = xrandr::Xrandr::open().ok()?;
+    unsafe {
+        let display: *mut Display = (xlib.XOpenDisplay)(std::ptr::null());
+        if display.is_null() {
+            return None;
+        }
+        let root = (xlib.XDefaultRootWindow)(display);
+
+        // Prefer mode-table rate from the primary (or first connected) output —
+        // more accurate than the legacy screen-config rate on multi-monitor.
+        let hz = refresh_hz_from_xrandr_resources(&xrandr, display, root)
+            .or_else(|| refresh_hz_from_xrandr_screen_config(&xrandr, display, root));
+
+        (xlib.XCloseDisplay)(display);
+        hz
+    }
+}
+
+#[cfg(target_os = "linux")]
+unsafe fn refresh_hz_from_xrandr_screen_config(
+    xrandr: &x11_dl::xrandr::Xrandr,
+    display: *mut x11_dl::xlib::Display,
+    root: x11_dl::xlib::Window,
+) -> Option<u32> {
+    let config = unsafe { (xrandr.XRRGetScreenInfo)(display, root) };
+    if config.is_null() {
+        return None;
+    }
+    let rate = unsafe { (xrandr.XRRConfigCurrentRate)(config) };
+    unsafe { (xrandr.XRRFreeScreenConfigInfo)(config) };
+    round_refresh_hz(rate as f64)
+}
+
+#[cfg(target_os = "linux")]
+unsafe fn refresh_hz_from_xrandr_resources(
+    xrandr: &x11_dl::xrandr::Xrandr,
+    display: *mut x11_dl::xlib::Display,
+    root: x11_dl::xlib::Window,
+) -> Option<u32> {
+    use x11_dl::xrandr::{RRMode, RR_Connected, XRRModeInfo};
+
+    let resources = unsafe { (xrandr.XRRGetScreenResourcesCurrent)(display, root) };
+    if resources.is_null() {
+        return None;
+    }
+
+    let primary = unsafe { (xrandr.XRRGetOutputPrimary)(display, root) };
+    let noutput = unsafe { (*resources).noutput };
+    let outputs = unsafe { (*resources).outputs };
+    if noutput <= 0 || outputs.is_null() {
+        unsafe { (xrandr.XRRFreeScreenResources)(resources) };
+        return None;
+    }
+
+    let mut chosen_mode: RRMode = 0;
+    // Prefer primary when connected; otherwise first connected output with a CRTC.
+    let order = std::iter::once(primary).chain((0..noutput).map(|i| unsafe { *outputs.add(i as usize) }));
+    for output in order {
+        if output == 0 {
+            continue;
+        }
+        let info = unsafe { (xrandr.XRRGetOutputInfo)(display, resources, output) };
+        if info.is_null() {
+            continue;
+        }
+        let connected = unsafe { (*info).connection } == RR_Connected as u16;
+        let crtc = unsafe { (*info).crtc };
+        unsafe { (xrandr.XRRFreeOutputInfo)(info) };
+        if !connected || crtc == 0 {
+            continue;
+        }
+        let crtc_info = unsafe { (xrandr.XRRGetCrtcInfo)(display, resources, crtc) };
+        if crtc_info.is_null() {
+            continue;
+        }
+        let mode = unsafe { (*crtc_info).mode };
+        unsafe { (xrandr.XRRFreeCrtcInfo)(crtc_info) };
+        if mode != 0 {
+            chosen_mode = mode;
+            break;
+        }
+    }
+
+    let mut hz = None;
+    if chosen_mode != 0 {
+        let nmode = unsafe { (*resources).nmode };
+        let modes = unsafe { (*resources).modes };
+        if nmode > 0 && !modes.is_null() {
+            for i in 0..nmode as usize {
+                let mode: &XRRModeInfo = unsafe { &*modes.add(i) };
+                if mode.id == chosen_mode {
+                    hz = refresh_hz_from_xrr_mode(mode);
+                    break;
+                }
+            }
+        }
+    }
+
+    unsafe { (xrandr.XRRFreeScreenResources)(resources) };
+    hz
+}
+
+/// Compute Hz from an XRRModeInfo: `dotClock / (hTotal * vTotal)`.
+#[cfg(target_os = "linux")]
+fn refresh_hz_from_xrr_mode(mode: &x11_dl::xrandr::XRRModeInfo) -> Option<u32> {
+    let denom = (mode.hTotal as u64).saturating_mul(mode.vTotal as u64);
+    if denom == 0 || mode.dotClock == 0 {
+        return None;
+    }
+    // dotClock is kHz in XRandR.
+    let hz = (mode.dotClock as f64 * 1000.0) / denom as f64;
+    round_refresh_hz(hz)
+}
+
+#[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
+fn query_refresh_hz_os() -> Option<u32> {
     None
 }
 
@@ -480,5 +681,15 @@ mod tests {
     fn detect_is_clamped_and_nonzero() {
         let hz = detect_refresh_hz();
         assert!((MIN_REFRESH_HZ..=MAX_REFRESH_HZ).contains(&hz));
+    }
+
+    #[test]
+    fn round_refresh_maps_fractional_panel_rates() {
+        assert_eq!(round_refresh_hz(59.94), Some(60));
+        assert_eq!(round_refresh_hz(119.88), Some(120));
+        assert_eq!(round_refresh_hz(144.0), Some(144));
+        assert_eq!(round_refresh_hz(0.0), None, "LCD/ProMotion sentinel");
+        assert_eq!(round_refresh_hz(-1.0), None);
+        assert_eq!(round_refresh_hz(f64::NAN), None);
     }
 }

--- a/crates/SphereUIComponents/src/perf.rs
+++ b/crates/SphereUIComponents/src/perf.rs
@@ -458,19 +458,74 @@ pub fn record_notify(reason: &'static str) {
 /// adapters wgpu can see (see `render::wgpu_renderer::detect_gpu_class`) and
 /// published here so cheap render-path checks never touch wgpu.
 ///
-/// The distinction that matters is "is there a discrete GPU at all": a
-/// machine with only integrated graphics — an Intel Mac, a Windows laptop on
-/// Iris/UHD/Vega — pays for every extra frame and every extra grid line in
-/// shared memory bandwidth the CPU also needs.
+/// Low-end shared-memory iGPUs — Intel Iris/UHD, older Radeon Vega on Windows
+/// laptops, Intel Macs — pay for every extra frame in bandwidth the CPU also
+/// needs. Apple Silicon is integrated metal but is *not* that class of
+/// device: treating it as low-end would leave ProMotion frames on the table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GpuClass {
-    /// No discrete adapter present. Integrated / software rendering only.
+    /// No discrete or otherwise capable adapter: classic low-end iGPU only.
     IntegratedOnly,
-    /// At least one discrete adapter is available to the process.
+    /// At least one discrete adapter — or a capable integrated GPU such as
+    /// Apple Silicon — is available to the process.
     Discrete,
     /// Not detected (enumeration failed, or the `gpu-renderer` feature is off).
     /// Treated exactly like `Discrete`: never slow the UI down on a guess.
     Unknown,
+}
+
+/// Adapter flavour used by [`classify_gpu_adapters`]. Kept as a plain enum so
+/// the pure classifier can be unit-tested without linking wgpu.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuDeviceKind {
+    Discrete,
+    Integrated,
+    Virtual,
+    Cpu,
+    Other,
+}
+
+/// Classify enumerated adapters into a [`GpuClass`]. Pure policy: discrete
+/// wins, then capable integrated (Apple Silicon), then classic iGPU.
+pub fn classify_gpu_adapters<'a, I>(adapters: I) -> GpuClass
+where
+    I: IntoIterator<Item = (GpuDeviceKind, &'a str)>,
+{
+    let mut saw_any = false;
+    let mut saw_discrete = false;
+    let mut saw_capable_integrated = false;
+    let mut saw_classic_integrated = false;
+    for (kind, name) in adapters {
+        saw_any = true;
+        match kind {
+            GpuDeviceKind::Discrete => saw_discrete = true,
+            GpuDeviceKind::Integrated if is_capable_integrated_gpu(name) => {
+                saw_capable_integrated = true;
+            }
+            GpuDeviceKind::Integrated => saw_classic_integrated = true,
+            GpuDeviceKind::Virtual | GpuDeviceKind::Cpu | GpuDeviceKind::Other => {}
+        }
+    }
+    if !saw_any {
+        GpuClass::Unknown
+    } else if saw_discrete || saw_capable_integrated {
+        GpuClass::Discrete
+    } else if saw_classic_integrated {
+        GpuClass::IntegratedOnly
+    } else {
+        // Software / virtual only — do not apply the low-end cap on a guess.
+        GpuClass::Unknown
+    }
+}
+
+/// Integrated GPUs that still have enough shared-memory bandwidth that the
+/// LowEnd profile and 60 Hz DisplaySync cap would only waste panel rate.
+///
+/// Today: Apple Silicon (`"Apple M1"`, `"Apple M4 Pro"`, `"Apple GPU"`, …).
+/// Keep this list tight — Iris/UHD/Vega must continue to select LowEnd.
+fn is_capable_integrated_gpu(name: &str) -> bool {
+    // wgpu Metal reports names like "Apple M3 Pro" / "Apple M1" / "Apple GPU".
+    name.to_ascii_lowercase().starts_with("apple ")
 }
 
 static DETECTED_GPU_CLASS: std::sync::OnceLock<GpuClass> = std::sync::OnceLock::new();
@@ -752,5 +807,31 @@ mod power_mode_tests {
         assert!(PowerMode::LowEnd.meter_min_delta() > PowerMode::Balanced.meter_min_delta());
         assert!(PowerMode::LowEnd.grid_line_budget_scale() < 1.0);
         assert!(!PowerMode::LowEnd.allow_sub_grid_lines());
+    }
+
+    #[test]
+    fn classic_igpu_is_low_end_but_apple_silicon_is_not() {
+        assert_eq!(
+            classify_gpu_adapters([(GpuDeviceKind::Integrated, "Intel(R) UHD Graphics 620")]),
+            GpuClass::IntegratedOnly
+        );
+        assert_eq!(
+            classify_gpu_adapters([(GpuDeviceKind::Integrated, "AMD Radeon(TM) Graphics")]),
+            GpuClass::IntegratedOnly
+        );
+        assert_eq!(
+            classify_gpu_adapters([(GpuDeviceKind::Integrated, "Apple M3 Pro")]),
+            GpuClass::Discrete,
+            "Apple Silicon must not inherit the Iris/UHD LowEnd profile"
+        );
+        assert_eq!(
+            classify_gpu_adapters([(GpuDeviceKind::Discrete, "NVIDIA GeForce RTX 3070")]),
+            GpuClass::Discrete
+        );
+        assert_eq!(
+            classify_gpu_adapters([(GpuDeviceKind::Cpu, "llvmpipe")]),
+            GpuClass::Unknown
+        );
+        assert_eq!(classify_gpu_adapters([]), GpuClass::Unknown);
     }
 }


### PR DESCRIPTION
## Summary
- Detect primary-monitor refresh rate on macOS (CoreGraphics/CoreVideo) and Linux (XRandR), matching Windows, so Display Sync can pace to high-refresh panels instead of a hardcoded 60 Hz fallback.
- Treat Apple Silicon as a capable GPU so it keeps Balanced mode and full Display Sync; classic shared-memory iGPUs (Iris/UHD/Vega) still get the LowEnd profile and 60 Hz automatic cap.
- Make bare Space toggle play/pause while a plug-in editor is focused on **Windows, macOS, and Linux** (host-owned VST shells and built-in CEF editors), by claiming the key in the host process and running the same `transport:play-pause` command as the arrangement.

## Transport Space details
- **Windows:** PeekMessage claim + `WH_KEYBOARD_LL` when the host process owns the foreground window (covers CEF/JUCE multi-thread UIs) + content/top shell `WM_KEYDOWN` claims into a process-wide counter.
- **macOS:** AppKit local key monitor + existing pump claim for nested plugin run loops.
- **Linux:** GTK capture-phase key controller + `XGrabKey` for XEmbed-focused children.
- **Built-in editors:** shell-level Space capture on every OS (not OSR-only); windowed CEF still uses `OnPreKeyEvent` as well.

## Test plan
- [x] `cargo check -p sphere_ui_components`
- [x] `cargo check -p sphere-plugin-host --bin FutureboardPluginHostX64` (Linux)
- [x] `cargo test -p sphere_ui_components --lib frame_scheduler::`
- [x] `cargo test -p sphere_ui_components --lib power_mode_tests`
- [ ] Open a built-in plugin editor and press Space → transport toggles (Win/Mac/Linux)
- [ ] Open a host VST editor and press Space → transport toggles; typing in a preset name field still accepts Space
- [ ] With arrangement focused, Space still works as before
- [ ] High-refresh Display Sync status label matches panel (Win/Mac/Linux)