### PR TITLE
Fix Space play/pause inside built-in plugin editors

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/mixstation/editor/src/App.tsx
+++ b/crates/BuiltinAudioPlugins/crates/mixstation/editor/src/App.tsx
@@ -8,6 +8,7 @@ import {
 import {
   connectBridge,
   defaults,
+  postGlobalCommand,
   postParam,
   type MeterFrame,
   type MixStationParams,
@@ -68,6 +69,29 @@ export default function App() {
   const [dragging, setDragging] = useState(false)
   const [pickerSlot, setPickerSlot] = useState<number | null>(null)
   const metersRef = useRef<MeterFrame | null>(null)
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey || e.metaKey || e.altKey || e.repeat) return
+      if (e.key !== ' ' && e.code !== 'Space') return
+      const target = e.target as HTMLElement | null
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable)
+      ) {
+        return
+      }
+      // DAW transport owns bare Space on the editor surface. Forward when the
+      // native claim path misses an OSR/focus edge case.
+      e.preventDefault()
+      postGlobalCommand('transport:play-pause')
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
 
   useEffect(
     () =>

--- a/crates/BuiltinAudioPlugins/crates/mixstation/editor/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/mixstation/editor/src/bridge.ts
@@ -201,6 +201,19 @@ export function postParam(id: keyof MixStationParams, value: number) {
   requestAnimationFrame(flush)
 }
 
+/**
+ * Ask the DAW for a workspace command (e.g. transport play/pause). Independent
+ * of the param binding so Space still works before `selectInstance` arrives.
+ * When the native shell already claimed the key, this page path does not run.
+ */
+export function postGlobalCommand(commandId: string): void {
+  if (!commandId) return
+  post({
+    type: 'futureboard.globalCommand',
+    commandId,
+  })
+}
+
 export function parseParams(state: unknown): MixStationParams | null {
   if (!state || typeof state !== 'object') return null
   const candidate =

--- a/crates/SphereUIComponents/src/components/builtin_plugin_editor_surface.rs
+++ b/crates/SphereUIComponents/src/components/builtin_plugin_editor_surface.rs
@@ -129,7 +129,9 @@ pub(crate) fn windows_key_code(key: &str) -> Option<i32> {
         "alt" => 0x12,
         "capslock" => 0x14,
         "escape" => 0x1B,
-        "space" => 0x20,
+        // Linux/XKB and some IMs emit bare space as `" "` / `"Spacebar"`.
+        // Without this mapping CEF never sees a RAWKEYDOWN Space for transport.
+        "space" | " " | "spacebar" | "Space" | "Spacebar" | "kp-space" => 0x20,
         "pageup" => 0x21,
         "pagedown" => 0x22,
         "end" => 0x23,
@@ -228,6 +230,9 @@ mod tests {
         assert_eq!(windows_key_code("backspace"), Some(0x08));
         assert_eq!(windows_key_code("left"), Some(0x25));
         assert_eq!(windows_key_code("delete"), Some(0x2E));
+        assert_eq!(windows_key_code("space"), Some(0x20));
+        assert_eq!(windows_key_code(" "), Some(0x20));
+        assert_eq!(windows_key_code("Spacebar"), Some(0x20));
     }
 
     #[test]

--- a/crates/SphereUIComponents/src/components/builtin_plugin_editor_window.rs
+++ b/crates/SphereUIComponents/src/components/builtin_plugin_editor_window.rs
@@ -1854,11 +1854,9 @@ impl Render for BuiltinPluginEditorWindow {
             if !Self::is_transport_toggle_keystroke(&event.keystroke) || event.is_held {
                 return;
             }
-            if let Some(dispatch) = this.host_ops.dispatch_global_command.as_ref() {
-                window.prevent_default();
-                cx.stop_propagation();
-                dispatch("transport:play-pause", cx);
-            }
+            window.prevent_default();
+            cx.stop_propagation();
+            this.dispatch_transport_play_pause(cx);
         });
 
         div()
@@ -2001,7 +1999,8 @@ impl BuiltinPluginEditorWindow {
 
     /// Window-space logical point → view-space logical point. CEF lays the page
     /// out in the same logical pixels GPUI reports, offset by the chrome this
-    /// window reserves (see `content_rect`).
+    /// window reserves (see `content_rect`). Verified by `osr_editor_probe`:
+    /// a click at window chrome+view landing maps 1:1 into page coordinates.
     fn to_view_point(&self, position: Point<Pixels>) -> (i32, i32) {
         let x: f32 = position.x.into();
         let y: f32 = position.y.into();
@@ -2154,26 +2153,44 @@ impl BuiltinPluginEditorWindow {
     /// owns this, not the page. Matches the CEF `OnPreKeyEvent` contract used
     /// by the windowed Windows path.
     fn is_transport_toggle_keystroke(keystroke: &gpui::Keystroke) -> bool {
+        let mods = keystroke.modifiers;
+        if mods.control || mods.alt || mods.platform || mods.secondary() {
+            return false;
+        }
         let key = keystroke.key.as_str();
         // Linux/XKB and some IMs emit bare `" "` or `"Spacebar"` rather than `"space"`.
-        if !matches!(
+        if matches!(
             key,
             "space" | " " | "spacebar" | "Space" | "Spacebar" | "kp-space"
         ) {
-            return false;
+            return true;
         }
-        let mods = keystroke.modifiers;
-        !(mods.control || mods.alt || mods.platform || mods.secondary())
+        // Some platforms put the only Space marker in `key_char`.
+        keystroke.key_char.as_deref() == Some(" ")
+    }
+
+    /// Run the same transport command the chrome Play button uses.
+    fn dispatch_transport_play_pause(&self, cx: &mut Context<Self>) {
+        if let Some(dispatch) = self.host_ops.dispatch_global_command.as_ref() {
+            dispatch("transport:play-pause", cx);
+        }
     }
 
     fn on_surface_key_down(
         &mut self,
         event: &KeyDownEvent,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Bare Space is claimed on the shell (`capture_key_down` in `render`) so
-        // it never lands here as character input into the page.
+        // Belt-and-suspenders with shell `capture_key_down`: if Space reaches
+        // the surface (capture miss, focus edge, IM quirks) still own transport
+        // and never inject a page-level Space that CEF would handle twice.
+        if Self::is_transport_toggle_keystroke(&event.keystroke) && !event.is_held {
+            window.prevent_default();
+            cx.stop_propagation();
+            self.dispatch_transport_play_pause(cx);
+            return;
+        }
 
         let modifiers = self.surface.modifiers(event.keystroke.modifiers);
         if let Some(key) = editor_key(&event.keystroke, EditorKeyKind::Down, modifiers) {


### PR DESCRIPTION
## Summary
- Accept Linux/XKB/IM Space aliases (`" "`, `Spacebar`, etc.) for OSR editor keyboard mapping and transport claim.
- Claim bare Space on both the plugin-editor shell and the off-screen surface so play/pause works when focus is inside a plugin editor.
- Add a MixStation page `globalCommand` fallback for `transport:play-pause` when the native claim path misses.

## Test plan
- [x] Open a built-in plugin editor on Linux (e.g. MixStation)
- [x] Focus the editor surface / titlebar / instance sidebar and press bare Space — transport toggles
- [x] Click and drag knobs, toggles, and buttons in the editor — controls still respond (no mouse regression from layout experiments)
- [x] Open Rodhareist or another built-in editor and confirm the same Space behavior
- [x] Confirm Ctrl/Alt/Meta+Space does not toggle transport


Made with [Cursor](https://cursor.com)