### PR TITLE
fix(transport): keep Space play/pause working inside effect editors

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Editor.tsx
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Editor.tsx
@@ -32,6 +32,7 @@ import {
   postPathOrder,
   type NamCaptureLoadOptions,
 } from "./bridge";
+import { postGlobalCommand } from "./instanceBridge";
 import { POWER_PARAM_ID } from "./globals";
 import {
   activeSnapshot,
@@ -1054,8 +1055,20 @@ export function RodhareistEditor({
         return;
       }
       if (e.key === " " || e.code === "Space") {
+        const target = e.target as HTMLElement | null;
+        if (
+          target &&
+          (target.tagName === "INPUT" ||
+            target.tagName === "TEXTAREA" ||
+            target.isContentEditable)
+        ) {
+          return;
+        }
+        // DAW transport owns bare Space on the editor surface. Forward so
+        // play/pause still works when the native claim path misses an OSR
+        // focus edge case. Never steal Space for bypass.
         e.preventDefault();
-        toggleBypass();
+        postGlobalCommand("transport:play-pause");
         return;
       }
       if (e.key >= "1" && e.key <= "9") {
@@ -1078,7 +1091,6 @@ export function RodhareistEditor({
     saveRig,
     selectCategory,
     stepPreset,
-    toggleBypass,
   ]);
 
   const pendingName =

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/instanceBridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/instanceBridge.ts
@@ -398,3 +398,17 @@ export function postSetParams(edits: ParamEdit[]): void {
     params: edits,
   });
 }
+
+/**
+ * Ask the DAW for a workspace command (e.g. transport play/pause). Not tied to
+ * a parameter binding so Space can still reach the studio with no instance yet.
+ * Native dedupes against `OnPreKeyEvent` / shell capture when those already
+ * claimed the physical key.
+ */
+export function postGlobalCommand(commandId: string): void {
+  if (!commandId) return;
+  post({
+    type: "futureboard.globalCommand",
+    commandId,
+  });
+}

--- a/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
@@ -17,6 +17,7 @@
 // VST3 spec reference:
 //   pluginterfaces/gui/iplugview.h — kPlatformTypeX11EmbedWindowID = "X11EmbedWindowID"
 
+#include <algorithm>
 #include <condition_variable>
 #include <cstdio>
 #include <cstring>
@@ -82,6 +83,20 @@ bool is_transport_toggle_key(guint keyval, GdkModifierType state) {
     return (state & blocking) == 0;
 }
 
+/// Debounce so the Gtk controller, XGrabKey path, and focus-poll path never
+/// each turn one physical press into three `TransportToggle` frames.
+void claim_transport_toggle_debounced(const char* source) {
+    static guint64 s_last_claim_ms = 0;
+    const guint64 now = g_get_monotonic_time() / 1000; // µs → ms
+    if (s_last_claim_ms != 0 && now - s_last_claim_ms < 80) {
+        return;
+    }
+    s_last_claim_ms = now;
+    sphere_daux_vst3_claim_transport_toggle();
+    std::fprintf(stderr,
+                 "[SphereVST3/linux] transport key claimed source=%s\n", source);
+}
+
 /// Claim Space for transport before the plug-in sees it. Returns TRUE when
 /// consumed (stop further handling), matching the Win32 / AppKit pumps.
 gboolean on_editor_key_pressed(GtkEventControllerKey* /*controller*/,
@@ -92,13 +107,172 @@ gboolean on_editor_key_pressed(GtkEventControllerKey* /*controller*/,
     if (!is_transport_toggle_key(keyval, state)) {
         return FALSE;
     }
-    sphere_daux_vst3_claim_transport_toggle();
-    std::fprintf(stderr,
-                 "[SphereVST3/linux] transport key claimed from editor focus\n");
+    claim_transport_toggle_debounced("gtk-capture");
     return TRUE;
 }
 
 #ifdef GDK_WINDOWING_X11
+// Open host editor XIDs (GtkWindow surfaces). The Space focus-poll uses these
+// to decide whether the current X focus lives inside a Futureboard editor.
+std::mutex s_editor_xids_mutex;
+std::vector<Window> s_editor_xids;
+guint s_space_poll_source = 0;
+bool s_space_was_down = false;
+
+const unsigned int k_transport_grab_masks[] = {
+    0u,
+    LockMask,
+    Mod2Mask,
+    LockMask | Mod2Mask,
+    Mod5Mask,
+    LockMask | Mod5Mask,
+    Mod2Mask | Mod5Mask,
+    LockMask | Mod2Mask | Mod5Mask,
+};
+
+bool window_is_under_any_editor(Display* dpy, Window focus) {
+    if (focus == None || focus == PointerRoot) {
+        return false;
+    }
+    std::vector<Window> editors;
+    {
+        std::lock_guard<std::mutex> lk(s_editor_xids_mutex);
+        editors = s_editor_xids;
+    }
+    if (editors.empty()) {
+        return false;
+    }
+    // Walk focus → root; match any registered host editor XID (the XEmbed child
+    // is a descendant of our GtkWindow surface).
+    Window current = focus;
+    for (int depth = 0; depth < 64 && current != None; ++depth) {
+        for (Window editor : editors) {
+            if (current == editor) {
+                return true;
+            }
+        }
+        Window root = None;
+        Window parent = None;
+        Window* children = nullptr;
+        unsigned int nchildren = 0;
+        if (!XQueryTree(dpy, current, &root, &parent, &children, &nchildren)) {
+            break;
+        }
+        if (children) {
+            XFree(children);
+        }
+        if (parent == None || parent == current || parent == root) {
+            // Final check against root-level editors (rare).
+            for (Window editor : editors) {
+                if (current == editor) {
+                    return true;
+                }
+            }
+            break;
+        }
+        current = parent;
+    }
+    return false;
+}
+
+bool keycode_is_down(const char keys[32], KeyCode code) {
+    if (code == 0) {
+        return false;
+    }
+    return (keys[code / 8] & (1 << (code % 8))) != 0;
+}
+
+/// Some plug-ins keep the keyboard on a foreign X connection; the Gtk
+/// capture/XGrabKey path then never sees Space. While any editor is open,
+/// poll XQueryKeymap and claim Space on rising edges under our editor tree.
+gboolean poll_transport_space_key(gpointer /*user_data*/) {
+    Display* dpy = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(s_editor_xids_mutex);
+        if (s_editor_xids.empty()) {
+            s_space_poll_source = 0;
+            s_space_was_down = false;
+            return G_SOURCE_REMOVE;
+        }
+    }
+    GdkDisplay* display = gdk_display_get_default();
+    if (!display || !GDK_IS_X11_DISPLAY(display)) {
+        return G_SOURCE_CONTINUE;
+    }
+    dpy = gdk_x11_display_get_xdisplay(display);
+    if (!dpy) {
+        return G_SOURCE_CONTINUE;
+    }
+
+    char keys[32];
+    XQueryKeymap(dpy, keys);
+    const KeyCode space = XKeysymToKeycode(dpy, XK_space);
+    const KeyCode kp_space = XKeysymToKeycode(dpy, XK_KP_Space);
+    const bool space_down =
+        keycode_is_down(keys, space) || keycode_is_down(keys, kp_space);
+    const bool rising = space_down && !s_space_was_down;
+    s_space_was_down = space_down;
+    if (!rising) {
+        return G_SOURCE_CONTINUE;
+    }
+
+    // Ignore while a modifier that should block the transport is held.
+    const KeyCode control_l = XKeysymToKeycode(dpy, XK_Control_L);
+    const KeyCode control_r = XKeysymToKeycode(dpy, XK_Control_R);
+    const KeyCode alt_l = XKeysymToKeycode(dpy, XK_Alt_L);
+    const KeyCode alt_r = XKeysymToKeycode(dpy, XK_Alt_R);
+    const KeyCode super_l = XKeysymToKeycode(dpy, XK_Super_L);
+    const KeyCode super_r = XKeysymToKeycode(dpy, XK_Super_R);
+    if (keycode_is_down(keys, control_l) || keycode_is_down(keys, control_r) ||
+        keycode_is_down(keys, alt_l) || keycode_is_down(keys, alt_r) ||
+        keycode_is_down(keys, super_l) || keycode_is_down(keys, super_r)) {
+        return G_SOURCE_CONTINUE;
+    }
+
+    Window focus = None;
+    int revert = RevertToNone;
+    XGetInputFocus(dpy, &focus, &revert);
+    if (!window_is_under_any_editor(dpy, focus)) {
+        return G_SOURCE_CONTINUE;
+    }
+
+    claim_transport_toggle_debounced("x11-focus-poll");
+    return G_SOURCE_CONTINUE;
+}
+
+void register_editor_xid(Window xid) {
+    if (xid == 0) {
+        return;
+    }
+    std::lock_guard<std::mutex> lk(s_editor_xids_mutex);
+    for (Window existing : s_editor_xids) {
+        if (existing == xid) {
+            return;
+        }
+    }
+    s_editor_xids.push_back(xid);
+    if (s_space_poll_source == 0) {
+        // 8 ms: short enough to catch a tap, long enough not to burn the GTK
+        // thread. Only runs while an editor XID is registered.
+        s_space_poll_source = g_timeout_add(8, poll_transport_space_key, nullptr);
+    }
+}
+
+void unregister_editor_xid(Window xid) {
+    if (xid == 0) {
+        return;
+    }
+    std::lock_guard<std::mutex> lk(s_editor_xids_mutex);
+    s_editor_xids.erase(
+        std::remove(s_editor_xids.begin(), s_editor_xids.end(), xid),
+        s_editor_xids.end());
+    if (s_editor_xids.empty() && s_space_poll_source != 0) {
+        g_source_remove(s_space_poll_source);
+        s_space_poll_source = 0;
+        s_space_was_down = false;
+    }
+}
+
 /// XEmbed children hold the keyboard focus independently of the GtkWindow.
 /// A passive grab on the host XID still delivers Space to us when a descendant
 /// (the plug-in view) has focus — without it, Space never reaches GTK.
@@ -113,20 +287,13 @@ void grab_transport_key_on_x11_window(GtkWidget* window) {
     if (code == 0 || xid == 0) {
         return;
     }
-    // Lock/NumLock as irrelevant noise — grab every common combination so a
-    // sticky lock state does not silently re-arm the plug-in's Space.
-    const unsigned int masks[] = {
-        0u,
-        LockMask,
-        Mod2Mask,
-        LockMask | Mod2Mask,
-    };
-    for (unsigned int mask : masks) {
+    for (unsigned int mask : k_transport_grab_masks) {
         // owner_events=False: we claim the press even when the focus window is
         // an embedded foreign XEmbed child.
         XGrabKey(dpy, code, mask, xid, False, GrabModeAsync, GrabModeAsync);
     }
     XFlush(dpy);
+    register_editor_xid(xid);
 }
 
 void ungrab_transport_key_on_x11_window(GtkWidget* window) {
@@ -143,16 +310,11 @@ void ungrab_transport_key_on_x11_window(GtkWidget* window) {
     if (code == 0 || xid == 0) {
         return;
     }
-    const unsigned int masks[] = {
-        0u,
-        LockMask,
-        Mod2Mask,
-        LockMask | Mod2Mask,
-    };
-    for (unsigned int mask : masks) {
+    for (unsigned int mask : k_transport_grab_masks) {
         XUngrabKey(dpy, code, mask, xid);
     }
     XFlush(dpy);
+    unregister_editor_xid(xid);
 }
 #else
 void grab_transport_key_on_x11_window(GtkWidget*) {}

--- a/crates/SphereUIComponents/src/components/builtin_plugin_editor_window.rs
+++ b/crates/SphereUIComponents/src/components/builtin_plugin_editor_window.rs
@@ -1820,18 +1820,29 @@ impl Render for BuiltinPluginEditorWindow {
             _ => None,
         };
 
+        // Same focus-reclaim contract as MixerWindow: GPUI only routes key events
+        // along the focused dispatch path. Sidebar / titlebar clicks leave no
+        // focus handle, so capture_key_down never runs and Space dies — especially
+        // on Linux. Off-screen CEF still receives keys through our surface
+        // forwarder once this shell holds focus again.
+        if OFFSCREEN_HOSTING && !self.focus.is_focused(window) {
+            window.focus(&self.focus, cx);
+        }
+        let focus_on_pointer = self.focus.clone();
+
         // Space must work even when focus is not on the CEF surface (titlebar /
         // instance sidebar) and on every OS — not only off-screen hosts. Capture
         // phase on the shell so bare Space always reaches the same transport
         // command as the arrangement. Windowed CEF still also claims via
         // OnPreKeyEvent; that path returns 1 (consumed) so we never toggle twice.
-        let transport_claim = cx.listener(|this, event: &KeyDownEvent, _window, cx| {
+        let transport_claim = cx.listener(|this, event: &KeyDownEvent, window, cx| {
             if !Self::is_transport_toggle_keystroke(&event.keystroke) || event.is_held {
                 return;
             }
             if let Some(dispatch) = this.host_ops.dispatch_global_command.as_ref() {
-                dispatch("transport:play-pause", cx);
+                window.prevent_default();
                 cx.stop_propagation();
+                dispatch("transport:play-pause", cx);
             }
         });
 
@@ -1840,6 +1851,11 @@ impl Render for BuiltinPluginEditorWindow {
             .flex()
             .flex_col()
             .bg(Colors::surface_panel())
+            // Pointer anywhere on the shell (titlebar, sidebar, browser) reclaims
+            // the keyboard anchor so the next Space hits the transport claim.
+            .capture_any_mouse_down(move |_event, window, cx| {
+                focus_on_pointer.focus(window, cx);
+            })
             .capture_key_down(transport_claim)
             .child(
                 // Shared external-dialog titlebar: gives this window the same
@@ -2124,7 +2140,11 @@ impl BuiltinPluginEditorWindow {
     /// by the windowed Windows path.
     fn is_transport_toggle_keystroke(keystroke: &gpui::Keystroke) -> bool {
         let key = keystroke.key.as_str();
-        if key != "space" && key != " " {
+        // Linux/XKB and some IMs emit bare `" "` or `"Spacebar"` rather than `"space"`.
+        if !matches!(
+            key,
+            "space" | " " | "spacebar" | "Space" | "Spacebar" | "kp-space"
+        ) {
             return false;
         }
         let mods = keystroke.modifiers;


### PR DESCRIPTION
## Summary
- Reclaim GPUI keyboard focus in built-in CEF editor shells (same Linux contract as the mixer) so Space always hits the transport capture path.
- Stop Rodhareist from using Space for module bypass; page forwards bare Space to `transport:play-pause` (text fields still get Space).
- Linux VST host: poll Space when keyboard focus is under an open editor XID, debounce claims, and broaden XGrabKey lock masks.

## Test plan
- [ ] Rebuild `futureboard_native` and `sphere-plugin-host` bins, restart with the host next to the app
- [ ] Open a built-in effect (e.g. Rodhareist) → Space toggles play/pause
- [ ] Click titlebar/sidebar then Space → still plays/pauses
- [ ] Focus a preset name field → Space inserts space, does not toggle transport
- [ ] Open an external VST on Linux → Space toggles play/pause while editor is focused
- [ ] Arrangement without plugin focused → Space still works as before


Made with [Cursor](https://cursor.com)