### PR TITLE
Keep the PDC latency refresh off the allocator on the audio thread

### DIFF
--- a/crates/SphereDirectAudioEngine/src/engine.rs
+++ b/crates/SphereDirectAudioEngine/src/engine.rs
@@ -5654,6 +5654,10 @@ mod bridge_insert_tests {
         // The block path reads the cached per-insert sink, exactly like the
         // SetPluginBridgeSink command handler.
         p.resolve_bridge_sinks();
+        // `build` plans and reserves before the callback ever runs; a
+        // hand-assembled project has to do the same or the realtime refresh has
+        // no sized plan to rewrite.
+        p.plan_latency_and_pdc();
 
         assert!(p.refresh_runtime_latency_graph(frames as u32));
         assert_eq!(p.latency_graph.track_plugin_latency[0], 0);
@@ -5661,6 +5665,126 @@ mod bridge_insert_tests {
         assert_eq!(p.latency_graph.track_pdc_delay[0], 32);
         assert_eq!(p.latency_graph.track_pdc_delay[1], 0);
         assert!(!p.refresh_runtime_latency_graph(frames as u32));
+    }
+
+    /// A bridged plugin whose reported latency moves while the graph stays put —
+    /// what a network plugin tracking its own jitter buffer looks like to the
+    /// host, as opposed to a fixed-latency effect.
+    #[derive(Debug, Default)]
+    struct DriftingLatencySink {
+        latency_samples: AtomicU32,
+    }
+
+    impl PluginBridgeSink for DriftingLatencySink {
+        fn dsp_ready(&self) -> bool {
+            true
+        }
+
+        fn read_output(&self, _: &mut [f32], _: &mut [f32], frames: usize) -> usize {
+            frames
+        }
+
+        fn push_midi(&self, _: u8, _: u8, _: u8, _: u32) {}
+
+        fn write_input(&self, _: &[f32], _: &[f32], _: usize) {}
+
+        fn request_block(&self, _: u32) {}
+
+        fn reported_latency_samples(&self) -> u32 {
+            self.latency_samples.load(Ordering::Relaxed)
+        }
+    }
+
+    #[test]
+    fn drifting_bridge_latency_refresh_matches_a_control_thread_replan() {
+        // The realtime refresh rewrites the plan in place instead of rebuilding
+        // it, so it has to land exactly where a fresh control-thread plan would
+        // — including on the way back down, where a stale value left in a reused
+        // vector would survive as phantom compensation.
+        let frames = 64u32;
+        let mut src = bridge_effect_track(1.0);
+        src.id = "src".to_string();
+        src.inserts[0].id = "src-insert".to_string();
+        src.sends = vec![crate::runtime::RuntimeSend {
+            id: "send-1".to_string(),
+            return_track_id: "ret".to_string(),
+            return_track_index: None,
+            level: 1.0,
+            enabled: true,
+            pre_fader: false,
+        }];
+        let mut ret = bridge_effect_track(1.0);
+        ret.id = "ret".to_string();
+        ret.track_type = "return".to_string();
+        ret.inserts.clear();
+        let mut master = bridge_effect_track(1.0);
+        master.id = "master".to_string();
+        master.track_type = "master".to_string();
+        master.inserts.clear();
+
+        let tracks = vec![src, ret, master];
+        let audio_graph = crate::audio_graph::plan_runtime_audio_graph(&tracks).unwrap();
+        let mut p = RuntimeProject {
+            tracks,
+            audio_graph,
+            pdc_enabled: true,
+            ..Default::default()
+        };
+        let sink = Arc::new(DriftingLatencySink::default());
+        p.plugin_bridge_sinks
+            .insert("src-insert".to_string(), sink.clone());
+        p.resolve_bridge_sinks();
+        p.plan_latency_and_pdc();
+
+        // Up, further up, then back down — the drop is the case a rebuild used
+        // to get for free.
+        for latency in [64u32, 4096, 128] {
+            sink.latency_samples.store(latency, Ordering::Relaxed);
+            assert!(
+                p.refresh_runtime_latency_graph(frames),
+                "latency {latency} should be observed as a change"
+            );
+
+            let observed = p.latency_graph.clone();
+            let expected = crate::latency_graph::plan_runtime_latency_graph(
+                &mut p.tracks,
+                &p.audio_graph,
+                p.pdc_enabled,
+            );
+            assert_eq!(
+                observed.track_plugin_latency, expected.track_plugin_latency,
+                "strip latency at {latency}"
+            );
+            assert_eq!(
+                observed.track_output_latency, expected.track_output_latency,
+                "output latency at {latency}"
+            );
+            assert_eq!(
+                observed.track_pdc_delay, expected.track_pdc_delay,
+                "pdc delays at {latency}"
+            );
+            assert_eq!(
+                observed.max_path_latency_samples, expected.max_path_latency_samples,
+                "max path at {latency}"
+            );
+
+            // Refitting inside the reserved capacity has to leave every ring
+            // long enough to actually serve its delay — `apply_pdc_delay_block`
+            // bypasses a track whose ring is too short.
+            for (idx, track) in p.tracks.iter().enumerate() {
+                let delay = observed.track_pdc_delay[idx] as usize;
+                assert!(
+                    delay == 0 || track.pdc_delay_l.len() > delay,
+                    "track {idx} ring {} cannot serve delay {delay} at latency {latency}",
+                    track.pdc_delay_l.len()
+                );
+            }
+
+            assert!(
+                !p.refresh_runtime_latency_graph(frames),
+                "a settled latency must not keep re-planning"
+            );
+        }
     }
 
     #[test]

--- a/crates/SphereDirectAudioEngine/src/latency_graph.rs
+++ b/crates/SphereDirectAudioEngine/src/latency_graph.rs
@@ -58,20 +58,37 @@ pub fn strip_plugin_latency_samples(track: &RuntimeTrack) -> u32 {
     from_inserts.max(track.plugin_latency_samples)
 }
 
-fn is_master_output(id: &str) -> bool {
-    id.is_empty() || id.eq_ignore_ascii_case("master")
+/// Resolve the routing indices latency planning reads: every track's
+/// main-output target and every send's return target.
+///
+/// Builds a track-id map, so this is a control-thread call — `RuntimeProject`
+/// runs it before the first plan and again from `resolve_indices` on every
+/// graph swap. Planning itself then works purely on indices, which is what lets
+/// the realtime refresh path recompute latency without hashing a track id.
+pub fn resolve_latency_routing_indices(tracks: &mut [RuntimeTrack]) {
+    let id_to_index: HashMap<String, usize> = tracks
+        .iter()
+        .enumerate()
+        .map(|(index, track)| (track.id.clone(), index))
+        .collect();
+    for track in tracks.iter_mut() {
+        track.output_track_index = track
+            .output_track_id
+            .as_deref()
+            .filter(|id| !crate::engine::is_master_output(id))
+            .and_then(|id| id_to_index.get(id).copied());
+        for send in &mut track.sends {
+            send.return_track_index = id_to_index.get(&send.return_track_id).copied();
+        }
+    }
 }
 
-fn resolve_output_target_index(
-    track_index: usize,
-    tracks: &[RuntimeTrack],
-    id_to_index: &HashMap<String, usize>,
-) -> Option<usize> {
-    let output_id = tracks[track_index].output_track_id.as_deref()?;
-    if is_master_output(output_id) {
-        return None;
-    }
-    id_to_index.get(output_id).copied()
+/// The track a main output feeds, or `None` when it reaches the master sum
+/// directly. This is the same index the render path routes on, so compensation
+/// is planned against the routing that actually runs.
+#[inline]
+fn resolve_output_target_index(track_index: usize, tracks: &[RuntimeTrack]) -> Option<usize> {
+    tracks[track_index].output_track_index
 }
 
 /// Tail latency from a routing track's output toward the master summing bus,
@@ -80,14 +97,13 @@ fn routing_tail_to_master(
     mut track_index: usize,
     tracks: &[RuntimeTrack],
     plugin_latency: &[u32],
-    id_to_index: &HashMap<String, usize>,
     master_index: Option<usize>,
 ) -> u32 {
     let mut tail = 0u32;
     let mut hops = 0usize;
     while hops < tracks.len() {
         hops += 1;
-        let Some(next) = resolve_output_target_index(track_index, tracks, id_to_index) else {
+        let Some(next) = resolve_output_target_index(track_index, tracks) else {
             break;
         };
         if Some(next) == master_index {
@@ -107,7 +123,6 @@ fn path_to_master_sum(
     tracks: &[RuntimeTrack],
     output_latency: &[u32],
     plugin_latency: &[u32],
-    id_to_index: &HashMap<String, usize>,
     master_index: Option<usize>,
 ) -> u32 {
     if Some(track_index) == master_index {
@@ -121,7 +136,6 @@ fn path_to_master_sum(
             track_index,
             tracks,
             plugin_latency,
-            id_to_index,
             master_index,
         ))
 }
@@ -131,7 +145,6 @@ fn effective_path_to_master(
     tracks: &[RuntimeTrack],
     output_latency: &[u32],
     plugin_latency: &[u32],
-    id_to_index: &HashMap<String, usize>,
     master_index: Option<usize>,
 ) -> u32 {
     let mut path = main_path_to_master(
@@ -139,7 +152,6 @@ fn effective_path_to_master(
         tracks,
         output_latency,
         plugin_latency,
-        id_to_index,
         master_index,
     );
 
@@ -147,13 +159,12 @@ fn effective_path_to_master(
         if !send.enabled {
             continue;
         }
-        if let Some(&ret_idx) = id_to_index.get(&send.return_track_id) {
+        if let Some(ret_idx) = send.return_track_index {
             let via_return = path_to_master_sum(
                 ret_idx,
                 tracks,
                 output_latency,
                 plugin_latency,
-                id_to_index,
                 master_index,
             );
             path = path.max(via_return);
@@ -170,20 +181,12 @@ fn main_path_to_master(
     tracks: &[RuntimeTrack],
     output_latency: &[u32],
     plugin_latency: &[u32],
-    id_to_index: &HashMap<String, usize>,
     master_index: Option<usize>,
 ) -> u32 {
-    resolve_output_target_index(track_index, tracks, id_to_index)
+    resolve_output_target_index(track_index, tracks)
         .filter(|&target| is_routing_track_type(&tracks[target].track_type))
         .map(|target| {
-            path_to_master_sum(
-                target,
-                tracks,
-                output_latency,
-                plugin_latency,
-                id_to_index,
-                master_index,
-            )
+            path_to_master_sum(target, tracks, output_latency, plugin_latency, master_index)
         })
         .unwrap_or_else(|| {
             path_to_master_sum(
@@ -191,7 +194,6 @@ fn main_path_to_master(
                 tracks,
                 output_latency,
                 plugin_latency,
-                id_to_index,
                 master_index,
             )
         })
@@ -200,8 +202,13 @@ fn main_path_to_master(
 /// Build latency metadata and per-track PDC delays from runtime tracks and the
 /// audio graph plan. When `pdc_enabled` is false, delays are zeroed but path
 /// latencies are still computed for reporting.
+///
+/// Takes the tracks mutably because it resolves their routing indices first:
+/// planning reads those, and a caller that had to remember to resolve them
+/// separately would get a silently mis-planned graph for forgetting. Control
+/// thread only — allocates.
 pub fn plan_runtime_latency_graph(
-    tracks: &[RuntimeTrack],
+    tracks: &mut [RuntimeTrack],
     audio_graph: &RuntimeAudioGraph,
     pdc_enabled: bool,
 ) -> RuntimeLatencyGraph {
@@ -209,19 +216,70 @@ pub fn plan_runtime_latency_graph(
     if n == 0 {
         return RuntimeLatencyGraph::default();
     }
+    resolve_latency_routing_indices(tracks);
 
-    let mut id_to_index: HashMap<String, usize> = HashMap::new();
-    for (idx, track) in tracks.iter().enumerate() {
-        id_to_index.insert(track.id.clone(), idx);
+    let mut graph = RuntimeLatencyGraph {
+        track_plugin_latency: vec![0; n],
+        track_output_latency: vec![0; n],
+        track_pdc_delay: vec![0; n],
+        max_path_latency_samples: 0,
+        master_plugin_latency: 0,
+    };
+    recompute_runtime_latency_graph(&mut graph, tracks, audio_graph, pdc_enabled);
+    graph
+}
+
+/// Recompute `graph` in place from the tracks' current latencies.
+///
+/// This is the whole planning algorithm; [`plan_runtime_latency_graph`] is just
+/// this behind a fresh allocation. Splitting it out is what makes the realtime
+/// refresh path safe: routing comes from the resolved index fields and every
+/// vector is already sized for `tracks`, so a recompute triggered from the audio
+/// callback by a bridged plugin's reported latency moving does not allocate,
+/// hash a track id, or touch the environment.
+///
+/// Only the numbers change here. Topology changes go through a graph swap, which
+/// rebuilds on the control thread via [`plan_runtime_latency_graph`], so a
+/// mismatched vector length means the caller skipped that swap — the recompute
+/// is skipped rather than resized, since growing a vector is exactly what this
+/// path exists to avoid.
+pub fn recompute_runtime_latency_graph(
+    graph: &mut RuntimeLatencyGraph,
+    tracks: &[RuntimeTrack],
+    audio_graph: &RuntimeAudioGraph,
+    pdc_enabled: bool,
+) {
+    let n = tracks.len();
+    debug_assert_eq!(graph.track_plugin_latency.len(), n);
+    debug_assert_eq!(graph.track_output_latency.len(), n);
+    debug_assert_eq!(graph.track_pdc_delay.len(), n);
+    if n == 0
+        || graph.track_plugin_latency.len() != n
+        || graph.track_output_latency.len() != n
+        || graph.track_pdc_delay.len() != n
+    {
+        return;
     }
 
-    let plugin_latency: Vec<u32> = tracks.iter().map(strip_plugin_latency_samples).collect();
+    // Destructured so the passes below can read one vector while writing
+    // another without the borrow checker seeing the whole graph as borrowed.
+    let RuntimeLatencyGraph {
+        track_plugin_latency: plugin_latency,
+        track_output_latency: output_latency,
+        track_pdc_delay,
+        max_path_latency_samples,
+        master_plugin_latency,
+    } = graph;
+
+    for (idx, track) in tracks.iter().enumerate() {
+        plugin_latency[idx] = strip_plugin_latency_samples(track);
+    }
     let master_index = audio_graph.master_index;
-    let master_plugin_latency = master_index
+    *master_plugin_latency = master_index
         .and_then(|idx| plugin_latency.get(idx).copied())
         .unwrap_or(0);
 
-    let mut output_latency = plugin_latency.clone();
+    output_latency.copy_from_slice(plugin_latency);
 
     for &idx in &audio_graph.pass2_routing_indices {
         let mut feed_max = 0u32;
@@ -233,19 +291,19 @@ pub fn plan_runtime_latency_graph(
                 if !send.enabled {
                     continue;
                 }
-                if id_to_index.get(&send.return_track_id) == Some(&idx) {
+                if send.return_track_index == Some(idx) {
                     feed_max = feed_max.max(output_latency[src_idx]);
                 }
             }
             // Main-output → bus/return feeds also contribute upstream latency.
-            if resolve_output_target_index(src_idx, tracks, &id_to_index) == Some(idx) {
+            if resolve_output_target_index(src_idx, tracks) == Some(idx) {
                 feed_max = feed_max.max(output_latency[src_idx]);
             }
         }
         output_latency[idx] = plugin_latency[idx].saturating_add(feed_max);
     }
 
-    let mut max_path_latency_samples = 0u32;
+    *max_path_latency_samples = 0;
     for idx in 0..n {
         if Some(idx) == master_index {
             continue;
@@ -253,19 +311,15 @@ pub fn plan_runtime_latency_graph(
         if is_master_track_type(&tracks[idx].track_type) {
             continue;
         }
-        let path = effective_path_to_master(
-            idx,
-            tracks,
-            &output_latency,
-            &plugin_latency,
-            &id_to_index,
-            master_index,
-        );
-        max_path_latency_samples = max_path_latency_samples.max(path);
+        let path =
+            effective_path_to_master(idx, tracks, output_latency, plugin_latency, master_index);
+        *max_path_latency_samples = (*max_path_latency_samples).max(path);
     }
 
-    let mut track_pdc_delay = vec![0u32; n];
-    if pdc_enabled && max_path_latency_samples > 0 {
+    // A recompute reuses the previous plan's vector, so the delays every branch
+    // below skips have to be cleared rather than left at their old values.
+    track_pdc_delay.fill(0);
+    if pdc_enabled && *max_path_latency_samples > 0 {
         for idx in 0..n {
             if Some(idx) == master_index || is_master_track_type(&tracks[idx].track_type) {
                 continue;
@@ -277,31 +331,17 @@ pub fn plan_runtime_latency_graph(
             // late vs direct-to-master tracks by exactly that extra delay.
             // Send→return is different: the dry main still goes to master, so
             // the source keeps its delay (applied after the pre-PDC send tap).
-            if resolve_output_target_index(idx, tracks, &id_to_index)
+            if resolve_output_target_index(idx, tracks)
                 .is_some_and(|target| is_routing_track_type(&tracks[target].track_type))
             {
                 continue;
             }
             // PDC delay is relative to the *main/dry* path so return-FX latency
             // can pull dry forward without also delaying the send feed.
-            let path = main_path_to_master(
-                idx,
-                tracks,
-                &output_latency,
-                &plugin_latency,
-                &id_to_index,
-                master_index,
-            );
-            track_pdc_delay[idx] = max_path_latency_samples.saturating_sub(path);
+            let path =
+                main_path_to_master(idx, tracks, output_latency, plugin_latency, master_index);
+            track_pdc_delay[idx] = (*max_path_latency_samples).saturating_sub(path);
         }
-    }
-
-    RuntimeLatencyGraph {
-        track_plugin_latency: plugin_latency,
-        track_output_latency: output_latency,
-        track_pdc_delay,
-        max_path_latency_samples,
-        master_plugin_latency,
     }
 }
 
@@ -402,13 +442,13 @@ mod tests {
 
     #[test]
     fn pdc_delays_shorter_track_to_match_longer_path() {
-        let tracks = vec![
+        let mut tracks = vec![
             track("fast", "audio", 0, vec![]),
             track("slow", "audio", 512, vec![]),
             track("master", "master", 0, vec![]),
         ];
         let audio_graph = plan_runtime_audio_graph(&tracks).unwrap();
-        let latency = plan_runtime_latency_graph(&tracks, &audio_graph, true);
+        let latency = plan_runtime_latency_graph(&mut tracks, &audio_graph, true);
         assert_eq!(latency.max_path_latency_samples, 512);
         assert_eq!(latency.track_pdc_delay[0], 512);
         assert_eq!(latency.track_pdc_delay[1], 0);
@@ -416,13 +456,13 @@ mod tests {
 
     #[test]
     fn return_feed_increases_path_latency() {
-        let tracks = vec![
+        let mut tracks = vec![
             track("src", "audio", 128, vec![send("s", "ret")]),
             track("ret", "return", 256, vec![]),
             track("master", "master", 0, vec![]),
         ];
         let audio_graph = plan_runtime_audio_graph(&tracks).unwrap();
-        let latency = plan_runtime_latency_graph(&tracks, &audio_graph, true);
+        let latency = plan_runtime_latency_graph(&mut tracks, &audio_graph, true);
         assert_eq!(latency.track_output_latency[1], 128 + 256);
         assert_eq!(latency.max_path_latency_samples, 128 + 256);
         // Dry main path is 128; wet via return is 384. PDC delays dry by 256
@@ -439,14 +479,14 @@ mod tests {
         // master-bound hop) compensates.
         let mut src = track("src", "audio", 0, vec![]);
         src.output_track_id = Some("bus".to_string());
-        let tracks = vec![
+        let mut tracks = vec![
             src,
             track("bus", "bus", 0, vec![]),
             track("slow", "audio", 512, vec![]),
             track("master", "master", 0, vec![]),
         ];
         let audio_graph = plan_runtime_audio_graph(&tracks).unwrap();
-        let latency = plan_runtime_latency_graph(&tracks, &audio_graph, true);
+        let latency = plan_runtime_latency_graph(&mut tracks, &audio_graph, true);
         assert_eq!(latency.max_path_latency_samples, 512);
         assert_eq!(
             latency.track_pdc_delay[0], 0,

--- a/crates/SphereDirectAudioEngine/src/runtime.rs
+++ b/crates/SphereDirectAudioEngine/src/runtime.rs
@@ -11,7 +11,10 @@ use std::sync::Arc;
 
 use crate::audio_graph::{plan_runtime_audio_graph, GraphValidationError, RuntimeAudioGraph};
 use crate::audio_source::{open_clip_audio_source, ClipAudioSource};
-use crate::latency_graph::{plan_runtime_latency_graph, RuntimeLatencyGraph};
+use crate::latency_graph::{
+    plan_runtime_latency_graph, recompute_runtime_latency_graph, resolve_latency_routing_indices,
+    RuntimeLatencyGraph,
+};
 use serde_json::Value;
 use sphere_audio_plugins::{canonical_plugin_id, should_rebuild_state, AudioPluginDspState};
 use sphere_soundfont_player::{
@@ -38,6 +41,17 @@ pub fn midi_engine_debug_enabled() -> bool {
     *FLAG.get_or_init(|| {
         std::env::var_os("FUTUREBOARD_FORENSIC_TRACE").is_some()
             || std::env::var_os("FUTUREBOARD_MIDI_ENGINE_DEBUG").is_some()
+    })
+}
+
+/// `FUTUREBOARD_PDC_DEBUG=1` (or `FUTUREBOARD_ROUTING_DEBUG=1`) enables the
+/// latency-refresh traces. Cached on first read: the refresh runs per block on
+/// the audio thread, and `std::env::var_os` there takes the environment lock.
+pub fn pdc_debug_enabled() -> bool {
+    static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *FLAG.get_or_init(|| {
+        std::env::var_os("FUTUREBOARD_PDC_DEBUG").is_some()
+            || std::env::var_os("FUTUREBOARD_ROUTING_DEBUG").is_some()
     })
 }
 
@@ -1197,19 +1211,11 @@ impl RuntimeProject {
             self.monitor.source_track_index = index;
             self.monitor.source_stage = stage.filter(|_| index.is_some());
         }
+        // Main-output and send-return targets. Shared with latency planning,
+        // which routes on these indices, so both see one rule for which id means
+        // "straight to master" and which resolves to a track.
+        resolve_latency_routing_indices(&mut self.tracks);
         for i in 0..self.tracks.len() {
-            let out_ix = self.tracks[i]
-                .output_track_id
-                .as_deref()
-                .filter(|id| !crate::engine::is_master_output(id))
-                .and_then(|id| track_indices.get(id).copied());
-            self.tracks[i].output_track_index = out_ix;
-            for s in 0..self.tracks[i].sends.len() {
-                let target_ix = track_indices
-                    .get(&self.tracks[i].sends[s].return_track_id)
-                    .copied();
-                self.tracks[i].sends[s].return_track_index = target_ix;
-            }
             // Multi-out (Slice 1): resolve each bridged instrument insert's child
             // "Out Ch" route destination track. Almost always empty.
             for n in 0..self.tracks[i].inserts.len() {
@@ -1358,14 +1364,33 @@ impl RuntimeProject {
             }
         }
 
-        self.latency_graph =
-            plan_runtime_latency_graph(&self.tracks, &self.audio_graph, self.pdc_enabled);
-        self.ensure_pdc_delay_capacity();
+        self.plan_latency_and_pdc();
         self.reset_pdc_delay_lines();
     }
 
+    /// Plan latency and size the PDC rings on the control thread.
+    ///
+    /// `build` runs this as part of constructing a project; anything that
+    /// assembles a `RuntimeProject` field by field has to run it before the
+    /// audio thread can refresh the plan, since
+    /// [`Self::refresh_runtime_latency_graph`] rewrites the plan in place and
+    /// takes the ring capacity as already reserved.
+    pub fn plan_latency_and_pdc(&mut self) {
+        self.latency_graph =
+            plan_runtime_latency_graph(&mut self.tracks, &self.audio_graph, self.pdc_enabled);
+        self.ensure_pdc_delay_capacity();
+    }
+
+    /// Latency the track's own strip contributes, observed from the live
+    /// processors (bridged inserts add the one-block handshake on top of what
+    /// the host reports).
+    ///
+    /// Reads nothing but `track`, so the refresh path can call it while holding
+    /// a mutable borrow of `self.tracks` — that is what lets the observed values
+    /// be written straight back into each track instead of through a scratch
+    /// `Vec` allocated on the audio thread.
     #[inline]
-    fn track_insert_latency_samples(&self, track: &RuntimeTrack, bridge_block_frames: u32) -> u32 {
+    fn track_insert_latency_samples(track: &RuntimeTrack, bridge_block_frames: u32) -> u32 {
         // The built-in Soundfont Player sits ahead of the inserts, so its
         // decimation delay is part of the track's path either way.
         let instrument = track
@@ -1396,29 +1421,76 @@ impl RuntimeProject {
         samples
     }
 
-    fn ensure_pdc_delay_capacity(&mut self) {
-        let pdc_buffer_frames = self.latency_graph.max_path_latency_samples.max(1) as usize
-            + DEFAULT_AUDIO_BLOCK_CAPACITY;
-        for track in &mut self.tracks {
-            let old_len = track.pdc_delay_l.len();
-            if old_len < pdc_buffer_frames {
-                // Growing the ring invalidates the write cursor — reset so we
-                // never read uninitialized slots. Same-size refreshes (common
-                // when bridge latency reports tick) must leave the cursor alone
-                // or mid-playback compensation clicks.
-                track.pdc_delay_l.resize(pdc_buffer_frames, 0.0);
-                track.pdc_delay_r.resize(pdc_buffer_frames, 0.0);
+    /// Ring length one track needs to serve the planned compensation.
+    #[inline]
+    fn pdc_buffer_frames(max_path_latency_samples: u32) -> usize {
+        max_path_latency_samples.max(1) as usize + DEFAULT_AUDIO_BLOCK_CAPACITY
+    }
+
+    /// Fit one track's rings to `frames`. Allocates only when `frames` exceeds
+    /// the vectors' capacity, so callers that have checked capacity first can
+    /// use it on the audio thread.
+    fn fit_track_pdc_len(track: &mut RuntimeTrack, frames: usize) {
+        let old_len = track.pdc_delay_l.len();
+        if old_len < frames {
+            // Growing the ring invalidates the write cursor — reset so we
+            // never read uninitialized slots. Same-size refreshes (common
+            // when bridge latency reports tick) must leave the cursor alone
+            // or mid-playback compensation clicks.
+            track.pdc_delay_l.resize(frames, 0.0);
+            track.pdc_delay_r.resize(frames, 0.0);
+            track.pdc_write_pos = 0;
+        } else if old_len > frames {
+            track.pdc_delay_l.truncate(frames);
+            track.pdc_delay_r.truncate(frames);
+            if frames > 0 {
+                track.pdc_write_pos %= frames;
+            } else {
                 track.pdc_write_pos = 0;
-            } else if old_len > pdc_buffer_frames {
-                track.pdc_delay_l.truncate(pdc_buffer_frames);
-                track.pdc_delay_r.truncate(pdc_buffer_frames);
-                if pdc_buffer_frames > 0 {
-                    track.pdc_write_pos %= pdc_buffer_frames;
-                } else {
-                    track.pdc_write_pos = 0;
-                }
             }
         }
+    }
+
+    /// Control-thread PDC ring sizing. Allocates.
+    ///
+    /// Capacity is reserved to the next power of two above what the plan needs
+    /// while the length stays exact. Later growth — a bridged plugin reporting
+    /// more latency mid-session — is then a length change inside memory this
+    /// thread already reserved, which is what lets
+    /// [`Self::fit_pdc_delay_capacity_realtime`] run without an allocator.
+    fn ensure_pdc_delay_capacity(&mut self) {
+        let frames = Self::pdc_buffer_frames(self.latency_graph.max_path_latency_samples);
+        let reserved = frames.next_power_of_two();
+        for track in &mut self.tracks {
+            let extra_l = reserved.saturating_sub(track.pdc_delay_l.len());
+            let extra_r = reserved.saturating_sub(track.pdc_delay_r.len());
+            track.pdc_delay_l.reserve_exact(extra_l);
+            track.pdc_delay_r.reserve_exact(extra_r);
+            Self::fit_track_pdc_len(track, frames);
+        }
+    }
+
+    /// Realtime PDC ring sizing: fits the rings to a freshly recomputed plan
+    /// without ever reaching the allocator.
+    ///
+    /// Returns `false` when the plan now needs more than the capacity the
+    /// control thread reserved. The rings are then left as they are instead of
+    /// grown; `apply_pdc_delay_block` passes a track whose ring cannot hold its
+    /// delay through undelayed, so the cost is a track that is briefly
+    /// uncompensated rather than an allocation inside the audio callback. The
+    /// next graph swap reserves the larger buffer on the control thread.
+    fn fit_pdc_delay_capacity_realtime(&mut self) -> bool {
+        let frames = Self::pdc_buffer_frames(self.latency_graph.max_path_latency_samples);
+        let fits = self.tracks.iter().all(|track| {
+            frames <= track.pdc_delay_l.capacity() && frames <= track.pdc_delay_r.capacity()
+        });
+        if !fits {
+            return false;
+        }
+        for track in &mut self.tracks {
+            Self::fit_track_pdc_len(track, frames);
+        }
+        true
     }
 
     /// Clear every track's PDC delay-line ring and rewind its write cursor.
@@ -1474,10 +1546,22 @@ impl RuntimeProject {
         }
     }
 
-    /// Refresh PDC planning when runtime-only bridge latency changes. The
-    /// steady-state path scans existing tracks/inserts without allocation; graph
-    /// rebuild + delay-line resize only happens when an observed latency differs
-    /// from the active plan.
+    /// Refresh PDC planning when runtime-only bridge latency changes.
+    ///
+    /// Runs per block from the audio callback, so both halves are realtime-safe.
+    /// The steady-state half scans a bounded slice of tracks and only reads
+    /// atomics. The recompute half — reached whenever an observed latency differs
+    /// from the active plan — rewrites the existing plan in place through
+    /// [`recompute_runtime_latency_graph`] and refits the delay lines inside the
+    /// capacity the control thread reserved.
+    ///
+    /// It used to rebuild instead: a `Vec` of observed values, a fresh plan
+    /// behind `HashMap<String, usize>` with a cloned id per track, a delay-line
+    /// resize, and two `std::env::var_os` calls — every one of them on the audio
+    /// thread. Plugins that report a fixed latency never reached it, but a
+    /// bridged plugin whose reported latency tracks something live (a network
+    /// jitter buffer, say) re-entered it as often as its latency moved, and every
+    /// visit was an allocation and an environment lock inside the callback.
     pub fn refresh_runtime_latency_graph(&mut self, bridge_block_frames: u32) -> bool {
         const TRACKS_PER_CALLBACK: usize = 64;
         let track_count = self.tracks.len();
@@ -1490,8 +1574,8 @@ impl RuntimeProject {
         let mut scanned = 0usize;
         for offset in 0..scan_count {
             let idx = (scan_start + offset) % track_count;
-            let track = &self.tracks[idx];
-            let observed = self.track_insert_latency_samples(track, bridge_block_frames);
+            let observed =
+                Self::track_insert_latency_samples(&self.tracks[idx], bridge_block_frames);
             changed = self
                 .latency_graph
                 .track_plugin_latency
@@ -1509,21 +1593,26 @@ impl RuntimeProject {
             return false;
         }
 
-        let observed: Vec<u32> = self
-            .tracks
-            .iter()
-            .map(|track| self.track_insert_latency_samples(track, bridge_block_frames))
-            .collect();
-        for (track, samples) in self.tracks.iter_mut().zip(observed) {
-            track.plugin_latency_samples = samples;
+        for track in &mut self.tracks {
+            track.plugin_latency_samples =
+                Self::track_insert_latency_samples(track, bridge_block_frames);
         }
-        self.latency_graph =
-            plan_runtime_latency_graph(&self.tracks, &self.audio_graph, self.pdc_enabled);
-        self.ensure_pdc_delay_capacity();
+        recompute_runtime_latency_graph(
+            &mut self.latency_graph,
+            &self.tracks,
+            &self.audio_graph,
+            self.pdc_enabled,
+        );
+        let refitted = self.fit_pdc_delay_capacity_realtime();
 
-        if std::env::var_os("FUTUREBOARD_PDC_DEBUG").is_some()
-            || std::env::var_os("FUTUREBOARD_ROUTING_DEBUG").is_some()
-        {
+        if pdc_debug_enabled() {
+            if !refitted {
+                eprintln!(
+                    "[pdc] delay-line capacity short for max_path={} — tracks stay uncompensated \
+                     until the next graph swap",
+                    self.latency_graph.max_path_latency_samples
+                );
+            }
             eprintln!(
                 "[pdc] refreshed max_path={} pdc_enabled={}",
                 self.latency_graph.max_path_latency_samples, self.pdc_enabled
@@ -2036,16 +2125,7 @@ impl RuntimeProject {
 
         let pdc_active = pdc_enabled
             && !std::env::var_os("FUTUREBOARD_PDC").is_some_and(|v| v == "0" || v == "false");
-        let latency_graph = plan_runtime_latency_graph(&tracks, &audio_graph, pdc_active);
-
-        let pdc_buffer_frames =
-            latency_graph.max_path_latency_samples.max(1) as usize + DEFAULT_AUDIO_BLOCK_CAPACITY;
-        for (idx, track) in tracks.iter_mut().enumerate() {
-            track.pdc_delay_l.resize(pdc_buffer_frames, 0.0);
-            track.pdc_delay_r.resize(pdc_buffer_frames, 0.0);
-            track.pdc_write_pos = 0;
-            let _ = idx;
-        }
+        let latency_graph = plan_runtime_latency_graph(&mut tracks, &audio_graph, pdc_active);
 
         if std::env::var_os("FUTUREBOARD_ROUTING_DEBUG").is_some() {
             eprintln!(
@@ -2098,6 +2178,11 @@ impl RuntimeProject {
         // Resolve cross-entity indices once, on this worker thread, so the
         // audio callback never does an id lookup per block.
         project.resolve_indices();
+        // Size the PDC rings here rather than inline above, so a freshly built
+        // project starts with the same reserved headroom every other
+        // control-thread path leaves behind — without it the first bridge
+        // latency the callback observes would have nowhere to grow into.
+        project.ensure_pdc_delay_capacity();
         Ok(project)
     }
 


### PR DESCRIPTION
## What

`RuntimeProject::refresh_runtime_latency_graph` runs **per block from the audio callback**. The bounded scan at its top is cheap, but as soon as an observed latency differed from the active plan it rebuilt everything:

- a `Vec<u32>` of observed values
- a fresh `plan_runtime_latency_graph`, which built a `HashMap<String, usize>` with a cloned track id per entry
- `ensure_pdc_delay_capacity` → `Vec::resize` on every track's delay lines
- two `std::env::var_os` calls

Allocation, string hashing, and the environment lock — all on the audio thread, which `plugin_bridge.rs` documents as "no allocation, no locks, no syscalls".

## Why it went unnoticed

Plugins that report a fixed latency never reach that branch: the observed value matches the plan forever after the first block. It only bites when a plugin's reported latency *moves* at runtime — a bridged network plugin following its own jitter buffer re-enters the rebuild as often as its latency changes, and every visit is an xrun. That is the SonoBus report: heavy dropouts around stop/seek, which is exactly when such a plugin's buffer state shifts.

## How

**Plan on indices, not ids.** `RuntimeTrack::output_track_index` and `RuntimeSend::return_track_index` are already resolved and are what the render path routes on. Latency planning now reads them too, so compensation is planned against the routing that actually runs and no id is hashed.

**One algorithm, two entry points.** `recompute_runtime_latency_graph` writes into an existing plan whose vectors are already sized for the tracks; `plan_runtime_latency_graph` is that same core behind a fresh allocation for the control thread. Splitting rather than duplicating is deliberate — the two paths cannot drift.

`plan_runtime_latency_graph` now takes `&mut [RuntimeTrack]` and resolves the routing indices itself, so a caller cannot plan against stale ones by forgetting a setup step. `RuntimeProject::resolve_indices` shares the same helper, so there is one rule for which output id means "straight to master".

**Rings reserve headroom.** `ensure_pdc_delay_capacity` (control thread) reserves capacity to the next power of two while length stays exact, so growth mid-session is a length change inside memory already reserved. `fit_pdc_delay_capacity_realtime` refits within that capacity and **declines rather than allocating** if a plan ever outgrows it — `apply_pdc_delay_block` then passes those tracks through undelayed until the next graph swap, which is the honest trade against allocating in the callback. `build` now routes through the same reservation instead of sizing rings exactly, so a freshly loaded project starts with the same headroom.

**Debug flags cached** in `pdc_debug_enabled()` (`OnceLock`), matching the other realtime trace flags.

## Testing

- `cargo test -p sphere_directaudioengine` — 225 passed, 0 failed
- `cargo check -p futureboard_native -p sphere-plugin-host` — clean
- `rustfmt --check` on the three touched files — clean

New test `drifting_bridge_latency_refresh_matches_a_control_thread_replan` drives a bridged sink's reported latency up, further up, then back down, and asserts after each step that the in-place refresh lands exactly where a fresh control-thread plan would — strip latency, output latency, PDC delays, max path — plus that every ring stays long enough to serve its delay. The step back down is the one a rebuild used to get for free and a reused vector would otherwise leave as phantom compensation.

Three existing tests were updated for the `&mut` signature, and `bridge_latency_refresh_updates_pdc_delays` now seeds its hand-assembled project with `plan_latency_and_pdc()` the way `build` does.

## Not covered here

This is realtime-safety only. Two other findings from the same investigation are untouched and still open:

1. **The graph stops running while the transport is stopped** (`backend/render.rs:930-977`). With no wake reason the callback returns silence without calling `request_block`, so the plugin host never calls `process()`. A network plugin needs that pump to keep its stream alive; this is likely the larger half of the reported dropouts.
2. **Scrubbing floods the command queue** (`timeline_ruler.rs:279-297` sends a seek per mouse-move, uncoalesced), and each `Seek` memsets every track's PDC rings in the drain.

## Verifying against the original report

`FUTUREBOARD_PDC_DEBUG=1` prints `[pdc] refreshed max_path=…` on each replan. It should still appear as often as the plugin's latency moves — that is the plugin's behaviour, not a bug — but each one is now integer math over preallocated buffers instead of an allocation. Correlate with `[AudioCallback] slow block` to confirm the xruns at those moments are gone.