### PR TITLE
fix(transport): make Space play/pause work from focused plugin editor…

### DIFF
--- a/crates/SphereDirectAudioEngine/build.rs
+++ b/crates/SphereDirectAudioEngine/build.rs
@@ -123,6 +123,9 @@ fn apply_vst3_platform_config(
             }
 
             println!("cargo:rustc-link-lib=dl");
+            // editor_linux.cpp uses XGrabKey so Space reaches the host even when
+            // an XEmbed plug-in child holds focus.
+            println!("cargo:rustc-link-lib=X11");
         }
         _ => {}
     }

--- a/crates/SphereDirectAudioEngine/vst3bridge/include/sphere_daux_vst3_processor.h
+++ b/crates/SphereDirectAudioEngine/vst3bridge/include/sphere_daux_vst3_processor.h
@@ -145,6 +145,14 @@ sphere_daux_vst3_embed_host_kind(SphereDauxVst3Processor *processor);
 SPHERE_DAUX_VST3_API int
 sphere_daux_vst3_embed_take_user_close(SphereDauxVst3Processor *processor);
 
+/// Claim one bare-Space transport toggle from any editor UI thread. Process-wide.
+SPHERE_DAUX_VST3_API void sphere_daux_vst3_claim_transport_toggle(void);
+
+/// Number of bare Space presses claimed from plug-in editor windows since the
+/// last call. Process-wide; the host turns each into HostEvent::TransportToggleRequested.
+SPHERE_DAUX_VST3_API unsigned int
+sphere_daux_vst3_take_transport_toggle_requests(void);
+
 SPHERE_DAUX_VST3_API void
 sphere_daux_vst3_embed_set_waiting_stage(SphereDauxVst3Processor *processor,
                                          const char *stage);

--- a/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
@@ -29,6 +29,8 @@
 
 #ifdef GDK_WINDOWING_X11
 #  include <gdk/x11/gdkx.h>
+#  include <X11/Xlib.h>
+#  include <X11/keysym.h>
 #endif
 #ifdef GDK_WINDOWING_WAYLAND
 #  include <gdk/wayland/gdkwayland.h>
@@ -38,6 +40,8 @@
 #include "pluginterfaces/gui/iplugview.h"
 
 #include "sphere_daux_editor_bridge.h"
+
+extern "C" void sphere_daux_vst3_claim_transport_toggle(void);
 
 // The Linux run-loop interfaces are GUI-layer IIDs that the SDK IID TUs we
 // compile (coreiids.cpp / vstinitiids.cpp) do not emit. Our IRunLoop frame's
@@ -63,6 +67,106 @@ GMainLoop*              s_main_loop    = nullptr;
 std::mutex              s_init_mutex;
 std::condition_variable s_init_cv;
 bool                    s_gtk_ready    = false;
