### PR TITLE
EQuz8 band auto-enable, EchoSpace tempo sync and L/R link

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/App.svelte
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/App.svelte
@@ -6,7 +6,14 @@
     matchingPresetIndex,
     postAllParams,
   } from './presets'
-  import { PARAMS, modeToWire, type Mode, type ParamId } from './params'
+  import {
+    DEFAULT_TEMPO_BPM,
+    PARAMS,
+    modeToWire,
+    type Mode,
+    type ParamId,
+  } from './params'
+  import DivisionSelect from './lib/DivisionSelect.svelte'
   import EchoView from './lib/EchoView.svelte'
   import Knob from './lib/Knob.svelte'
   import ModeSelect from './lib/ModeSelect.svelte'
@@ -25,6 +32,14 @@
   let connected = $state(false)
   let preset = $state<number | null>(0)
 
+  /**
+   * Transport tempo, republished by the host about once a second. A synced
+   * delay time is a note length, so everything that prints milliseconds — the
+   * division readouts and the echo picture — is derived from this rather than
+   * from an assumed 120 BPM.
+   */
+  let tempoBpm = $state(DEFAULT_TEMPO_BPM)
+
   $effect(() =>
     connectBridge(
       (next) => {
@@ -34,12 +49,61 @@
       (isConnected) => {
         connected = isConnected
       },
+      (bpm) => {
+        tempoBpm = bpm
+      },
     ),
   )
 
   function set(id: ParamId, value: number) {
     params[id] = value
     postParam(id, value)
+    preset = null
+  }
+
+  /**
+   * Edit one side of the delay, carrying the other side with it while Link is
+   * on. Rust mirrors the same way on the wire index, so the two agree whether
+   * the edit arrives from here or from automation; posting both ids keeps this
+   * view honest rather than assuming what the DSP did with the first one.
+   */
+  function setSide(side: 'L' | 'R', value: number) {
+    const id: ParamId = side === 'L' ? 'timeMsL' : 'timeMsR'
+    const other: ParamId = side === 'L' ? 'timeMsR' : 'timeMsL'
+    set(id, value)
+    if (params.link) set(other, value)
+  }
+
+  function setDivision(side: 'L' | 'R', value: number) {
+    const id = side === 'L' ? 'divisionL' : 'divisionR'
+    const other = side === 'L' ? 'divisionR' : 'divisionL'
+    params[id] = value
+    postParam(id, value)
+    if (params.link) {
+      params[other] = value
+      postParam(other, value)
+    }
+    preset = null
+  }
+
+  function setSync(on: boolean) {
+    params.sync = on
+    postParam('sync', on ? 1 : 0)
+    preset = null
+  }
+
+  /**
+   * Turning Link on pulls the right side onto the left, the same snap
+   * `ipc::apply_link` does — otherwise the lit toggle would sit over two
+   * different times until the next edit.
+   */
+  function setLink(on: boolean) {
+    params.link = on
+    if (on) {
+      params.timeMsR = params.timeMsL
+      params.divisionR = params.divisionL
+    }
+    postParam('link', on ? 1 : 0)
     preset = null
   }
 
@@ -114,25 +178,61 @@
 
   <div class="body">
     <div class="stage" class:bypassed={!params.power}>
-      <EchoView {params} />
+      <EchoView {params} {tempoBpm} />
     </div>
 
     <div class="rack">
       <section class="group" aria-label="Timing">
-        <div class="group-title">Timing</div>
-        <div class="group-knobs">
-          <Knob
-            spec={PARAMS.timeMsL}
-            value={params.timeMsL}
-            onchange={(v) => set('timeMsL', v)}
-          />
-          <Knob
-            spec={PARAMS.timeMsR}
-            value={params.timeMsR}
-            onchange={(v) => set('timeMsR', v)}
-            disabled={monoCollapsed}
-          />
+        <div class="group-head">
+          <div class="group-title">Timing</div>
+          <div class="group-flags">
+            <Toggle
+              compact
+              label="Sync"
+              value={params.sync}
+              onchange={setSync}
+            />
+            <Toggle
+              compact
+              label="Link"
+              value={params.link}
+              onchange={setLink}
+              disabled={monoCollapsed}
+            />
+          </div>
         </div>
+        {#if params.sync}
+          <div class="group-knobs">
+            <DivisionSelect
+              label="Left"
+              value={params.divisionL}
+              {tempoBpm}
+              onchange={(v) => setDivision('L', v)}
+            />
+            <DivisionSelect
+              label="Right"
+              value={params.divisionR}
+              {tempoBpm}
+              onchange={(v) => setDivision('R', v)}
+              disabled={monoCollapsed}
+            />
+          </div>
+          <div class="group-note">{Math.round(tempoBpm)} BPM</div>
+        {:else}
+          <div class="group-knobs">
+            <Knob
+              spec={PARAMS.timeMsL}
+              value={params.timeMsL}
+              onchange={(v) => setSide('L', v)}
+            />
+            <Knob
+              spec={PARAMS.timeMsR}
+              value={params.timeMsR}
+              onchange={(v) => setSide('R', v)}
+              disabled={monoCollapsed}
+            />
+          </div>
+        {/if}
       </section>
 
       <section class="group" aria-label="Echoes">
@@ -314,6 +414,30 @@
     font-weight: 650;
     letter-spacing: 0.08em;
     text-transform: uppercase;
+  }
+
+  .group-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-1);
+    min-width: 0;
+    flex-wrap: wrap;
+  }
+
+  .group-flags {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    min-width: 0;
+  }
+
+  .group-note {
+    padding: 0 var(--space-1);
+    color: var(--text-faint);
+    font-size: 0.66rem;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
   }
 
   .group-knobs {

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/bridge.ts
@@ -9,7 +9,13 @@
  * against a torn-down instance can never land on its replacement.
  */
 
-import { MODES, type Mode } from './params'
+import {
+  DEFAULT_DIVISION_L,
+  DEFAULT_DIVISION_R,
+  DIVISION_BEATS,
+  MODES,
+  type Mode,
+} from './params'
 
 export const BRIDGE_PROTOCOL_VERSION = 1
 export const PLUGIN_ID = 'echospace'
@@ -28,6 +34,13 @@ export type EchoParams = {
   mix: number
   outputDb: number
   freeze: boolean
+  /** Delay times follow the host tempo and the divisions below. */
+  sync: boolean
+  /** Index into `DIVISION_LABELS`, used while `sync` is on. */
+  divisionL: number
+  divisionR: number
+  /** Both sides move together. */
+  link: boolean
 }
 
 type Binding = {
@@ -50,6 +63,22 @@ type InstanceRemovedMessage = {
   type: 'futureboard.instanceRemoved'
   protocolVersion: number
   instanceId: string
+}
+
+/**
+ * Low-rate (~1 Hz) host telemetry. Only `tempoBpm` is consumed here: a synced
+ * delay time is a note length, and the editor cannot turn that into the
+ * milliseconds it prints — or into the echo picture — without the tempo the
+ * DSP is actually running against.
+ */
+type HostStatusMessage = {
+  type: 'futureboard.hostStatus'
+  protocolVersion: number
+  instanceId: string
+  sampleRate: number
+  blockSize: number
+  latencySamples: number
+  tempoBpm: number
 }
 
 let binding: Binding | null = null
@@ -108,10 +137,21 @@ const NUMERIC_KEYS = [
   'outputDb',
 ] as const
 
+/** Clamp a division index out of a blob onto the table Rust indexes with. */
+function parseDivision(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.min(Math.max(Math.round(value), 0), DIVISION_BEATS.length - 1)
+}
+
 /**
  * Accept a host state blob only when every field is present and of the right
  * type. A partial blob is rejected whole rather than merged: a half-applied
  * state would show values the DSP does not have.
+ *
+ * The tempo-sync fields are the exception, and deliberately so: projects saved
+ * before EchoSpace had them carry no `sync`/`division*`/`link`, and Rust
+ * restores those blobs with the same defaults rather than rejecting them.
+ * Rejecting here would blank an editor over state the DSP accepted.
  */
 function parseParams(state: unknown): EchoParams | null {
   if (!state || typeof state !== 'object') return null
@@ -128,12 +168,19 @@ function parseParams(state: unknown): EchoParams | null {
     const value = params[key]
     if (typeof value !== 'number' || !Number.isFinite(value)) return null
   }
-  return params as unknown as EchoParams
+  return {
+    ...(params as unknown as EchoParams),
+    sync: params.sync === true,
+    link: params.link === true,
+    divisionL: parseDivision(params.divisionL, DEFAULT_DIVISION_L),
+    divisionR: parseDivision(params.divisionR, DEFAULT_DIVISION_R),
+  }
 }
 
 export function connectBridge(
   onParams: (params: EchoParams) => void,
   onConnection: (connected: boolean) => void,
+  onTempo?: (tempoBpm: number) => void,
 ) {
   post({
     type: 'futureboard.bridgeReady',
@@ -146,8 +193,17 @@ export function connectBridge(
     const message = event.data as
       | SelectInstanceMessage
       | InstanceRemovedMessage
+      | HostStatusMessage
       | undefined
     if (!message || typeof message !== 'object') return
+
+    if (message.type === 'futureboard.hostStatus') {
+      if (binding?.instanceId !== message.instanceId) return
+      if (typeof message.tempoBpm === 'number' && message.tempoBpm > 0) {
+        onTempo?.(message.tempoBpm)
+      }
+      return
+    }
 
     if (message.type === 'futureboard.selectInstance') {
       binding = {

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/DivisionSelect.svelte
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/DivisionSelect.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { DIVISION_LABELS, divisionMs } from '../params'
+
+  type Props = {
+    label: string
+    /** Index into `DIVISION_LABELS`; the wire value Rust indexes with. */
+    value: number
+    /** Transport tempo, for the millisecond readout under the note. */
+    tempoBpm: number
+    onchange: (value: number) => void
+    disabled?: boolean
+  }
+
+  const { label, value, tempoBpm, onchange, disabled = false }: Props = $props()
+
+  const last = DIVISION_LABELS.length - 1
+  const index = $derived(Math.min(Math.max(Math.round(value), 0), last))
+  const ms = $derived(divisionMs(index, tempoBpm))
+
+  /**
+   * The readout is what the delay line is really running at, tempo included —
+   * a note name alone hides the moment a long division clamps against the
+   * line's 4 s ceiling.
+   */
+  const readout = $derived(
+    ms >= 1000 ? `${(ms / 1000).toFixed(2)} s` : `${Math.round(ms)} ms`,
+  )
+
+  function step(delta: number) {
+    const next = index + delta
+    if (next < 0 || next > last) return
+    onchange(next)
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    if (event.key === 'ArrowUp' || event.key === 'ArrowRight') {
+      event.preventDefault()
+      step(1)
+    } else if (event.key === 'ArrowDown' || event.key === 'ArrowLeft') {
+      event.preventDefault()
+      step(-1)
+    }
+  }
+</script>
+
+<div class="division" class:disabled>
+  <div class="row">
+    <button
+      type="button"
+      class="step"
+      aria-label="Shorter {label} division"
+      disabled={disabled || index === 0}
+      onclick={() => step(-1)}
+    >
+      ‹
+    </button>
+    <label class="select">
+      <span class="note">{DIVISION_LABELS[index]}</span>
+      <select
+        aria-label="{label} division"
+        {disabled}
+        value={index}
+        onkeydown={onKeyDown}
+        onchange={(event) =>
+          onchange(Number((event.currentTarget as HTMLSelectElement).value))}
+      >
+        {#each DIVISION_LABELS as name, option (name)}
+          <option value={option}>{name}</option>
+        {/each}
+      </select>
+    </label>
+    <button
+      type="button"
+      class="step"
+      aria-label="Longer {label} division"
+      disabled={disabled || index === last}
+      onclick={() => step(1)}
+    >
+      ›
+    </button>
+  </div>
+  <div class="readout">{readout}</div>
+  <div class="label">{label}</div>
+</div>
+
+<style>
+  .division {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .division.disabled {
+    opacity: 0.45;
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 1.35rem minmax(0, 1fr) 1.35rem;
+    align-items: stretch;
+    width: min(100%, 7.5rem);
+    height: 1.9rem;
+    overflow: hidden;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    background: var(--base);
+  }
+
+  .step {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .step:hover:not(:disabled) {
+    color: var(--text);
+    background: var(--raised);
+  }
+
+  .step:disabled {
+    cursor: default;
+    opacity: 0.35;
+  }
+
+  .select {
+    position: relative;
+    display: grid;
+    place-items: center;
+    min-width: 0;
+    border-inline: 1px solid var(--border);
+  }
+
+  .note {
+    overflow: hidden;
+    width: 100%;
+    color: var(--accent);
+    font-size: 0.76rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* The real control sits invisibly on top so the native picker (and its
+     keyboard handling) does the work, with our own face drawn underneath —
+     the same trick `PresetControl` uses. */
+  .select select {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    border: 0;
+    opacity: 0;
+    cursor: pointer;
+    background: var(--raised);
+    color: var(--text);
+  }
+
+  .select select:disabled {
+    cursor: default;
+  }
+
+  .readout {
+    color: var(--text-muted);
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .label {
+    color: var(--text-faint);
+    font-size: 0.66rem;
+    font-weight: 650;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+</style>

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/EchoView.svelte
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/EchoView.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import type { EchoParams } from '../bridge'
   import { echoModel, envelopeAt, filterMagnitude, tapTimes } from '../model'
-  import { MODE_HINTS } from '../params'
+  import { DEFAULT_TEMPO_BPM, DIVISION_LABELS, MODE_HINTS } from '../params'
 
-  type Props = { params: EchoParams }
-  const { params }: Props = $props()
+  type Props = {
+    params: EchoParams
+    /** Transport tempo the synced tap times are derived from. */
+    tempoBpm?: number
+  }
+  const { params, tempoBpm = DEFAULT_TEMPO_BPM }: Props = $props()
 
   let canvas: HTMLCanvasElement | undefined = $state()
   let host: HTMLDivElement | undefined = $state()
@@ -19,8 +23,8 @@
   /** Number echo marks 1..N so the first hits read as a countable sequence. */
   const NUMBERED_PASSES = 4
 
-  const model = $derived(echoModel(params))
-  const times = $derived(tapTimes(params))
+  const model = $derived(echoModel(params, -60, 64, tempoBpm))
+  const times = $derived(tapTimes(params, tempoBpm))
 
   const windowSec = $derived.by(() => {
     const floor = 10 ** (WINDOW_FLOOR_DB / 20)
@@ -250,6 +254,7 @@
 
   $effect(() => {
     void params
+    void tempoBpm
     void windowSec
     void cssWidth
     void cssHeight
@@ -274,6 +279,17 @@
 
   const mono = $derived(params.mode === 'mono')
   const story = $derived(MODE_HINTS[params.mode])
+
+  /** Note name in front of a synced side's time, so the legend says *why* the
+   *  spacing is what it is. Empty while the line runs on free time. */
+  function note(division: number): string {
+    if (!params.sync) return ''
+    const index = Math.min(
+      Math.max(Math.round(division), 0),
+      DIVISION_LABELS.length - 1,
+    )
+    return `${DIVISION_LABELS[index]} · `
+  }
 </script>
 
 <div class="view" bind:this={host} class:frozen={params.freeze}>
@@ -289,7 +305,7 @@
         <span class="swatch left"></span>
         <div class="copy">
           <span class="key">{mono ? 'Delay' : 'Left'}</span>
-          <span class="val">{ms(times.left)}</span>
+          <span class="val">{note(params.divisionL)}{ms(times.left)}</span>
         </div>
       </div>
       {#if !mono}
@@ -297,7 +313,7 @@
           <span class="swatch right"></span>
           <div class="copy">
             <span class="key">Right</span>
-            <span class="val">{ms(times.right)}</span>
+            <span class="val">{note(params.divisionR)}{ms(times.right)}</span>
           </div>
         </div>
       {/if}

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/Toggle.svelte
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/lib/Toggle.svelte
@@ -6,6 +6,9 @@
     /** `warn` marks a hold/override state; `accent` marks ordinary engagement. */
     tone?: 'accent' | 'warn'
     disabled?: boolean
+    /** Rack-sized: the header has room for the full control, a group header
+     *  sitting above two knobs does not. */
+    compact?: boolean
   }
 
   const {
@@ -14,6 +17,7 @@
     onchange,
     tone = 'accent',
     disabled = false,
+    compact = false,
   }: Props = $props()
 </script>
 
@@ -21,6 +25,7 @@
   type="button"
   class="toggle {tone}"
   class:active={value}
+  class:compact
   role="switch"
   aria-checked={value}
   aria-label={label}
@@ -46,6 +51,19 @@
     font-size: 0.78rem;
     font-weight: 600;
     cursor: pointer;
+  }
+
+  .toggle.compact {
+    gap: 0.3rem;
+    min-height: 1.5rem;
+    padding: 0.2rem 0.55rem 0.2rem 0.45rem;
+    font-size: 0.68rem;
+    letter-spacing: 0.02em;
+  }
+
+  .toggle.compact .dot {
+    width: 0.4rem;
+    height: 0.4rem;
   }
 
   .toggle:hover:not(:disabled) {

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/model.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/model.test.ts
@@ -4,12 +4,14 @@ import type { EchoParams } from './bridge'
 import {
   MAX_FEEDBACK,
   echoModel,
+  effectiveTimesMs,
   envelopeAt,
   filterMagnitude,
   laneFor,
   loopGain,
   tapTimes,
 } from './model'
+import { DIVISION_LABELS } from './params'
 import { DEFAULT_PARAMS } from './presets'
 import { LIB_RS, rustScalar } from './rust'
 
@@ -94,6 +96,61 @@ describe('tap layout', () => {
     expect(passes).toBe(32)
     expect(taps).toHaveLength(64)
     expect(taps.every((tap) => tap.amplitude > 0.9)).toBe(true)
+  })
+})
+
+describe('tempo sync', () => {
+  const quarter = DIVISION_LABELS.indexOf('1/4')
+  const dottedEighth = DIVISION_LABELS.indexOf('1/8.')
+
+  test('a free line ignores the tempo entirely', () => {
+    const free = { ...defaults, sync: false }
+    expect(effectiveTimesMs(free, 90)).toEqual(
+      effectiveTimesMs(free, 174),
+    )
+    expect(effectiveTimesMs(free, 90).left).toBe(defaults.timeMsL)
+  })
+
+  test('a synced line takes its spacing from the tempo, not the free times', () => {
+    const synced = {
+      ...defaults,
+      sync: true,
+      divisionL: quarter,
+      divisionR: dottedEighth,
+      timeMsL: 12,
+      timeMsR: 12,
+    }
+    const times = effectiveTimesMs(synced, 120)
+    expect(times.left).toBeCloseTo(500, 6)
+    expect(times.right).toBeCloseTo(375, 6)
+    // Half the tempo, twice the spacing.
+    expect(effectiveTimesMs(synced, 60).left).toBeCloseTo(1000, 6)
+  })
+
+  /** The picture is the reason the times exist here at all: a synced delay must
+   *  redraw when the project tempo moves, not only when a control does. */
+  test('the echo picture follows the tempo while synced', () => {
+    const synced = { ...defaults, sync: true, mode: 'stereo' as const }
+    const fast = echoModel(synced, -60, 64, 160)
+    const slow = echoModel(synced, -60, 64, 80)
+    expect(slow.lastTime).toBeCloseTo(fast.lastTime * 2, 6)
+    expect(tapTimes(synced, 80).left).toBeCloseTo(
+      tapTimes(synced, 160).left * 2,
+      9,
+    )
+  })
+
+  test('mono still collapses both lanes onto the left division', () => {
+    const synced = {
+      ...defaults,
+      sync: true,
+      mode: 'mono' as const,
+      divisionL: quarter,
+      divisionR: dottedEighth,
+    }
+    const times = tapTimes(synced, 120)
+    expect(times.right).toBe(times.left)
+    expect(times.left).toBeCloseTo(0.5, 9)
   })
 })
 

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/model.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/model.ts
@@ -8,7 +8,7 @@
  * `model.test.ts` pins the constants against the Rust source.
  */
 
-import type { Mode } from './params'
+import { DEFAULT_TEMPO_BPM, divisionMs, type Mode } from './params'
 import type { EchoParams } from './bridge'
 
 /** `echospace::MAX_FEEDBACK`. */
@@ -54,10 +54,29 @@ export function filterMagnitude(params: EchoParams, hz: number): number {
   return highPass * lowPass
 }
 
+/**
+ * Delay time each side actually runs at, in ms — the tempo-derived division
+ * while synced, the free time otherwise. Mirrors `Params::effective_time_ms_*`.
+ */
+export function effectiveTimesMs(
+  params: EchoParams,
+  tempoBpm = DEFAULT_TEMPO_BPM,
+): { left: number; right: number } {
+  if (!params.sync) return { left: params.timeMsL, right: params.timeMsR }
+  return {
+    left: divisionMs(params.divisionL, tempoBpm),
+    right: divisionMs(params.divisionR, tempoBpm),
+  }
+}
+
 /** Delay time per channel in seconds, after the mode's routing. */
-export function tapTimes(params: EchoParams): { left: number; right: number } {
-  const left = params.timeMsL / 1000
-  const right = params.timeMsR / 1000
+export function tapTimes(
+  params: EchoParams,
+  tempoBpm = DEFAULT_TEMPO_BPM,
+): { left: number; right: number } {
+  const times = effectiveTimesMs(params, tempoBpm)
+  const left = times.left / 1000
+  const right = times.right / 1000
   // Mono collapses both lines onto the left time — the DSP sums the input to
   // mono and both rings read the same tap.
   if (params.mode === 'mono') return { left, right: left }
@@ -97,9 +116,10 @@ export function echoModel(
   params: EchoParams,
   floorDb = -60,
   maxPasses = 64,
+  tempoBpm = DEFAULT_TEMPO_BPM,
 ): EchoModel {
   const gain = loopGain(params)
-  const times = tapTimes(params)
+  const times = tapTimes(params, tempoBpm)
   const floor = 10 ** (floorDb / 20)
   const taps: Tap[] = []
   let lastTime = 0

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/params.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/params.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
+  DEFAULT_DIVISION_L,
+  DEFAULT_DIVISION_R,
+  DEFAULT_TEMPO_BPM,
+  DIVISION_BEATS,
+  DIVISION_LABELS,
+  MAX_TEMPO_BPM,
+  MIN_TEMPO_BPM,
   MODES,
   MODE_LABELS,
   PARAMS,
+  divisionMs,
   format,
   fromNorm,
   modeFromWire,
@@ -12,7 +20,16 @@ import {
   unitFor,
   type ParamId,
 } from './params'
-import { IPC_RS, rustModeOrder, rustRanges, rustStringArray } from './rust'
+import {
+  IPC_RS,
+  LIB_RS,
+  rustFloatArray,
+  rustModeOrder,
+  rustRanges,
+  rustScalar,
+  rustStringArray,
+  rustU8Scalar,
+} from './rust'
 
 const rustIds = rustStringArray(IPC_RS, 'UI_PARAM_IDS')
 const rustRangeTable = rustRanges('RANGES')
@@ -37,12 +54,20 @@ describe('the schema mirrors echospace::ipc', () => {
   })
 
   /**
-   * `power`, `mode` and `freeze` are not knobs, so they are absent from
-   * `PARAMS` on purpose — but nothing else may be.
+   * The flags, the mode and the two note divisions are not knobs, so they are
+   * absent from `PARAMS` on purpose — but nothing else may be.
    */
   test('only the non-continuous params are missing from the knob table', () => {
     const missing = rustIds.filter((id) => !(id in PARAMS))
-    expect(missing.sort()).toEqual(['freeze', 'mode', 'power'])
+    expect(missing.sort()).toEqual([
+      'divisionL',
+      'divisionR',
+      'freeze',
+      'link',
+      'mode',
+      'power',
+      'sync',
+    ])
   })
 
   test('mode order is the wire contract', () => {
@@ -57,6 +82,84 @@ describe('the schema mirrors echospace::ipc', () => {
   test('an unknown mode wire value falls back to ping-pong, as Rust does', () => {
     expect(modeFromWire(99)).toBe('pingpong')
     expect(modeFromWire(-1)).toBe('pingpong')
+  })
+})
+
+describe('note divisions mirror echospace::DIVISION_*', () => {
+  test('the label table matches the Rust table entry for entry', () => {
+    expect(DIVISION_LABELS.map(String)).toEqual(
+      rustStringArray(LIB_RS, 'DIVISION_LABELS'),
+    )
+  })
+
+  /** The index is the wire value, so a beat count that drifts would silently
+   *  play a different note than the one the control reads out. */
+  test('the beat counts match the Rust table entry for entry', () => {
+    const rustBeats = rustFloatArray(LIB_RS, 'DIVISION_BEATS')
+    expect(DIVISION_BEATS).toHaveLength(rustBeats.length)
+    for (const [index, beats] of DIVISION_BEATS.entries()) {
+      expect(beats).toBeCloseTo(rustBeats[index]!, 6)
+    }
+  })
+
+  test('the tables are the same length and the wire ceiling is the last index', () => {
+    expect(DIVISION_LABELS).toHaveLength(DIVISION_BEATS.length)
+    expect(rustScalar(LIB_RS, 'MAX_DIVISION_WIRE')).toBe(
+      DIVISION_BEATS.length - 1,
+    )
+  })
+
+  test('durations rise monotonically, so stepping sweeps the range', () => {
+    for (let i = 1; i < DIVISION_BEATS.length; i++) {
+      expect(DIVISION_BEATS[i]!).toBeGreaterThan(DIVISION_BEATS[i - 1]!)
+    }
+  })
+
+  test('the tempo window and the defaults match Rust', () => {
+    expect(MIN_TEMPO_BPM).toBe(rustScalar(LIB_RS, 'MIN_TEMPO_BPM'))
+    expect(MAX_TEMPO_BPM).toBe(rustScalar(LIB_RS, 'MAX_TEMPO_BPM'))
+    expect(DEFAULT_TEMPO_BPM).toBe(rustScalar(LIB_RS, 'DEFAULT_TEMPO_BPM'))
+    expect(DEFAULT_DIVISION_L).toBe(rustU8Scalar(LIB_RS, 'DEFAULT_DIVISION_L'))
+    expect(DEFAULT_DIVISION_R).toBe(rustU8Scalar(LIB_RS, 'DEFAULT_DIVISION_R'))
+  })
+
+  test('a quarter note is one beat and the dotted forms are 1.5x', () => {
+    expect(divisionMs(DIVISION_LABELS.indexOf('1/4'), 120)).toBeCloseTo(500, 6)
+    expect(divisionMs(DIVISION_LABELS.indexOf('1/8'), 120)).toBeCloseTo(250, 6)
+    expect(divisionMs(DIVISION_LABELS.indexOf('1/8.'), 120)).toBeCloseTo(375, 6)
+    expect(divisionMs(DIVISION_LABELS.indexOf('1/4T'), 120)).toBeCloseTo(
+      1000 / 3,
+      6,
+    )
+    // Halving the tempo doubles every length.
+    expect(divisionMs(DIVISION_LABELS.indexOf('1/4'), 60)).toBeCloseTo(1000, 6)
+  })
+
+  /** The defaults are chosen so switching Sync on at 120 BPM lands on the same
+   *  figure the free-time defaults describe. */
+  test('the default divisions restate the default free times at 120 BPM', () => {
+    expect(divisionMs(DEFAULT_DIVISION_L, 120)).toBeCloseTo(
+      PARAMS.timeMsL.default,
+      6,
+    )
+    expect(divisionMs(DEFAULT_DIVISION_R, 120)).toBeCloseTo(500, 6)
+  })
+
+  test('a garbage index or tempo clamps instead of producing NaN', () => {
+    const longest = DIVISION_BEATS.length - 1
+    expect(divisionMs(-5, 120)).toBe(divisionMs(0, 120))
+    expect(divisionMs(999, 120)).toBe(divisionMs(longest, 120))
+    expect(divisionMs(10, Number.NaN)).toBe(divisionMs(10, DEFAULT_TEMPO_BPM))
+    expect(divisionMs(10, 0)).toBe(divisionMs(10, MIN_TEMPO_BPM))
+    expect(divisionMs(10, 1e9)).toBe(divisionMs(10, MAX_TEMPO_BPM))
+  })
+
+  /** The longest divisions run past the delay line's ceiling at slow tempos;
+   *  the readout has to show the length that is actually reachable. */
+  test('a division longer than the line clamps to its maximum', () => {
+    expect(divisionMs(DIVISION_LABELS.indexOf('1/1.'), 40)).toBe(
+      PARAMS.timeMsL.max,
+    )
   })
 })
 

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/params.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/params.ts
@@ -87,6 +87,77 @@ export const PARAMS: Record<ParamId, ParamSpec> = {
   outputDb: spec('outputDb', 'Output', -24, 12, 0, 'dB', 'lin', 1, 0.5, 0),
 }
 
+/**
+ * Note divisions a synced line can lock to, mirroring `echospace::DIVISION_*`.
+ * The index is the wire value, so the order is the contract — `params.test.ts`
+ * pins both the labels and the beat counts against the Rust table.
+ */
+export const DIVISION_LABELS = [
+  '1/32T',
+  '1/32',
+  '1/16T',
+  '1/32.',
+  '1/16',
+  '1/8T',
+  '1/16.',
+  '1/8',
+  '1/4T',
+  '1/8.',
+  '1/4',
+  '1/2T',
+  '1/4.',
+  '1/2',
+  '1/1T',
+  '1/2.',
+  '1/1',
+  '1/1.',
+] as const
+
+/** Quarter notes each division spans. `echospace::DIVISION_BEATS`. */
+export const DIVISION_BEATS = [
+  1 / 12,
+  0.125,
+  1 / 6,
+  0.1875,
+  0.25,
+  1 / 3,
+  0.375,
+  0.5,
+  2 / 3,
+  0.75,
+  1,
+  4 / 3,
+  1.5,
+  2,
+  8 / 3,
+  3,
+  4,
+  6,
+] as const
+
+/** `echospace::DEFAULT_DIVISION_L` / `DEFAULT_DIVISION_R` — dotted eighth and
+ *  quarter, the same pattern the free-time defaults describe at 120 BPM. */
+export const DEFAULT_DIVISION_L = 9
+export const DEFAULT_DIVISION_R = 10
+
+/** `echospace::MIN_TEMPO_BPM` / `MAX_TEMPO_BPM` / `DEFAULT_TEMPO_BPM`. */
+export const MIN_TEMPO_BPM = 20
+export const MAX_TEMPO_BPM = 999
+export const DEFAULT_TEMPO_BPM = 120
+
+/**
+ * Delay time a division spans at `tempoBpm`, in ms — the same conversion (and
+ * the same clamps) `echospace::division_ms` does, so the readout under a synced
+ * control is the length the delay line is actually running at.
+ */
+export function divisionMs(division: number, tempoBpm: number): number {
+  const index = clamp(Math.round(division), 0, DIVISION_BEATS.length - 1)
+  const bpm = Number.isFinite(tempoBpm)
+    ? clamp(tempoBpm, MIN_TEMPO_BPM, MAX_TEMPO_BPM)
+    : DEFAULT_TEMPO_BPM
+  return clamp((DIVISION_BEATS[index]! * 60_000) / bpm, 1, PARAMS.timeMsL.max)
+}
+
 export const MODES = ['stereo', 'pingpong', 'mono'] as const
 export type Mode = (typeof MODES)[number]
 

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/presets.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/presets.test.ts
@@ -5,6 +5,7 @@ import {
   matchingPresetIndex,
   paramsMatch,
 } from './presets'
+import { DIVISION_BEATS, divisionMs } from './params'
 import { PARAMS } from './params'
 
 describe('factory presets', () => {
@@ -26,6 +27,34 @@ describe('factory presets', () => {
       }
       expect(entry.params.power).toBe(true)
       expect(entry.params.freeze).toBe(false)
+      for (const division of [entry.params.divisionL, entry.params.divisionR]) {
+        expect(Number.isInteger(division)).toBe(true)
+        expect(division).toBeGreaterThanOrEqual(0)
+        expect(division).toBeLessThan(DIVISION_BEATS.length)
+      }
+      // `link` promises the two sides agree — Rust snaps them together on the
+      // way in, so a preset that says otherwise would not survive the trip.
+      if (entry.params.link) {
+        expect(entry.params.timeMsL).toBe(entry.params.timeMsR)
+        expect(entry.params.divisionL).toBe(entry.params.divisionR)
+      }
+    }
+  })
+
+  /** A synced preset's free times are the fallback the user lands on when they
+   *  switch Sync off, so they have to state the same figure at 120 BPM. */
+  test('a synced preset restates its own divisions in its free times', () => {
+    const synced = FACTORY_PRESETS.filter((entry) => entry.params.sync)
+    expect(synced.length).toBeGreaterThan(0)
+    for (const entry of synced) {
+      expect(divisionMs(entry.params.divisionL, 120)).toBeCloseTo(
+        entry.params.timeMsL,
+        6,
+      )
+      expect(divisionMs(entry.params.divisionR, 120)).toBeCloseTo(
+        entry.params.timeMsR,
+        6,
+      )
     }
   })
 

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/presets.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/presets.ts
@@ -7,7 +7,13 @@
  */
 
 import { postParam, type EchoParams } from './bridge'
-import { PARAMS, modeToWire, type ParamId } from './params'
+import {
+  DEFAULT_DIVISION_L,
+  DEFAULT_DIVISION_R,
+  PARAMS,
+  modeToWire,
+  type ParamId,
+} from './params'
 
 export const DEFAULT_PARAMS: EchoParams = {
   power: true,
@@ -22,6 +28,10 @@ export const DEFAULT_PARAMS: EchoParams = {
   mix: PARAMS.mix.default,
   outputDb: PARAMS.outputDb.default,
   freeze: false,
+  sync: false,
+  divisionL: DEFAULT_DIVISION_L,
+  divisionR: DEFAULT_DIVISION_R,
+  link: false,
 }
 
 export type FactoryPreset = {
@@ -49,6 +59,9 @@ export const FACTORY_PRESETS: FactoryPreset[] = [
     saturation: 18,
     mix: 24,
   }),
+  // The two note-named presets ride the project tempo: a "Quarter Ping" pinned
+  // to 500 ms is only a quarter note at 120 BPM. Their free times still hold
+  // the same figure at 120, so switching Sync off lands where the name says.
   preset('Quarter Ping', {
     mode: 'pingpong',
     timeMsL: 500,
@@ -59,6 +72,10 @@ export const FACTORY_PRESETS: FactoryPreset[] = [
     highCutHz: 10000,
     saturation: 6,
     mix: 26,
+    sync: true,
+    divisionL: 10,
+    divisionR: 10,
+    link: true,
   }),
   preset('Dotted Eighth', {
     mode: 'pingpong',
@@ -70,6 +87,9 @@ export const FACTORY_PRESETS: FactoryPreset[] = [
     highCutHz: 11000,
     saturation: 4,
     mix: 22,
+    sync: true,
+    divisionL: 9,
+    divisionR: 7,
   }),
   preset('Tape Echo', {
     mode: 'stereo',
@@ -125,7 +145,11 @@ export function paramsMatch(left: EchoParams, right: EchoParams) {
   if (
     left.power !== right.power ||
     left.freeze !== right.freeze ||
-    left.mode !== right.mode
+    left.mode !== right.mode ||
+    left.sync !== right.sync ||
+    left.link !== right.link ||
+    left.divisionL !== right.divisionL ||
+    left.divisionR !== right.divisionR
   ) {
     return false
   }
@@ -152,6 +176,14 @@ export function matchingPresetIndex(params: EchoParams) {
 export function postAllParams(params: EchoParams) {
   postParam('power', params.power ? 1 : 0)
   postParam('mode', modeToWire(params.mode))
+  // `link` leads the batch: while it is on, Rust mirrors a time or division
+  // edit onto the other side, so a preset that turns it *off* has to say so
+  // before its two sides arrive — otherwise the left value would be copied
+  // over the right on the way in.
+  postParam('link', params.link ? 1 : 0)
+  postParam('sync', params.sync ? 1 : 0)
+  postParam('divisionL', params.divisionL)
+  postParam('divisionR', params.divisionR)
   for (const id of NUMERIC_IDS) {
     postParam(id, params[id])
   }

--- a/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/rust.ts
+++ b/crates/BuiltinAudioPlugins/crates/echospace/editorui/src/rust.ts
@@ -41,6 +41,15 @@ export function rustScalar(source: string, name: string): number {
   return num(match[1])
 }
 
+/** `pub const NAME: u8 = 9;` */
+export function rustU8Scalar(source: string, name: string): number {
+  const match = new RegExp(
+    `(?:pub )?const ${name}\\s*:\\s*u8\\s*=\\s*([0-9_]+)\\s*;`,
+  ).exec(source)
+  if (!match?.[1]) throw new Error(`${name} not found in Rust source`)
+  return num(match[1])
+}
+
 export function rustFloatArray(source: string, name: string): number[] {
   return arrayBody(source, name)
     .split(',')

--- a/crates/BuiltinAudioPlugins/crates/echospace/src/ipc.rs
+++ b/crates/BuiltinAudioPlugins/crates/echospace/src/ipc.rs
@@ -7,7 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{DelayMode, MAX_DELAY_MS, Params, clamp, default_params};
+use crate::{DelayMode, MAX_DELAY_MS, MAX_DIVISION_WIRE, Params, clamp, default_params};
 
 pub const PROTOCOL_VERSION: u32 = 1;
 pub const STATE_VERSION: u32 = 1;
@@ -24,8 +24,12 @@ pub const SATURATION_INDEX: u32 = 8;
 pub const MIX_INDEX: u32 = 9;
 pub const OUTPUT_INDEX: u32 = 10;
 pub const FREEZE_INDEX: u32 = 11;
+pub const SYNC_INDEX: u32 = 12;
+pub const DIVISION_L_INDEX: u32 = 13;
+pub const DIVISION_R_INDEX: u32 = 14;
+pub const LINK_INDEX: u32 = 15;
 
-pub const PARAM_COUNT: usize = 12;
+pub const PARAM_COUNT: usize = 16;
 
 /// Wire index *is* the position in this table; the editor and the host both
 /// resolve through it, so the order is part of the persisted contract. Append
@@ -43,6 +47,10 @@ pub const UI_PARAM_IDS: [&str; PARAM_COUNT] = [
     "mix",
     "outputDb",
     "freeze",
+    "sync",
+    "divisionL",
+    "divisionR",
+    "link",
 ];
 
 /// Inclusive `(min, max)` for every continuous parameter, indexed by wire
@@ -50,24 +58,47 @@ pub const UI_PARAM_IDS: [&str; PARAM_COUNT] = [
 /// own arms in [`apply_wire_param`]. Single source of truth for clamping, so
 /// [`sanitize_params`] and the wire path cannot drift apart.
 const RANGES: [(f32, f32); PARAM_COUNT] = [
-    (0.0, 0.0),          // power
-    (0.0, 0.0),          // mode
-    (1.0, MAX_DELAY_MS), // timeMsL
-    (1.0, MAX_DELAY_MS), // timeMsR
-    (0.0, 98.0),         // feedback
-    (0.0, 100.0),        // crossFeedback
-    (20.0, 2_000.0),     // lowCutHz
-    (1_000.0, 20_000.0), // highCutHz
-    (0.0, 100.0),        // saturation
-    (0.0, 100.0),        // mix
-    (-24.0, 12.0),       // outputDb
-    (0.0, 0.0),          // freeze
+    (0.0, 0.0),               // power
+    (0.0, 0.0),               // mode
+    (1.0, MAX_DELAY_MS),      // timeMsL
+    (1.0, MAX_DELAY_MS),      // timeMsR
+    (0.0, 98.0),              // feedback
+    (0.0, 100.0),             // crossFeedback
+    (20.0, 2_000.0),          // lowCutHz
+    (1_000.0, 20_000.0),      // highCutHz
+    (0.0, 100.0),             // saturation
+    (0.0, 100.0),             // mix
+    (-24.0, 12.0),            // outputDb
+    (0.0, 0.0),               // freeze
+    (0.0, 0.0),               // sync
+    (0.0, MAX_DIVISION_WIRE), // divisionL
+    (0.0, MAX_DIVISION_WIRE), // divisionR
+    (0.0, 0.0),               // link
 ];
 
 #[inline]
 fn clamp_wire(index: u32, value: f32) -> f32 {
     let (min, max) = RANGES[index as usize];
     clamp(value, min, max)
+}
+
+/// A division travels as its table index. Rounded rather than truncated so a
+/// host that steps the control in normalised units cannot land one entry short.
+#[inline]
+fn wire_to_division(value: f32) -> u8 {
+    clamp(value, 0.0, MAX_DIVISION_WIRE).round() as u8
+}
+
+/// `link` is a promise that the two sides agree, so enabling it — or restoring
+/// it from a blob — pulls the right side onto the left. Every path that can set
+/// the flag goes through this, so a lit Link can never sit over two different
+/// times.
+#[inline]
+fn apply_link(params: &mut Params) {
+    if params.link {
+        params.time_ms_r = params.time_ms_l;
+        params.division_r = params.division_l;
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -123,6 +154,9 @@ pub fn sanitize_params(params: &mut Params) {
     params.saturation = clamp_wire(SATURATION_INDEX, params.saturation);
     params.mix = clamp_wire(MIX_INDEX, params.mix);
     params.output_db = clamp_wire(OUTPUT_INDEX, params.output_db);
+    params.division_l = params.division_l.min(MAX_DIVISION_WIRE as u8);
+    params.division_r = params.division_r.min(MAX_DIVISION_WIRE as u8);
+    apply_link(params);
 }
 
 /// Apply one compact UI/control update. Allocation-free and total: invalid
@@ -136,8 +170,38 @@ pub fn apply_wire_param(params: &mut Params, index: u32, value: f32) -> bool {
         POWER_INDEX => params.power = value >= 0.5,
         MODE_INDEX => params.mode = DelayMode::from_wire(value),
         FREEZE_INDEX => params.freeze = value >= 0.5,
-        TIME_L_INDEX => params.time_ms_l = clamp_wire(index, value),
-        TIME_R_INDEX => params.time_ms_r = clamp_wire(index, value),
+        SYNC_INDEX => params.sync = value >= 0.5,
+        LINK_INDEX => {
+            params.link = value >= 0.5;
+            apply_link(params);
+        }
+        // While linked, either side's control drives both — the edit is made on
+        // the side the user touched and mirrored onto the other, rather than the
+        // right side being a read-only shadow of the left.
+        TIME_L_INDEX => {
+            params.time_ms_l = clamp_wire(index, value);
+            if params.link {
+                params.time_ms_r = params.time_ms_l;
+            }
+        }
+        TIME_R_INDEX => {
+            params.time_ms_r = clamp_wire(index, value);
+            if params.link {
+                params.time_ms_l = params.time_ms_r;
+            }
+        }
+        DIVISION_L_INDEX => {
+            params.division_l = wire_to_division(value);
+            if params.link {
+                params.division_r = params.division_l;
+            }
+        }
+        DIVISION_R_INDEX => {
+            params.division_r = wire_to_division(value);
+            if params.link {
+                params.division_l = params.division_r;
+            }
+        }
         FEEDBACK_INDEX => params.feedback = clamp_wire(index, value),
         CROSS_INDEX => params.cross_feedback = clamp_wire(index, value),
         LOW_CUT_INDEX => params.low_cut_hz = clamp_wire(index, value),
@@ -174,6 +238,14 @@ pub fn ui_values(params: &Params) -> Vec<(&'static str, f32)> {
         ("mix", params.mix),
         ("outputDb", params.output_db),
         ("freeze", f32::from(params.freeze)),
+        ("sync", f32::from(params.sync)),
+        ("divisionL", f32::from(params.division_l)),
+        ("divisionR", f32::from(params.division_r)),
+        // Replayed last, after both sides carry their own restored values.
+        // `link` only ever pulls right onto left, and a blob that had it lit was
+        // sanitized with the two sides already equal, so this is a no-op on a
+        // consistent project and a repair on a hand-edited one.
+        ("link", f32::from(params.link)),
     ]
 }
 
@@ -252,6 +324,165 @@ mod tests {
         assert_eq!(params.feedback, 98.0);
         assert_eq!(params.high_cut_hz, 20_000.0);
         assert_eq!(params.output_db, 12.0);
+    }
+
+    /// Link is the "both sides at once" promise: whichever control the user
+    /// touched drives both, and the other is never left behind.
+    #[test]
+    fn link_carries_an_edit_from_either_side_to_the_other() {
+        let mut params = default_params();
+        assert!(apply_ui_param(&mut params, "link", 1.0));
+
+        assert!(apply_ui_param(&mut params, "timeMsL", 250.0));
+        assert_eq!(params.time_ms_r, 250.0);
+        assert!(apply_ui_param(&mut params, "timeMsR", 800.0));
+        assert_eq!(params.time_ms_l, 800.0);
+
+        assert!(apply_ui_param(&mut params, "divisionL", 7.0));
+        assert_eq!(params.division_r, 7);
+        assert!(apply_ui_param(&mut params, "divisionR", 12.0));
+        assert_eq!(params.division_l, 12);
+
+        // Unlinked, the two sides go back to moving on their own.
+        assert!(apply_ui_param(&mut params, "link", 0.0));
+        assert!(apply_ui_param(&mut params, "timeMsL", 100.0));
+        assert_eq!(params.time_ms_r, 800.0);
+        assert!(apply_ui_param(&mut params, "divisionL", 3.0));
+        assert_eq!(params.division_r, 12);
+    }
+
+    /// Turning Link on has to reconcile the two sides immediately — a lit
+    /// toggle over two different times would be a lie until the next edit.
+    #[test]
+    fn enabling_link_pulls_the_right_side_onto_the_left() {
+        let mut params = default_params();
+        params.time_ms_l = 375.0;
+        params.time_ms_r = 900.0;
+        params.division_l = 4;
+        params.division_r = 15;
+        assert!(apply_ui_param(&mut params, "link", 1.0));
+        assert_eq!(params.time_ms_r, 375.0);
+        assert_eq!(params.division_r, 4);
+    }
+
+    #[test]
+    fn division_wire_values_are_rounded_and_clamped() {
+        let mut params = default_params();
+        assert!(apply_ui_param(&mut params, "divisionL", 6.6));
+        assert_eq!(params.division_l, 7);
+        assert!(apply_ui_param(&mut params, "divisionL", -12.0));
+        assert_eq!(params.division_l, 0);
+        assert!(apply_ui_param(&mut params, "divisionL", 9_000.0));
+        assert_eq!(params.division_l, MAX_DIVISION_WIRE as u8);
+        assert!(!apply_ui_param(&mut params, "divisionL", f32::NAN));
+    }
+
+    #[test]
+    fn sync_and_link_are_flags_like_power_and_freeze() {
+        let mut params = default_params();
+        assert!(!params.sync);
+        assert!(apply_ui_param(&mut params, "sync", 1.0));
+        assert!(params.sync);
+        assert!(apply_ui_param(&mut params, "sync", 0.0));
+        assert!(!params.sync);
+    }
+
+    /// A project written before EchoSpace had tempo sync carries none of the
+    /// new fields. It must open at the documented defaults rather than being
+    /// rejected whole, which would silently reset the whole insert.
+    #[test]
+    fn a_blob_written_before_tempo_sync_still_loads() {
+        let legacy = r#"{
+            "version": 1,
+            "params": {
+                "power": true,
+                "mode": "stereo",
+                "timeMsL": 320.0,
+                "timeMsR": 340.0,
+                "feedback": 52.0,
+                "crossFeedback": 25.0,
+                "lowCutHz": 260.0,
+                "highCutHz": 4200.0,
+                "saturation": 62.0,
+                "mix": 30.0,
+                "outputDb": -1.5,
+                "freeze": false
+            }
+        }"#;
+        let decoded = EchospaceState::from_json(legacy).expect("legacy blob must still decode");
+        assert_eq!(decoded.params.time_ms_l, 320.0);
+        assert!(!decoded.params.sync);
+        assert!(!decoded.params.link);
+        assert_eq!(decoded.params.division_l, crate::DEFAULT_DIVISION_L);
+        assert_eq!(decoded.params.division_r, crate::DEFAULT_DIVISION_R);
+    }
+
+    /// `link` is an invariant, not just a flag, so a hand-edited blob that
+    /// claims it while carrying two different sides is repaired on the way in.
+    #[test]
+    fn sanitize_reconciles_a_linked_blob_whose_sides_disagree() {
+        let mut params = default_params();
+        params.link = true;
+        params.time_ms_l = 250.0;
+        params.time_ms_r = 900.0;
+        params.division_l = 5;
+        params.division_r = 200;
+        sanitize_params(&mut params);
+        assert_eq!(params.time_ms_r, 250.0);
+        assert_eq!(params.division_r, 5);
+    }
+
+    #[test]
+    fn sanitize_clamps_an_out_of_table_division() {
+        let mut params = default_params();
+        params.division_l = 250;
+        params.division_r = 99;
+        sanitize_params(&mut params);
+        assert_eq!(params.division_l, MAX_DIVISION_WIRE as u8);
+        assert_eq!(params.division_r, MAX_DIVISION_WIRE as u8);
+    }
+
+    /// Replay walks `ui_values` in wire order, and `link` only ever pulls right
+    /// onto left — so it has to land after both sides have been restored.
+    #[test]
+    fn a_linked_state_survives_a_replay_through_the_wire() {
+        let mut saved = default_params();
+        saved.link = true;
+        saved.sync = true;
+        saved.time_ms_l = 250.0;
+        saved.division_l = 7;
+        sanitize_params(&mut saved);
+
+        let mut rebuilt = default_params();
+        for (id, value) in ui_values(&saved) {
+            assert!(
+                apply_ui_param(&mut rebuilt, id, value),
+                "`{id}` was rejected"
+            );
+        }
+        assert_eq!(rebuilt.time_ms_l, saved.time_ms_l);
+        assert_eq!(rebuilt.time_ms_r, saved.time_ms_r);
+        assert_eq!(rebuilt.division_l, saved.division_l);
+        assert_eq!(rebuilt.division_r, saved.division_r);
+        assert!(rebuilt.link && rebuilt.sync);
+    }
+
+    /// The same replay for an *unlinked* project: the two sides are different
+    /// on purpose, and nothing on the way in may reconcile them.
+    #[test]
+    fn an_unlinked_replay_keeps_the_two_sides_apart() {
+        let mut saved = default_params();
+        saved.time_ms_l = 250.0;
+        saved.time_ms_r = 900.0;
+        saved.division_l = 7;
+        saved.division_r = 12;
+
+        let mut rebuilt = default_params();
+        for (id, value) in ui_values(&saved) {
+            assert!(apply_ui_param(&mut rebuilt, id, value));
+        }
+        assert_eq!(rebuilt.time_ms_r, 900.0);
+        assert_eq!(rebuilt.division_r, 12);
     }
 
     #[test]

--- a/crates/BuiltinAudioPlugins/crates/echospace/src/lib.rs
+++ b/crates/BuiltinAudioPlugins/crates/echospace/src/lib.rs
@@ -28,6 +28,75 @@ pub const MAX_DELAY_MS: f32 = 4_000.0;
 /// by the saturator — which the user is allowed to turn off.
 const MAX_FEEDBACK: f32 = 0.9995;
 
+/// Tempo window a synced delay time is derived from. The transport publishes a
+/// real tempo every block, but a region read before the engine's first publish —
+/// or a project with a nonsense tempo — must not turn into an infinite or
+/// zero-length delay, so the conversion clamps rather than trusts.
+pub const MIN_TEMPO_BPM: f32 = 20.0;
+pub const MAX_TEMPO_BPM: f32 = 999.0;
+
+/// Tempo assumed until the host publishes a transport block.
+pub const DEFAULT_TEMPO_BPM: f32 = 120.0;
+
+/// Note divisions a synced line can lock to, shortest first. Straight, dotted
+/// and triplet forms are interleaved in duration order so stepping the control
+/// sweeps the musical range monotonically instead of jumping between families.
+///
+/// Index *is* the wire value for `divisionL` / `divisionR`, so this table is
+/// part of the persisted contract — append only, and only at the end.
+pub const DIVISION_LABELS: [&str; DIVISION_COUNT] = [
+    "1/32T", "1/32", "1/16T", "1/32.", "1/16", "1/8T", "1/16.", "1/8", "1/4T", "1/8.", "1/4",
+    "1/2T", "1/4.", "1/2", "1/1T", "1/2.", "1/1", "1/1.",
+];
+
+/// Quarter notes each entry of [`DIVISION_LABELS`] spans. A dotted note is
+/// 1.5x its straight form, a triplet 2/3 of it.
+pub const DIVISION_BEATS: [f32; DIVISION_COUNT] = [
+    0.083_333_336,
+    0.125,
+    0.166_666_67,
+    0.1875,
+    0.25,
+    0.333_333_34,
+    0.375,
+    0.5,
+    0.666_666_7,
+    0.75,
+    1.0,
+    1.333_333_4,
+    1.5,
+    2.0,
+    2.666_666_7,
+    3.0,
+    4.0,
+    6.0,
+];
+
+pub const DIVISION_COUNT: usize = 18;
+
+/// Highest valid `divisionL` / `divisionR` wire value.
+pub const MAX_DIVISION_WIRE: f32 = 17.0;
+
+/// Default division per side, chosen so switching Sync on from the factory
+/// settings lands on the same dotted-eighth / quarter pattern the free times
+/// describe at 120 BPM.
+pub const DEFAULT_DIVISION_L: u8 = 9;
+pub const DEFAULT_DIVISION_R: u8 = 10;
+
+/// Delay time one division spans at `tempo_bpm`, already inside the line's
+/// reachable range. Allocation-free and total: an out-of-table index saturates
+/// and the tempo is clamped, so this can be called from the producer thread.
+#[inline]
+pub fn division_ms(division: u8, tempo_bpm: f32) -> f32 {
+    let beats = DIVISION_BEATS[(division as usize).min(DIVISION_COUNT - 1)];
+    let bpm = if tempo_bpm.is_finite() {
+        clamp(tempo_bpm, MIN_TEMPO_BPM, MAX_TEMPO_BPM)
+    } else {
+        DEFAULT_TEMPO_BPM
+    };
+    clamp(beats * 60_000.0 / bpm, 1.0, MAX_DELAY_MS)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DelayMode {
@@ -86,6 +155,34 @@ pub struct Params {
     pub mix: f32,
     pub output_db: f32,
     pub freeze: bool,
+    /// Derive both delay times from the host tempo and the divisions below,
+    /// instead of from `time_ms_l` / `time_ms_r`.
+    ///
+    /// The free times are kept untouched while this is on, so switching back
+    /// returns the line to exactly where it was rather than to a default.
+    #[serde(default)]
+    pub sync: bool,
+    /// Note division per side while `sync` is on; an index into
+    /// [`DIVISION_BEATS`].
+    #[serde(default = "default_division_l")]
+    pub division_l: u8,
+    #[serde(default = "default_division_r")]
+    pub division_r: u8,
+    /// Both sides move together: an edit to either time or division is applied
+    /// to the other as well.
+    #[serde(default)]
+    pub link: bool,
+}
+
+/// Serde fallbacks for the tempo-sync fields, which projects written before
+/// EchoSpace had them do not carry. Without these the whole blob would be
+/// rejected and the insert would silently open at factory settings.
+fn default_division_l() -> u8 {
+    DEFAULT_DIVISION_L
+}
+
+fn default_division_r() -> u8 {
+    DEFAULT_DIVISION_R
 }
 
 pub fn default_params() -> Params {
@@ -102,6 +199,32 @@ pub fn default_params() -> Params {
         mix: 20.0,
         output_db: 0.0,
         freeze: false,
+        sync: false,
+        division_l: DEFAULT_DIVISION_L,
+        division_r: DEFAULT_DIVISION_R,
+        link: false,
+    }
+}
+
+impl Params {
+    /// Delay time the left line actually runs at: the tempo-derived division
+    /// while synced, the free time otherwise.
+    #[inline]
+    pub fn effective_time_ms_l(&self, tempo_bpm: f32) -> f32 {
+        if self.sync {
+            division_ms(self.division_l, tempo_bpm)
+        } else {
+            self.time_ms_l
+        }
+    }
+
+    #[inline]
+    pub fn effective_time_ms_r(&self, tempo_bpm: f32) -> f32 {
+        if self.sync {
+            division_ms(self.division_r, tempo_bpm)
+        } else {
+            self.time_ms_r
+        }
     }
 }
 
@@ -209,6 +332,38 @@ pub fn descriptor() -> PluginDescriptor {
                 max: 1.0,
                 unit: "bool",
             },
+            ParamDescriptor {
+                id: "sync",
+                name: "Tempo Sync",
+                default_value: 0.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
+            ParamDescriptor {
+                id: "divisionL",
+                name: "Division L",
+                default_value: DEFAULT_DIVISION_L as f32,
+                min: 0.0,
+                max: MAX_DIVISION_WIRE,
+                unit: "note",
+            },
+            ParamDescriptor {
+                id: "divisionR",
+                name: "Division R",
+                default_value: DEFAULT_DIVISION_R as f32,
+                min: 0.0,
+                max: MAX_DIVISION_WIRE,
+                unit: "note",
+            },
+            ParamDescriptor {
+                id: "link",
+                name: "Link L/R",
+                default_value: 0.0,
+                min: 0.0,
+                max: 1.0,
+                unit: "bool",
+            },
         ],
     }
 }
@@ -253,6 +408,9 @@ impl DelayLine {
 pub struct Dsp {
     sample_rate: f32,
     params: Params,
+    /// Latest transport tempo, republished by the host each block. Only the
+    /// synced delay times read it; the free times ignore it entirely.
+    tempo_bpm: f32,
     delay_l: DelayLine,
     delay_r: DelayLine,
     delay_samples_l: usize,
@@ -280,6 +438,7 @@ impl Dsp {
         let mut dsp = Self {
             sample_rate: sr,
             params: default_params(),
+            tempo_bpm: DEFAULT_TEMPO_BPM,
             delay_l: DelayLine::new(capacity),
             delay_r: DelayLine::new(capacity),
             delay_samples_l: 1,
@@ -304,6 +463,24 @@ impl Dsp {
         self.apply_params();
     }
 
+    /// Publish the block's transport tempo. Called from the host producer
+    /// before `process_stereo`, so it must stay allocation-free: it is a
+    /// compare plus, at most, the same two integer conversions a time edit
+    /// already does, and only while a synced line is actually reading it.
+    pub fn set_tempo_bpm(&mut self, tempo_bpm: f32) {
+        if !tempo_bpm.is_finite() || (tempo_bpm - self.tempo_bpm).abs() < 1.0e-4 {
+            return;
+        }
+        self.tempo_bpm = tempo_bpm;
+        if self.params.sync {
+            self.apply_scalars();
+        }
+    }
+
+    pub fn tempo_bpm(&self) -> f32 {
+        self.tempo_bpm
+    }
+
     /// Apply a compact wire update already resolved by the UI/control thread.
     ///
     /// The audio path never parses JSON or looks up string parameter ids. Every
@@ -316,7 +493,13 @@ impl Dsp {
         }
         match wire_index {
             ipc::LOW_CUT_INDEX | ipc::HIGH_CUT_INDEX => self.rebuild_filters(),
-            ipc::TIME_L_INDEX | ipc::TIME_R_INDEX | ipc::OUTPUT_INDEX => self.apply_scalars(),
+            ipc::TIME_L_INDEX
+            | ipc::TIME_R_INDEX
+            | ipc::OUTPUT_INDEX
+            | ipc::SYNC_INDEX
+            | ipc::DIVISION_L_INDEX
+            | ipc::DIVISION_R_INDEX
+            | ipc::LINK_INDEX => self.apply_scalars(),
             // Feedback, cross, saturation, mix, mode and the two flags are read
             // straight off `params` in `process_stereo`; nothing to recompute.
             _ => {}
@@ -345,10 +528,10 @@ impl Dsp {
 
     fn apply_scalars(&mut self) {
         let max_delay = self.delay_l.buffer.len().saturating_sub(2).max(1);
-        self.delay_samples_l =
-            ((self.params.time_ms_l * 0.001 * self.sample_rate) as usize).clamp(1, max_delay);
-        self.delay_samples_r =
-            ((self.params.time_ms_r * 0.001 * self.sample_rate) as usize).clamp(1, max_delay);
+        let time_l = self.params.effective_time_ms_l(self.tempo_bpm);
+        let time_r = self.params.effective_time_ms_r(self.tempo_bpm);
+        self.delay_samples_l = ((time_l * 0.001 * self.sample_rate) as usize).clamp(1, max_delay);
+        self.delay_samples_r = ((time_r * 0.001 * self.sample_rate) as usize).clamp(1, max_delay);
         self.output_gain = db_to_linear(self.params.output_db);
     }
 
@@ -719,6 +902,87 @@ mod tests {
         for _ in 0..4_410 {
             let (l, r) = dsp.process_stereo(0.3, -0.3);
             assert!(l.is_finite() && r.is_finite());
+        }
+    }
+
+    /// A synced line's spacing is a note length: it has to come out of the
+    /// transport tempo, not out of the free `time_ms_*` the control still
+    /// holds.
+    #[test]
+    fn a_synced_line_takes_its_delay_from_the_tempo() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.time_ms_l = 12.0;
+        params.time_ms_r = 12.0;
+        params.sync = true;
+        params.division_l = DIVISION_LABELS.iter().position(|l| *l == "1/4").unwrap() as u8;
+        params.division_r = params.division_l;
+        dsp.set_params(params);
+        dsp.set_tempo_bpm(120.0);
+
+        // A quarter note at 120 BPM is 500 ms.
+        assert_eq!(dsp.delay_samples_l, 24_000);
+        assert_eq!(dsp.delay_samples_r, 24_000);
+
+        // Half the tempo, twice the spacing — without any parameter edit.
+        dsp.set_tempo_bpm(60.0);
+        assert_eq!(dsp.delay_samples_l, 48_000);
+
+        // ...and switching sync off returns the line to the time the control
+        // was holding all along.
+        assert!(dsp.apply_ui_param("sync", 0.0));
+        assert_eq!(dsp.delay_samples_l, 576);
+    }
+
+    #[test]
+    fn a_free_line_ignores_the_tempo() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.time_ms_l = 250.0;
+        params.sync = false;
+        dsp.set_params(params);
+        let before = dsp.delay_samples_l;
+        dsp.set_tempo_bpm(174.0);
+        assert_eq!(dsp.delay_samples_l, before);
+        assert_eq!(dsp.tempo_bpm(), 174.0);
+    }
+
+    /// A nonsense tempo — a region read before the engine's first publish, or a
+    /// project with a zero in it — must not turn into a zero-length or infinite
+    /// delay.
+    #[test]
+    fn a_nonsense_tempo_cannot_break_the_delay_line() {
+        let mut dsp = Dsp::new(48_000.0);
+        let mut params = default_params();
+        params.sync = true;
+        dsp.set_params(params);
+        for bpm in [0.0, -240.0, f32::NAN, f32::INFINITY, 1.0e12] {
+            dsp.set_tempo_bpm(bpm);
+            assert!(dsp.delay_samples_l >= 1);
+            assert!(dsp.delay_samples_l < dsp.delay_l.buffer.len());
+            let (l, r) = dsp.process_stereo(0.4, -0.4);
+            assert!(l.is_finite() && r.is_finite(), "diverged at {bpm} BPM");
+        }
+    }
+
+    #[test]
+    fn every_division_stays_inside_the_line_at_any_tempo() {
+        let mut dsp = Dsp::new(48_000.0);
+        for bpm in [MIN_TEMPO_BPM, 60.0, 120.0, 174.0, MAX_TEMPO_BPM] {
+            for division in 0..DIVISION_COUNT as u8 {
+                let mut params = default_params();
+                params.sync = true;
+                params.division_l = division;
+                params.division_r = division;
+                dsp.set_params(params);
+                dsp.set_tempo_bpm(bpm);
+                assert!(
+                    dsp.delay_samples_l >= 1 && dsp.delay_samples_l < dsp.delay_l.buffer.len(),
+                    "division {division} at {bpm} BPM left the ring"
+                );
+                let ms = division_ms(division, bpm);
+                assert!((1.0..=MAX_DELAY_MS).contains(&ms));
+            }
         }
     }
 

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/App.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/App.tsx
@@ -61,15 +61,32 @@ function App() {
     [],
   )
 
+  /// Apply a band edit, switching the band on if it was off.
+  ///
+  /// Every band opens inactive and flat (see `DEFAULT_PARAMS`), so the first
+  /// thing anyone does is reach for one. Dragging its node or turning one of
+  /// its knobs *is* the request to use it: shaping a band that stays silent
+  /// reads as a broken control, and the alternative is hunting for the chip
+  /// or the toggle before every first move. An explicit `active` in the patch
+  /// — the chip's double-click, the rack's switch — is left exactly as asked,
+  /// so turning a band off still turns it off.
   const updateBand = useCallback((index: number, patch: Partial<Band>) => {
-    setParams((current) => ({
-      ...current,
-      bands: current.bands.map((band, bandIndex) =>
-        bandIndex === index ? { ...band, ...patch } : band,
-      ),
-    }))
+    setParams((current) => {
+      const band = current.bands[index]
+      if (!band) return current
+      const effective =
+        patch.active === undefined && !band.active && Object.keys(patch).length > 0
+          ? { ...patch, active: true }
+          : patch
+      postBandPatch(index, effective)
+      return {
+        ...current,
+        bands: current.bands.map((entry, bandIndex) =>
+          bandIndex === index ? { ...entry, ...effective } : entry,
+        ),
+      }
+    })
     setPreset(null)
-    postBandPatch(index, patch)
   }, [])
 
   /// Audition one band's frequency region on its own, FabFilter-style.

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/BandChips.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/BandChips.tsx
@@ -32,7 +32,7 @@ export function BandChips({
             band.freq,
           )} Hz — click to select, double-click to ${
             band.active ? 'disable' : 'enable'
-          }`}
+          }${band.active ? '' : '. Moving the band switches it on too.'}`}
           onClick={() => onSelect(index)}
           onDoubleClick={() => onToggle(index)}
         >

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ResponseGraph.tsx
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/components/ResponseGraph.tsx
@@ -495,8 +495,9 @@ export function ResponseGraph({
               </g>
             )}
             <title>
-              {`Band ${index + 1} — drag to move, wheel for Q, ` +
-                'hold right-button to sweep and listen, Alt-click to keep listening'}
+              {`Band ${index + 1} — drag to move${band.active ? '' : ' (switches it on)'}` +
+                ', wheel for Q, hold right-button to sweep and listen, ' +
+                'Alt-click to keep listening'}
             </title>
             <circle className="node-halo" r={isSelected ? 19 : 15} />
             <circle className="node-ring" r={isSelected ? 11 : 9} />

--- a/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
+++ b/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
@@ -734,6 +734,21 @@ impl BuiltinHostProcessor {
         }
     }
 
+    /// Hand the block's transport tempo to the cores that derive a musical time
+    /// from it. Producer thread only, same exclusivity contract as
+    /// [`Self::process_block`].
+    ///
+    /// Only the tempo-synced delay reads it today, so the other variants fall
+    /// through without touching their DSP: this costs a discriminant test per
+    /// block, and inside EchoSpace a float compare that exits early unless the
+    /// tempo actually moved.
+    fn set_transport_tempo(&self, tempo_bpm: f32) {
+        // SAFETY: the dedicated producer thread is the sole DSP accessor.
+        if let BuiltinDsp::Echospace(dsp) = unsafe { &mut *self.dsp.get() } {
+            dsp.set_tempo_bpm(tempo_bpm);
+        }
+    }
+
     /// Capture one block into the analyser. Producer thread only. Cheap by
     /// construction — a mono sum into a preallocated ring, no transform.
     fn capture_spectrum(&self, left: &[f32], right: &[f32]) {
@@ -2037,8 +2052,11 @@ fn service_audio_bridge(
             .read_deinterleaved(&mut in_l[..frames], &mut in_r[..frames], frames);
     }
     // Analyser capture, before the DSP touches anything: the editor's spectrum
-    // overlay shows the signal arriving at the insert.
+    // overlay shows the signal arriving at the insert. The transport tempo the
+    // engine published for this block goes in at the same point, so a built-in
+    // that locks to the grid uses the real project tempo rather than a stub.
     if let BlockRuntime::Builtin(b) = runtime {
+        b.set_transport_tempo(bridge.load_transport().tempo_bpm as f32);
         b.capture_spectrum(&in_l[..frames], &in_r[..frames]);
     }
     let output_channels = match runtime {

--- a/crates/SphereUIComponents/src/components/builtin_plugin_editor_window.rs
+++ b/crates/SphereUIComponents/src/components/builtin_plugin_editor_window.rs
@@ -244,6 +244,9 @@ struct HostStatusMsg {
     sample_rate: u32,
     block_size: u32,
     latency_samples: u32,
+    /// Transport tempo the DSP is processing against, for editors that show a
+    /// musical time rather than milliseconds.
+    tempo_bpm: f64,
 }
 
 /// Native -> React: DAW transport state. Pushed on change only (and once when
@@ -545,9 +548,10 @@ pub type BuiltinMeterSource = std::sync::Arc<
     dyn Fn(&PluginInstanceKey) -> Option<SpherePluginHost::audio_bridge::BuiltinMeterFrame>,
 >;
 
-/// Polls (sample_rate, block_frames, latency_samples) from the region header.
+/// Polls (sample_rate, block_frames, latency_samples, tempo_bpm) from the
+/// region header.
 pub type BuiltinHostStatusSource =
-    std::sync::Arc<dyn Fn(&PluginInstanceKey) -> Option<(u32, u32, u32)>>;
+    std::sync::Arc<dyn Fn(&PluginInstanceKey) -> Option<(u32, u32, u32, f64)>>;
 
 /// Polls the latest analyser frame for an instance's shared region, as
 /// `(publish sequence, dB bins)`. UI thread, ~30 Hz.
@@ -591,6 +595,11 @@ impl BuiltinEditorHostOps {
 /// CEF pump interval. 8 ms keeps the editor responsive without spinning the UI
 /// thread; CEF coalesces its own work internally.
 const PUMP_INTERVAL: Duration = Duration::from_millis(8);
+
+/// Pump ticks between `futureboard.hostStatus` pushes — ~1 Hz at
+/// [`PUMP_INTERVAL`]. Sample rate, block size and tempo all change rarely
+/// enough that a footer reading them does not need a faster leg.
+const HOST_STATUS_TICKS: u32 = 128;
 
 #[derive(Debug, Clone, PartialEq)]
 enum Status {
@@ -865,6 +874,10 @@ impl BuiltinPluginEditorWindow {
         // Sequences are per-region, so the new instance's current frame could
         // collide with the old one's and be suppressed as "unchanged".
         self.spectrum_seq = 0;
+        // Status lands on the *next* pump tick rather than up to a second later.
+        // An editor that reads the transport tempo (EchoSpace's note divisions)
+        // would otherwise open showing lengths for the wrong tempo.
+        self.telemetry_tick = HOST_STATUS_TICKS - 1;
         self.push_selected_instance();
         cx.notify();
     }
@@ -1399,9 +1412,10 @@ impl BuiltinPluginEditorWindow {
                 }
             }
         }
-        if self.telemetry_tick % 128 == 0 {
+        if self.telemetry_tick % HOST_STATUS_TICKS == 0 {
             if let Some(source) = self.host_ops.host_status_source.as_ref() {
-                if let Some((sample_rate, block_size, latency_samples)) = source(active) {
+                if let Some((sample_rate, block_size, latency_samples, tempo_bpm)) = source(active)
+                {
                     self.post_to_view(&HostStatusMsg {
                         r#type: "futureboard.hostStatus",
                         protocol_version: BRIDGE_PROTOCOL_VERSION,
@@ -1409,6 +1423,7 @@ impl BuiltinPluginEditorWindow {
                         sample_rate,
                         block_size,
                         latency_samples,
+                        tempo_bpm,
                     });
                 }
             }

--- a/crates/SphereUIComponents/src/layout/plugin_bridge_runtime.rs
+++ b/crates/SphereUIComponents/src/layout/plugin_bridge_runtime.rs
@@ -822,8 +822,12 @@ impl PluginBridgeRuntime {
     }
 
     /// Region-header status for the footer: (sample_rate, block_frames,
-    /// latency_samples). `None` when no region is mapped.
-    pub fn builtin_host_status(&self, instance_id: &str) -> Option<(u32, u32, u32)> {
+    /// latency_samples, tempo_bpm). `None` when no region is mapped.
+    ///
+    /// The tempo comes from the same transport block the DSP is processing
+    /// against, so an editor that shows a musical time (EchoSpace's note
+    /// divisions) cannot print a length the delay line is not running at.
+    pub fn builtin_host_status(&self, instance_id: &str) -> Option<(u32, u32, u32, f64)> {
         use std::sync::atomic::Ordering;
         let region = self.shared_audio.get(instance_id)?;
         let bridge = region.bridge();
@@ -831,6 +835,7 @@ impl PluginBridgeRuntime {
             bridge.sample_rate.load(Ordering::Relaxed),
             bridge.max_block_size.load(Ordering::Relaxed),
             bridge.latency_samples.load(Ordering::Relaxed),
+            bridge.load_transport().tempo_bpm,
         ))
     }
 


### PR DESCRIPTION
## EQuz8 — moving a band switches it on

Every band opens inactive and flat, so the first gesture on one did nothing audible — you had to find the chip or the rack switch before your first move.

Shaping a band now enables it in the same edit: dragging its node, turning a Freq/Gain/Q knob, the wheel, arrow keys. A patch that names `active` itself (chip double-click, rack switch) is left exactly as asked, so turning a band off still turns it off.

## EchoSpace — tempo sync and L/R link

Four appended wire params (`sync`, `divisionL`, `divisionR`, `link`), with Rust authoritative throughout.

- **Divisions**: an 18-entry table of straight/dotted/triplet notes ordered by duration, so stepping the control sweeps the musical range monotonically. Index *is* the wire value, append-only.
- **Tempo conversion** clamps at both ends (20–999 BPM, 1–4000 ms) — a region read before the engine's first publish, or a project with a zero in it, cannot produce a zero-length or infinite delay.
- **Free times survive**: `time_ms_l/r` are untouched while synced, so switching Sync off returns the line to where it was rather than to a default.
- **Link** mirrors an edit from whichever side was touched, and snaps right onto left when enabled. `sanitize_params` enforces the same invariant, so a hand-edited blob cannot show a lit Link over two different times. Wire order puts `link` last so replay restores both sides first.
- **Project compatibility**: blobs saved before these fields existed still load, at the documented defaults, instead of being rejected whole.

### Transport plumbing

Built-in DSPs received no transport at all — only VST3 and AU did. The host producer now reads the block's tempo out of the shared region and hands it to the core before `process_block` (one relaxed atomic load, a discriminant test, and a float compare that exits early unless the tempo moved). `hostStatus` gained `tempoBpm` so the editor prints the length the delay line is actually running at, and status is pushed on instance bind rather than up to a second later — otherwise an editor opened at 174 BPM would briefly show lengths for 120.

### Editor

Sync/Link toggles in the Timing group, a note-division stepper per side showing the resulting ms, and the echo picture derived from the effective times with the note name in the legend. The two note-named presets ("Quarter Ping", "Dotted Eighth") now ride the project tempo; their free times restate the same figure at 120 BPM, so switching Sync off lands where the name says.

## Validation

```
cargo test -p echospace           33 passed
cargo test -p sphere-plugin-host  all suites passed
cargo check --workspace           clean
cargo fmt -p echospace --check    clean
bun test (echospace editorui)     43 passed
bun run build (echospace, equz8)  0 errors
eslint (equz8 editor)             clean
```

New tests cover: a synced line following the tempo, a free line ignoring it, a nonsense tempo not breaking the line, every division staying inside the ring at every tempo, link in both directions, the snap on enable, wire replay for linked and unlinked projects, the legacy blob load, and the TS division tables matching the Rust source entry for entry.

**Not exercised in the running app** — no runtime or visual evidence for the drag gesture, the Sync/Link controls, or the redrawn echo view.