+
+/// Bare Space presses claimed from plug-in editor windows for the DAW
+/// transport. Written on the GTK thread; drained by the host IPC loop via
+/// `sphere_daux_vst3_take_transport_toggle_requests` (process-wide counter in
+/// the VST3 processor TU).
+bool is_transport_toggle_key(guint keyval, GdkModifierType state) {
+    if (keyval != GDK_KEY_space && keyval != GDK_KEY_KP_Space) {
+        return false;
+    }
+    const GdkModifierType blocking = static_cast<GdkModifierType>(
+        GDK_CONTROL_MASK | GDK_ALT_MASK | GDK_SUPER_MASK | GDK_META_MASK |
+        GDK_HYPER_MASK);
+    return (state & blocking) == 0;
+}
+
+/// Claim Space for transport before the plug-in sees it. Returns TRUE when
+/// consumed (stop further handling), matching the Win32 / AppKit pumps.
+gboolean on_editor_key_pressed(GtkEventControllerKey* /*controller*/,
+                                guint keyval,
+                                guint /*keycode*/,
+                                GdkModifierType state,
+                                gpointer /*user_data*/) {
+    if (!is_transport_toggle_key(keyval, state)) {
+        return FALSE;
+    }
+    sphere_daux_vst3_claim_transport_toggle();
+    std::fprintf(stderr,
+                 "[SphereVST3/linux] transport key claimed from editor focus\n");
+    return TRUE;
+}
+
+#ifdef GDK_WINDOWING_X11
+/// XEmbed children hold the keyboard focus independently of the GtkWindow.
+/// A passive grab on the host XID still delivers Space to us when a descendant
+/// (the plug-in view) has focus — without it, Space never reaches GTK.
+void grab_transport_key_on_x11_window(GtkWidget* window) {
+    GdkSurface* surface = gtk_native_get_surface(GTK_NATIVE(window));
+    if (!surface || !GDK_IS_X11_SURFACE(surface)) {
+        return;
+    }
+    Display* dpy = gdk_x11_display_get_xdisplay(gdk_surface_get_display(surface));
+    Window xid = gdk_x11_surface_get_xid(surface);
+    KeyCode code = XKeysymToKeycode(dpy, XK_space);
+    if (code == 0 || xid == 0) {
+        return;
+    }
+    // Lock/NumLock as irrelevant noise — grab every common combination so a
+    // sticky lock state does not silently re-arm the plug-in's Space.
+    const unsigned int masks[] = {
+        0u,
+        LockMask,
+        Mod2Mask,
+        LockMask | Mod2Mask,
+    };
+    for (unsigned int mask : masks) {
+        // owner_events=False: we claim the press even when the focus window is
+        // an embedded foreign XEmbed child.
+        XGrabKey(dpy, code, mask, xid, False, GrabModeAsync, GrabModeAsync);
+    }
+    XFlush(dpy);
+}
+
+void ungrab_transport_key_on_x11_window(GtkWidget* window) {
+    if (!window || !GTK_IS_NATIVE(window)) {
+        return;
+    }
+    GdkSurface* surface = gtk_native_get_surface(GTK_NATIVE(window));
+    if (!surface || !GDK_IS_X11_SURFACE(surface)) {
+        return;
+    }
+    Display* dpy = gdk_x11_display_get_xdisplay(gdk_surface_get_display(surface));
+    Window xid = gdk_x11_surface_get_xid(surface);
+    KeyCode code = XKeysymToKeycode(dpy, XK_space);
+    if (code == 0 || xid == 0) {
+        return;
+    }
+    const unsigned int masks[] = {
+        0u,
+        LockMask,
+        Mod2Mask,
+        LockMask | Mod2Mask,
+    };
+    for (unsigned int mask : masks) {
+        XUngrabKey(dpy, code, mask, xid);
+    }
+    XFlush(dpy);
+}
+#else
+void grab_transport_key_on_x11_window(GtkWidget*) {}
+void ungrab_transport_key_on_x11_window(GtkWidget*) {}
+#endif
+
+void install_transport_key_handlers(GtkWidget* window) {
+    GtkEventController* controller = gtk_event_controller_key_new();
+    gtk_event_controller_set_propagation_phase(controller, GTK_PHASE_CAPTURE);
+    g_signal_connect(controller, "key-pressed", G_CALLBACK(on_editor_key_pressed),
+                     nullptr);
+    gtk_widget_add_controller(window, controller);
+    grab_transport_key_on_x11_window(window);
+}
 
 /// Entry point for the dedicated GTK event-loop thread.
 void gtk_thread_main() {
@@ -324,6 +428,8 @@ static void close_editor_on_gtk_thread(SphereDauxVst3Processor* proc) {
     void* win_ptr = sphere_daux_editor_get_native_window(proc);
     if (!win_ptr) return;
 
+    ungrab_transport_key_on_x11_window(static_cast<GtkWidget*>(win_ptr));
+
     // Grab the IRunLoop frame (stored in native_embed) before clearing.
     auto* frame = static_cast<LinuxRunLoopFrame*>(
         sphere_daux_editor_get_native_embed(proc));
@@ -455,6 +561,9 @@ static gboolean idle_open_editor(gpointer user_data) {
         // XEmbed expect a mapped parent XID when the plug-in reparents.
         gtk_window_present(GTK_WINDOW(window));
 
+        // Space → transport before the plug-in (or its XEmbed child) can eat it.
+        install_transport_key_handlers(window);
+
         // ── Attach IPlugView ──────────────────────────────────────────────
         // Pass the X11 Window ID cast to void* (XEmbed parent).
         if (!sphere_daux_editor_attach_view(proc,
@@ -466,6 +575,7 @@ static gboolean idle_open_editor(gpointer user_data) {
                          kLinuxPlatformType);
             sphere_daux_editor_set_frame(proc, nullptr);
             delete frame;
+            ungrab_transport_key_on_x11_window(window);
             gtk_window_destroy(GTK_WINDOW(window));
             goto done;
         }

--- a/crates/SphereDirectAudioEngine/vst3bridge/src/editorplatform/windows/editor_windows_windowproc.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/editorplatform/windows/editor_windows_windowproc.cpp
@@ -3,6 +3,9 @@
 #include <algorithm>
 #include <cstdio>
 
+// Process-wide transport claim (same counter the host IPC loop drains).
+extern "C" void sphere_daux_vst3_claim_transport_toggle(void);
+
 namespace daux_editor_windows {
 
 LRESULT hit_test(HWND h, Context *c, LPARAM lp) {
@@ -126,6 +129,18 @@ LRESULT CALLBACK content_proc(HWND h, UINT msg, WPARAM wp, LPARAM lp) {
       return 0;
     }
     break;
+  case WM_KEYDOWN:
+  case WM_SYSKEYDOWN:
+    // Bare Space → DAW transport. Claims before DefWindowProc / plugin child
+    // can consume it when focus is on our content surface.
+    if (wp == VK_SPACE && (lp & (1u << 30)) == 0) {
+      if ((GetKeyState(VK_CONTROL) >= 0) && (GetKeyState(VK_MENU) >= 0) &&
+          (GetKeyState(VK_LWIN) >= 0) && (GetKeyState(VK_RWIN) >= 0)) {
+        sphere_daux_vst3_claim_transport_toggle();
+        return 0;
+      }
+    }
+    break;
   case WM_ERASEBKGND:
     return 1; // fully repainted in WM_PAINT (no flicker)
   case WM_PAINT: {
@@ -168,6 +183,16 @@ LRESULT CALLBACK top_proc(HWND h, UINT msg, WPARAM wp, LPARAM lp) {
       c->window.shell_hwnd = ptr(h);
     return TRUE;
   }
+  case WM_KEYDOWN:
+  case WM_SYSKEYDOWN:
+    if (wp == VK_SPACE && (lp & (1u << 30)) == 0) {
+      if ((GetKeyState(VK_CONTROL) >= 0) && (GetKeyState(VK_MENU) >= 0) &&
+          (GetKeyState(VK_LWIN) >= 0) && (GetKeyState(VK_RWIN) >= 0)) {
+        sphere_daux_vst3_claim_transport_toggle();
+        return 0;
+      }
+    }
+    break;
   case WM_NCCALCSIZE:
     if (wp && borderless)
       return 0;

--- a/crates/SphereDirectAudioEngine/vst3bridge/src/vst3_processor.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/vst3_processor.cpp
@@ -4146,6 +4146,21 @@ sphere_daux_vst3_embed_take_user_close(SphereDauxVst3Processor *processor) {
 #endif
 }
 
+// Process-wide transport-key counter shared by Win32 / AppKit / GTK editors and
+// the host's low-level keyboard filters. Host IPC drains this into
+// HostEvent::TransportToggleRequested; main app never touches it.
+namespace {
+std::atomic<unsigned int> g_transport_toggle_requests{0};
+} // namespace
+
+extern "C" void sphere_daux_vst3_claim_transport_toggle(void) {
+  g_transport_toggle_requests.fetch_add(1, std::memory_order_relaxed);
+}
+
+extern "C" unsigned int sphere_daux_vst3_take_transport_toggle_requests(void) {
+  return g_transport_toggle_requests.exchange(0, std::memory_order_relaxed);
+}
+
 extern "C" void
 sphere_daux_vst3_embed_set_waiting_stage(SphereDauxVst3Processor *processor,
                                          const char *stage) {

--- a/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
+++ b/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
@@ -5142,27 +5142,29 @@ mod platform {
     use windows::Win32::Foundation::{LPARAM, RECT, WAIT_OBJECT_0, WPARAM};
     use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED};
     use windows::Win32::System::Threading::{
-        GetCurrentThreadId, GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        GetCurrentProcessId, GetCurrentThreadId, GetExitCodeProcess, OpenProcess,
+        PROCESS_QUERY_LIMITED_INFORMATION,
     };
     use windows::Win32::UI::HiDpi::{
         GetDpiForSystem, SetThreadDpiAwarenessContext, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
     };
     use windows::Win32::UI::Input::KeyboardAndMouse::{
-        GetCapture, GetFocus, GetKeyState, IsWindowEnabled, ReleaseCapture, SetFocus, VIRTUAL_KEY,
-        VK_CONTROL, VK_LWIN, VK_MENU, VK_RWIN,
+        GetAsyncKeyState, GetCapture, GetFocus, GetKeyState, IsWindowEnabled, ReleaseCapture,
+        SetFocus, VIRTUAL_KEY, VK_CONTROL, VK_LWIN, VK_MENU, VK_RWIN, VK_SPACE,
     };
     use windows::Win32::UI::WindowsAndMessaging::{
-        BringWindowToTop, ChildWindowFromPointEx, CreateWindowExW, DestroyWindow, DispatchMessageW,
-        EnumChildWindows, EnumThreadWindows, GetAncestor, GetClassNameW, GetParent, GetWindow,
-        GetWindowLongPtrW, GetWindowRect, GetWindowTextW, GetWindowThreadProcessId, IsChild,
-        IsDialogMessageW, IsWindow, IsWindowVisible, MsgWaitForMultipleObjectsEx, PeekMessageW,
-        PostThreadMessageW, SetForegroundWindow, SetWindowPos, ShowWindow, TranslateMessage,
+        BringWindowToTop, CallNextHookEx, ChildWindowFromPointEx, CreateWindowExW, DestroyWindow,
+        DispatchMessageW, EnumChildWindows, EnumThreadWindows, GetAncestor, GetClassNameW,
+        GetForegroundWindow, GetParent, GetWindow, GetWindowLongPtrW, GetWindowRect, GetWindowTextW,
+        GetWindowThreadProcessId, IsChild, IsDialogMessageW, IsWindow, IsWindowVisible,
+        MsgWaitForMultipleObjectsEx, PeekMessageW, PostThreadMessageW, SetForegroundWindow,
+        SetWindowPos, SetWindowsHookExW, ShowWindow, TranslateMessage, UnhookWindowsHookEx,
         WindowFromPoint, CWP_ALL, CW_USEDEFAULT, GA_PARENT, GA_ROOT, GWLP_HWNDPARENT, GWL_EXSTYLE,
-        GWL_STYLE, GW_CHILD, GW_OWNER, HWND_TOP, MSG, MWMO_INPUTAVAILABLE, PM_REMOVE, QS_ALLINPUT,
-        SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW, SW_SHOWNORMAL, WINDOW_EX_STYLE, WM_KEYDOWN,
-        WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MOUSEMOVE, WM_NULL, WM_RBUTTONDOWN,
-        WM_RBUTTONUP, WM_TIMER, WS_CHILD, WS_CLIPCHILDREN, WS_CLIPSIBLINGS, WS_OVERLAPPEDWINDOW,
-        WS_VISIBLE,
+        GWL_STYLE, GW_CHILD, GW_OWNER, HHOOK, HOOKPROC, HWND_TOP, KBDLLHOOKSTRUCT, LLKHF_INJECTED,
+        MSG, MWMO_INPUTAVAILABLE, PM_REMOVE, QS_ALLINPUT, SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW,
+        SW_SHOWNORMAL, WH_KEYBOARD_LL, WINDOW_EX_STYLE, WM_KEYDOWN, WM_LBUTTONDOWN, WM_LBUTTONUP,
+        WM_MBUTTONDOWN, WM_MOUSEMOVE, WM_NULL, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SYSKEYDOWN,
+        WM_TIMER, WS_CHILD, WS_CLIPCHILDREN, WS_CLIPSIBLINGS, WS_OVERLAPPEDWINDOW, WS_VISIBLE,
     };
 
     /// End-to-end plugin debug switch (`FUTUREBOARD_PLUGIN_DEBUG=1`), shared
@@ -5296,6 +5298,74 @@ mod platform {
         unsafe {
             let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
         }
+        install_transport_keyboard_hook();
+    }
+
+    /// Low-level keyboard hook so Space still reaches the host when a plug-in's
+    /// own UI thread (CEF / JUCE / browser editors) owns the message queue.
+    /// Only claims when *this process* owns the foreground window — the main
+    /// Studio process keeps Space when the arrangement is focused.
+    fn install_transport_keyboard_hook() {
+        static HOOK: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+        HOOK.get_or_init(|| {
+            unsafe {
+                match SetWindowsHookExW(WH_KEYBOARD_LL, Some(transport_ll_keyboard_proc), None, 0)
+                {
+                    Ok(hook) if !hook.is_invalid() => {
+                        // Keep the hook alive for process lifetime. The OS unhooks
+                        // when the process exits; we deliberately leak the handle.
+                        std::mem::forget(hook);
+                        eprintln!("[PluginEditorInput] WH_KEYBOARD_LL transport hook installed");
+                    }
+                    Ok(_) | Err(_) => {
+                        eprintln!(
+                            "[PluginEditorInput] WARNING failed to install WH_KEYBOARD_LL transport hook"
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    unsafe extern "system" fn transport_ll_keyboard_proc(
+        code: i32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> windows::Win32::Foundation::LRESULT {
+        if code >= 0 {
+                let msg = wparam.0 as u32;
+                if msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN {
+                let kb = &*(lparam.0 as *const KBDLLHOOKSTRUCT);
+                let injected = (kb.flags.0 & LLKHF_INJECTED.0) != 0;
+                if !injected && kb.vkCode == VK_SPACE.0 as u32 {
+                    let held = |vk: VIRTUAL_KEY| GetAsyncKeyState(vk.0 as i32) < 0;
+                    if !held(VK_CONTROL) && !held(VK_MENU) && !held(VK_LWIN) && !held(VK_RWIN) {
+                        let fg = GetForegroundWindow();
+                        let mut pid = 0u32;
+                        if !fg.is_invalid() {
+                            GetWindowThreadProcessId(fg, Some(&mut pid));
+                        }
+                        if pid == GetCurrentProcessId() {
+                            let focus = GetFocus();
+                            let text =
+                                !focus.is_invalid() && is_text_entry_class(&class_name(focus));
+                            if !text {
+                                TRANSPORT_TOGGLE_REQUESTS
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                if plugin_debug() {
+                                    eprintln!(
+                                        "[PluginEditorInput] transport key claimed via WH_KEYBOARD_LL"
+                                    );
+                                }
+                                // Swallow so the plug-in does not also act on Space.
+                                return windows::Win32::Foundation::LRESULT(1);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        CallNextHookEx(None, code, wparam, lparam)
     }
 
     pub fn ensure_dpi_awareness() {
@@ -5554,7 +5624,9 @@ mod platform {
     fn is_transport_toggle_key(msg: &MSG) -> bool {
         const VK_SPACE_W: usize = 0x20;
         const KEY_REPEAT_BIT: isize = 1 << 30;
-        if msg.message != WM_KEYDOWN || msg.wParam.0 != VK_SPACE_W {
+        if (msg.message != WM_KEYDOWN && msg.message != WM_SYSKEYDOWN)
+            || msg.wParam.0 != VK_SPACE_W
+        {
             return false;
         }
         if msg.lParam.0 & KEY_REPEAT_BIT != 0 {
@@ -5576,7 +5648,17 @@ mod platform {
     /// Number of transport-key presses since the last call. The IPC loop turns
     /// each into a `HostEvent::TransportToggleRequested`.
     pub fn take_transport_toggle_requests() -> u32 {
-        TRANSPORT_TOGGLE_REQUESTS.swap(0, std::sync::atomic::Ordering::Relaxed)
+        let from_pump = TRANSPORT_TOGGLE_REQUESTS.swap(0, std::sync::atomic::Ordering::Relaxed);
+        // C++ editor shell / shared VST3 host also publishes claims here (e.g.
+        // Content HWND WndProc when focus never enters the PeekMessage path).
+        let from_daux = unsafe { daux_transport::sphere_daux_vst3_take_transport_toggle_requests() };
+        from_pump.saturating_add(from_daux)
+    }
+
+    mod daux_transport {
+        unsafe extern "C" {
+            pub fn sphere_daux_vst3_take_transport_toggle_requests() -> u32;
+        }
     }
 
     #[cfg(test)]
@@ -6121,17 +6203,26 @@ mod platform {
     }
 
     /// Number of transport-key presses claimed from plug-in editor windows since
-    /// the last call. The AppKit pump swallows a bare Space so the main app can
-    /// run its own `transport:play-pause`; see the Windows pump for the same
-    /// contract.
+    /// the last call. Platform pumps + the process-wide C++ VST3 counter all
+    /// feed this.
     pub fn take_transport_toggle_requests() -> u32 {
-        #[cfg(target_os = "macos")]
-        {
-            unsafe { appkit::sphere_plugin_host_mac_ui_take_transport_toggles() as u32 }
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            0
+        let from_platform = {
+            #[cfg(target_os = "macos")]
+            {
+                unsafe { appkit::sphere_plugin_host_mac_ui_take_transport_toggles() as u32 }
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                0u32
+            }
+        };
+        let from_daux = unsafe { daux_transport::sphere_daux_vst3_take_transport_toggle_requests() };
+        from_platform.saturating_add(from_daux)
+    }
+
+    mod daux_transport {
+        unsafe extern "C" {
+            pub fn sphere_daux_vst3_take_transport_toggle_requests() -> u32;
         }
     }
 

--- a/crates/SpherePluginHost/vst3backend/src/host_ui_mac.mm
+++ b/crates/SpherePluginHost/vst3backend/src/host_ui_mac.mm
@@ -102,9 +102,23 @@ extern "C" void sphere_plugin_host_mac_ui_init(void) {
     // stays the app the user sees.
     [app setActivationPolicy:NSApplicationActivationPolicyAccessory];
     [app finishLaunching];
+
+    // Local monitor covers every key window in this process, including plug-in
+    // views that never go through nextEventMatchingMask in our pump (CEF/JUCE
+    // nested run loops). Returning nil swallows the event — same contract as
+    // the Windows WH_KEYBOARD_LL path.
+    [NSEvent
+        addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown
+                                     handler:^NSEvent *(NSEvent *event) {
+                                       if (claim_transport_key(event)) {
+                                         return nil;
+                                       }
+                                       return event;
+                                     }];
+
     std::fprintf(stderr,
                  "[plugin-host-ui/mac] NSApplication ready policy=accessory "
-                 "main_thread=%d\n",
+                 "transport_key_monitor=on main_thread=%d\n",
                  (int)NSThread.isMainThread);
   }
 }

--- a/crates/SphereUIComponents/src/components/builtin_plugin_editor_window.rs
+++ b/crates/SphereUIComponents/src/components/builtin_plugin_editor_window.rs
@@ -1820,11 +1820,27 @@ impl Render for BuiltinPluginEditorWindow {
             _ => None,
         };
 
+        // Space must work even when focus is not on the CEF surface (titlebar /
+        // instance sidebar) and on every OS — not only off-screen hosts. Capture
+        // phase on the shell so bare Space always reaches the same transport
+        // command as the arrangement. Windowed CEF still also claims via
+        // OnPreKeyEvent; that path returns 1 (consumed) so we never toggle twice.
+        let transport_claim = cx.listener(|this, event: &KeyDownEvent, _window, cx| {
+            if !Self::is_transport_toggle_keystroke(&event.keystroke) || event.is_held {
+                return;
+            }
+            if let Some(dispatch) = this.host_ops.dispatch_global_command.as_ref() {
+                dispatch("transport:play-pause", cx);
+                cx.stop_propagation();
+            }
+        });
+
         div()
             .size_full()
             .flex()
             .flex_col()
             .bg(Colors::surface_panel())
+            .capture_key_down(transport_claim)
             .child(
                 // Shared external-dialog titlebar: gives this window the same
                 // chrome as every other floating Studio surface, plus the drag
@@ -2103,12 +2119,27 @@ impl BuiltinPluginEditorWindow {
         Self::schedule_input_pump(cx);
     }
 
+    /// Bare Space (no Ctrl/Alt/Cmd/Win, no platform key) — DAW transport
+    /// owns this, not the page. Matches the CEF `OnPreKeyEvent` contract used
+    /// by the windowed Windows path.
+    fn is_transport_toggle_keystroke(keystroke: &gpui::Keystroke) -> bool {
+        let key = keystroke.key.as_str();
+        if key != "space" && key != " " {
+            return false;
+        }
+        let mods = keystroke.modifiers;
+        !(mods.control || mods.alt || mods.platform || mods.secondary())
+    }
+
     fn on_surface_key_down(
         &mut self,
         event: &KeyDownEvent,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Bare Space is claimed on the shell (`capture_key_down` in `render`) so
+        // it never lands here as character input into the page.
+
         let modifiers = self.surface.modifiers(event.keystroke.modifiers);
         if let Some(key) = editor_key(&event.keystroke, EditorKeyKind::Down, modifiers) {
             self.send_input(EditorInput::Key(key));


### PR DESCRIPTION
…s on all OSes

Keys stay on the host/plugin process while an editor is focused, so bare Space never reached the main window. Claim it process-wide (Win32 LL hook + shell WndProc, AppKit local monitor, GTK/XEmbed grab) and from built-in CEF shells, then run the same transport:play-pause command as the arrangement.