### PR TITLE
Fix ALSA input buffers and readable device lists

### DIFF
--- a/crates/SphereDirectAudioEngine/src/backend/cpal_backend.rs
+++ b/crates/SphereDirectAudioEngine/src/backend/cpal_backend.rs
@@ -188,7 +188,7 @@ pub(crate) fn open_on_host(
 /// `BufferSize::Fixed` it is handed, so a 4-period ring is what makes the
 /// callback block come back equal to the requested period.
 #[cfg(target_os = "linux")]
-const ALSA_PERIODS_PER_BUFFER: u32 = 4;
+pub(crate) const ALSA_PERIODS_PER_BUFFER: u32 = 4;
 
 /// Translate a requested *period* (callback block size, which is what the UI
 /// and every other platform mean by "buffer size") into the `BufferSize::Fixed`
@@ -201,8 +201,11 @@ const ALSA_PERIODS_PER_BUFFER: u32 = 4;
 /// period as a quarter of it. Requesting 256 there therefore produced 64-frame
 /// wakeups backed by only 5.3 ms of headroom at 48 kHz, roughly a quarter of
 /// the safety margin the same setting buys on WASAPI Shared or CoreAudio.
+///
+/// Shared by output open and **input** open so capture does not fall back to
+/// ALSA's default 100 ms ring while playback runs at the UI buffer size.
 #[cfg(target_os = "linux")]
-fn period_candidates(period: u32) -> Vec<(&'static str, u32, u32)> {
+pub(crate) fn period_candidates(period: u32) -> Vec<(&'static str, u32, u32)> {
     // The callback is handed everything available, which after a late wakeup is
     // the *entire* ring — measured, not assumed: a 4096-frame ring delivers
     // 4096-frame blocks. `request_block` clamps at `MAX_BRIDGE_BLOCK_FRAMES`,
@@ -229,8 +232,15 @@ fn period_candidates(period: u32) -> Vec<(&'static str, u32, u32)> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn period_candidates(period: u32) -> Vec<(&'static str, u32, u32)> {
+pub(crate) fn period_candidates(period: u32) -> Vec<(&'static str, u32, u32)> {
     vec![("requested", period, period)]
+}
+
+/// Promote a cpal ALSA capture thread the same way output is promoted.
+/// Callers announce from the first callback (see `rt_priority::Announcer`).
+#[cfg(target_os = "linux")]
+pub(crate) fn spawn_capture_rt_promoter() -> rt_priority::Announcer {
+    rt_priority::spawn_promoter()
 }
 
 // ── Stream builders ───────────────────────────────────────────────────────────

--- a/crates/SphereDirectAudioEngine/src/device/mod.rs
+++ b/crates/SphereDirectAudioEngine/src/device/mod.rs
@@ -1,5 +1,6 @@
 use crate::types::JsAudioDeviceInfo;
 use cpal::traits::{DeviceTrait, HostTrait};
+use cpal::{BufferSize, StreamConfig, SupportedStreamConfig};
 
 /// `FUTUREBOARD_AUDIO_DEVICE_DEBUG=1` traces enumerated devices + channel counts.
 fn device_debug_enabled() -> bool {
@@ -12,8 +13,8 @@ fn log_devices(direction: &str, devices: &[JsAudioDeviceInfo]) {
     }
     for d in devices {
         eprintln!(
-            "[audio-device] {direction} name={:?} channels={} default_sr={} default={} backend={}",
-            d.name, d.channels, d.default_sample_rate, d.is_default, d.backend
+            "[audio-device] {direction} id={:?} name={:?} channels={} default_sr={} default={} backend={}",
+            d.id, d.name, d.channels, d.default_sample_rate, d.is_default, d.backend
         );
     }
 }
@@ -37,24 +38,29 @@ pub(crate) fn list_output_devices_for_host(host: &cpal::Host) -> Vec<JsAudioDevi
         Ok(devices) => {
             let list: Vec<JsAudioDeviceInfo> = devices
                 .filter_map(|dev| {
-                    let name = dev.name().ok()?;
+                    let id = dev.name().ok()?;
+                    if !include_device_in_list(&id, &backend) {
+                        return None;
+                    }
                     let cfg = dev.default_output_config().ok().or_else(|| {
                         dev.supported_output_configs()
                             .ok()?
                             .next()
                             .map(|range| range.with_max_sample_rate())
                     })?;
+                    let is_default = default_name.as_ref() == Some(&id);
                     Some(JsAudioDeviceInfo {
-                        id: name.clone(),
-                        name: name.clone(),
+                        name: display_name_for_device(&id, &backend),
+                        id,
                         kind: "output".into(),
                         channels: cfg.channels() as u32,
                         default_sample_rate: cfg.sample_rate().0,
-                        is_default: Some(&name) == default_name.as_ref(),
+                        is_default,
                         backend: backend.clone(),
                     })
                 })
                 .collect();
+            let list = sort_and_dedupe_devices(list);
             log_devices("output", &list);
             list
         }
@@ -79,24 +85,29 @@ pub(crate) fn list_input_devices_for_host(host: &cpal::Host) -> Vec<JsAudioDevic
         Ok(devices) => {
             let list: Vec<JsAudioDeviceInfo> = devices
                 .filter_map(|dev| {
-                    let name = dev.name().ok()?;
+                    let id = dev.name().ok()?;
+                    if !include_device_in_list(&id, &backend) {
+                        return None;
+                    }
                     let cfg = dev.default_input_config().ok().or_else(|| {
                         dev.supported_input_configs()
                             .ok()?
                             .next()
                             .map(|range| range.with_max_sample_rate())
                     })?;
+                    let is_default = default_name.as_ref() == Some(&id);
                     Some(JsAudioDeviceInfo {
-                        id: name.clone(),
-                        name: name.clone(),
+                        name: display_name_for_device(&id, &backend),
+                        id,
                         kind: "input".into(),
                         channels: cfg.channels() as u32,
                         default_sample_rate: cfg.sample_rate().0,
-                        is_default: Some(&name) == default_name.as_ref(),
+                        is_default,
                         backend: backend.clone(),
                     })
                 })
                 .collect();
+            let list = sort_and_dedupe_devices(list);
             log_devices("input", &list);
             list
         }
@@ -105,6 +116,9 @@ pub(crate) fn list_input_devices_for_host(host: &cpal::Host) -> Vec<JsAudioDevic
 
 /// Resolve a named output device (or the system default if `id` is None).
 /// Returns `(device, actual_name)` or an error string.
+///
+/// `id` may be the openable endpoint id **or** the friendly display name shown
+/// in Preferences — ALSA lists use readable names that no longer match cpal.
 pub fn resolve_output_device(id: Option<&str>) -> Result<(cpal::Device, String), String> {
     resolve_output_device_for_host(&cpal::default_host(), id)
 }
@@ -124,14 +138,333 @@ pub(crate) fn resolve_output_device_for_host(
             Ok((dev, name))
         }
         Some(wanted) => {
+            let open_id = resolve_open_id(host, wanted, false);
             let mut devices = host.output_devices().map_err(|e| e.to_string())?;
             devices
-                .find(|d| d.name().map(|n| n == wanted).unwrap_or(false))
+                .find(|d| d.name().map(|n| n == open_id).unwrap_or(false))
                 .map(|d| {
-                    let n = d.name().unwrap_or_else(|_| wanted.into());
+                    let n = d.name().unwrap_or_else(|_| open_id.clone());
                     (d, n)
                 })
                 .ok_or_else(|| format!("Output device '{wanted}' not found"))
+        }
+    }
+}
+
+/// Map a stored Preferences value (id **or** display name) to the openable
+/// cpal device name. Falls back to the raw string when nothing matches.
+pub(crate) fn resolve_open_id(host: &cpal::Host, wanted: &str, input: bool) -> String {
+    let wanted = wanted.trim();
+    if wanted.is_empty() {
+        return wanted.to_string();
+    }
+    // Direct match against cpal's own name — works when the caller already has
+    // a raw endpoint id from an older settings file or a non-ALSA backend.
+    let hosts_devices = if input {
+        host.input_devices()
+    } else {
+        host.output_devices()
+    };
+    if let Ok(mut devices) = hosts_devices {
+        if devices.any(|d| d.name().as_deref().ok() == Some(wanted)) {
+            return wanted.to_string();
+        }
+    }
+    // Match friendly display names from our formatted list.
+    let listed = if input {
+        list_input_devices_for_host(host)
+    } else {
+        list_output_devices_for_host(host)
+    };
+    listed
+        .into_iter()
+        .find(|d| d.id == wanted || d.name == wanted)
+        .map(|d| d.id)
+        .unwrap_or_else(|| wanted.to_string())
+}
+
+// ── Input stream candidate building ───────────────────────────────────────────
+
+/// Stream configs to try when opening a cpal input, in preference order.
+///
+/// Mirrors the output path: on ALSA, `BufferSize::Fixed` is the whole PCM ring
+/// while the UI buffer is the period, so we ask for multi-period rings first.
+/// Also tries the engine's active sample rate before the device default so
+/// monitored input does not pitch-shift against the open output stream.
+pub(crate) fn input_stream_config_candidates(
+    default_supported: &SupportedStreamConfig,
+    preferred_period: Option<u32>,
+    preferred_sample_rate: Option<u32>,
+) -> Vec<(&'static str, StreamConfig)> {
+    let default_cfg = default_supported.config();
+    let channels = default_cfg.channels;
+    let default_sr = default_cfg.sample_rate.0;
+
+    let mut sample_rates = Vec::with_capacity(2);
+    if let Some(sr) = preferred_sample_rate.filter(|&s| s > 0 && s != default_sr) {
+        sample_rates.push(sr);
+    }
+    sample_rates.push(default_sr);
+
+    let mut out = Vec::new();
+    for sr in sample_rates {
+        if let Some(period) = preferred_period.filter(|&p| p > 0) {
+            for (label, fixed, _callback) in crate::backend::cpal_backend::period_candidates(period)
+            {
+                out.push((
+                    label,
+                    StreamConfig {
+                        channels,
+                        sample_rate: cpal::SampleRate(sr),
+                        buffer_size: BufferSize::Fixed(fixed),
+                    },
+                ));
+            }
+        }
+        out.push((
+            "device default",
+            StreamConfig {
+                channels,
+                sample_rate: cpal::SampleRate(sr),
+                buffer_size: BufferSize::Default,
+            },
+        ));
+    }
+    out
+}
+
+// ── ALSA list readability / ranking ───────────────────────────────────────────
+
+/// Whether this endpoint is useful enough to appear in Preferences.
+///
+/// ALSA dumps every plugin PCM for every card (`surround51`, `dmix`, `dsnoop`,
+/// `iec958`, rate converters…). Most of those are either exclusive plugins
+/// that fight PipeWire or duplicates of the same pair of hardware channels.
+/// Users need `default` / PipeWire / `front` / `hdmi` / `hw` — not 40 near-
+/// identical aliases.
+fn include_device_in_list(id: &str, backend: &str) -> bool {
+    if !backend_is_alsa(backend) {
+        return true;
+    }
+    let base = alsa_pcm_base(id);
+    // Hard-exclude pure policy / rate / routing plugins.
+    const EXCLUDE: &[&str] = &[
+        "null",
+        "dmix",
+        "dsnoop",
+        "dshare",
+        "upmix",
+        "vdownmix",
+        "lavrate",
+        "samplerate",
+        "speexrate",
+        "speex",
+        "jack",
+        "oss",
+        "a52",
+        "ladspa",
+        "usbstream",
+        "phonon",
+        "ttable",
+        "file",
+        "shm",
+        // Surround layouts are the same card with different channel maps — the
+        // engine asks for channel counts from `front` / default instead.
+        "surround21",
+        "surround40",
+        "surround41",
+        "surround50",
+        "surround51",
+        "surround71",
+    ];
+    if EXCLUDE.iter().any(|p| base.eq_ignore_ascii_case(p)) {
+        return false;
+    }
+    true
+}
+
+fn backend_is_alsa(backend: &str) -> bool {
+    let b = backend.to_ascii_lowercase();
+    // cpal's default Linux host reports id name `"ALSA"`. Keep a loose check so
+    // custom host labels like `"DAUx ALSA"` still get the readable formatting.
+    b.contains("alsa")
+}
+
+/// Human label for Preferences / device pickers. `id` stays the openable endpoint.
+pub(crate) fn display_name_for_device(id: &str, backend: &str) -> String {
+    if !backend_is_alsa(backend) {
+        return id.to_string();
+    }
+    format_alsa_display_name(id)
+}
+
+/// Turn ALSA PCM ids into short, readable labels.
+///
+/// Keeps card / device info so two cards stay distinguishable:
+/// `front:CARD=PCH,DEV=0` → `Front · PCH`
+/// `hdmi:CARD=PCH,DEV=3` → `HDMI · PCH (device 3)`
+/// `sysdefault:CARD=PCH` → `System Default · PCH`
+/// `default` / `pipewire` / `pulse` → plain titles
+pub(crate) fn format_alsa_display_name(id: &str) -> String {
+    let id = id.trim();
+    if id.is_empty() {
+        return "Unknown".into();
+    }
+    match id {
+        "default" => return "System Default".into(),
+        "sysdefault" => return "System Default (sysdefault)".into(),
+        "pipewire" => return "PipeWire".into(),
+        "pulse" => return "PulseAudio".into(),
+        "jack" => return "JACK".into(),
+        _ => {}
+    }
+
+    let base = alsa_pcm_base(id);
+    let card = alsa_hint_value(id, "CARD");
+    let dev = alsa_hint_value(id, "DEV");
+
+    let kind = match base {
+        "default" => "System Default",
+        "sysdefault" => "System Default",
+        "front" => "Front",
+        "rear" => "Rear",
+        "center_lfe" => "Center / LFE",
+        "side" => "Side",
+        "hdmi" => "HDMI",
+        "hw" => "Hardware",
+        "plughw" => "Hardware (plug)",
+        "iec958" | "spdif" => "S/PDIF",
+        "surround21" => "Surround 2.1",
+        "surround40" => "Surround 4.0",
+        "surround41" => "Surround 4.1",
+        "surround50" => "Surround 5.0",
+        "surround51" => "Surround 5.1",
+        "surround71" => "Surround 7.1",
+        other if other.eq_ignore_ascii_case("pipewire") => "PipeWire",
+        other if other.eq_ignore_ascii_case("pulse") => "PulseAudio",
+        other => other,
+    };
+
+    match (card, dev) {
+        (Some(card), Some(dev)) if dev != "0" => format!("{kind} · {card} (device {dev})"),
+        (Some(card), _) => format!("{kind} · {card}"),
+        (None, Some(dev)) if dev != "0" => format!("{kind} (device {dev})"),
+        _ => {
+            // Unparsed exotic PCMs: pretty-print separators instead of a wall of
+            // `KEY=value` commas.
+            if id.contains(':') || id.contains(',') {
+                id.replace(',', " · ").replace(':', " · ")
+            } else {
+                kind.to_string()
+            }
+        }
+    }
+}
+
+fn alsa_pcm_base(id: &str) -> &str {
+    id.split_once(':').map(|(base, _)| base).unwrap_or(id)
+}
+
+fn alsa_hint_value<'a>(id: &'a str, key: &str) -> Option<&'a str> {
+    let (_, rest) = id.split_once(':')?;
+    for part in rest.split(',') {
+        let part = part.trim();
+        if let Some((k, v)) = part.split_once('=') {
+            if k.eq_ignore_ascii_case(key) {
+                let v = v.trim();
+                if !v.is_empty() {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Preference order: system default / shared servers first, then front-of-
+/// board, then direct hardware, then everything else. Defaults win ties.
+fn device_rank(id: &str, is_default: bool) -> (u8, u8, String) {
+    let base = alsa_pcm_base(id).to_ascii_lowercase();
+    let rank = match base.as_str() {
+        "default" => 0,
+        "pipewire" => 1,
+        "pulse" => 2,
+        "sysdefault" => 3,
+        "front" => 4,
+        "plughw" => 5,
+        "hw" => 6,
+        "hdmi" => 7,
+        "iec958" | "spdif" => 8,
+        _ => 20,
+    };
+    // `false` sorts before `true`, so a true-is_default becomes 0.
+    let default_boost = u8::from(!is_default);
+    (rank, default_boost, id.to_ascii_lowercase())
+}
+
+fn sort_and_dedupe_devices(mut list: Vec<JsAudioDeviceInfo>) -> Vec<JsAudioDeviceInfo> {
+    list.sort_by(|a, b| {
+        device_rank(&a.id, a.is_default)
+            .cmp(&device_rank(&b.id, b.is_default))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    // Drop exact id duplicates (defensive).
+    list.dedup_by(|a, b| a.id == b.id);
+    list
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alsa_display_names_are_readable() {
+        assert_eq!(format_alsa_display_name("default"), "System Default");
+        assert_eq!(format_alsa_display_name("pipewire"), "PipeWire");
+        assert_eq!(
+            format_alsa_display_name("front:CARD=PCH,DEV=0"),
+            "Front · PCH"
+        );
+        assert_eq!(
+            format_alsa_display_name("hdmi:CARD=NVidia,DEV=3"),
+            "HDMI · NVidia (device 3)"
+        );
+        assert_eq!(
+            format_alsa_display_name("hw:CARD=Generic,DEV=0"),
+            "Hardware · Generic"
+        );
+        assert_eq!(
+            format_alsa_display_name("sysdefault:CARD=PCH"),
+            "System Default · PCH"
+        );
+    }
+
+    #[test]
+    fn plugin_pcms_are_filtered_on_alsa() {
+        assert!(!include_device_in_list("dmix:CARD=PCH,DEV=0", "ALSA"));
+        assert!(!include_device_in_list("surround51:CARD=PCH,DEV=0", "ALSA"));
+        assert!(include_device_in_list("front:CARD=PCH,DEV=0", "ALSA"));
+        assert!(include_device_in_list("hdmi:CARD=PCH,DEV=0", "ALSA"));
+        assert!(include_device_in_list("Speakers (Realtek)", "WASAPI"));
+    }
+
+    #[test]
+    fn defaults_rank_ahead_of_raw_hardware() {
+        let default_key = device_rank("default", true);
+        let hw_key = device_rank("hw:CARD=PCH,DEV=0", false);
+        assert!(default_key < hw_key);
+    }
+
+    #[test]
+    fn input_candidates_prefer_output_rate_and_period() {
+        // Minimal SupportedStreamConfig construction is heavy; smoke-test
+        // period_candidates wiring instead for the fixed ALSA case.
+        let candidates = crate::backend::cpal_backend::period_candidates(256);
+        assert!(!candidates.is_empty());
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(candidates[0].1, 1024);
+            assert_eq!(candidates[0].2, 256);
         }
     }
 }

--- a/crates/SphereDirectAudioEngine/src/engine.rs
+++ b/crates/SphereDirectAudioEngine/src/engine.rs
@@ -2680,11 +2680,20 @@ impl EngineInner {
         let session = self
             .find_input_device_for_active_backend(config.input_device_id.as_deref())
             .and_then(|device| {
+                let preferred_period = {
+                    let st = self.status.lock();
+                    if st.buffer_size > 0 {
+                        Some(st.buffer_size)
+                    } else {
+                        self.daux_config.lock().buffer_size.filter(|&p| p > 0)
+                    }
+                };
                 recording::start_recording_with_device(
                     config,
                     Arc::clone(&self.shared),
                     monitor_mix,
                     device,
+                    preferred_period,
                 )
             });
         match session {
@@ -3262,43 +3271,52 @@ impl EngineInner {
         let default_cfg = device.default_input_config().map_err(|e| {
             SphereAudioError::NativeError(format!("Input device config error: {e}"))
         })?;
-        let stream_config = cpal::StreamConfig {
-            channels: default_cfg.channels(),
-            sample_rate: default_cfg.sample_rate(),
-            buffer_size: cpal::BufferSize::Default,
+        let preferred_period = {
+            let st = self.status.lock();
+            if st.buffer_size > 0 {
+                Some(st.buffer_size)
+            } else {
+                self.daux_config.lock().buffer_size.filter(|&p| p > 0)
+            }
         };
-        let channel_count = stream_config.channels.max(1) as usize;
-        let input_sr = stream_config.sample_rate.0;
+        let preferred_sample_rate = {
+            let out_sr = self.shared.sample_rate.load(Ordering::Relaxed);
+            (out_sr > 0).then_some(out_sr)
+        };
+        let candidates = crate::device::input_stream_config_candidates(
+            &default_cfg,
+            preferred_period,
+            preferred_sample_rate,
+        );
         let device_label = device
             .name()
             .unwrap_or_else(|_| desired_device.clone().unwrap_or_else(|| "default".into()));
 
-        eprintln!(
-            "[AudioDevice] opening input stream: device='{device_label}' sample_rate={input_sr} \
-             channels={channel_count} buffer=default monitor_channels=({mon_l_ch},{mon_r_ch})"
-        );
-        eprintln!(
-            "[WASAPI] input sample_rate={input_sr} channels={channel_count} format={:?}",
-            default_cfg.sample_format()
-        );
-        let output_sr = self.shared.sample_rate.load(Ordering::Relaxed);
-        if output_sr != 0 && input_sr != 0 && output_sr != input_sr {
-            eprintln!(
-                "[WASAPI] ⚠ input sample_rate ({input_sr}) != output sample_rate ({output_sr}); \
-                 monitored audio will be pitch-shifted until resampling is added (Layer 9 TODO)"
-            );
-        }
+        // Try ALSA multi-period / matched-rate candidates first so live monitor
+        // shares geometry with the open output stream.
+        let mut last_error = None;
+        let mut opened: Option<(cpal::StreamConfig, cpal::Stream)> = None;
+        for (label, stream_config) in candidates {
+            let channel_count = stream_config.channels.max(1) as usize;
+            let input_sr = stream_config.sample_rate.0;
+            self.shared
+                .input_ring
+                .set_active(true, channel_count as u32, input_sr);
 
-        // Reset and arm the input ring for this stream's format.
-        self.shared
-            .input_ring
-            .set_active(true, channel_count as u32, input_sr);
+            let shared = Arc::clone(&self.shared);
+            #[cfg(target_os = "linux")]
+            let rt_announcer = crate::backend::cpal_backend::spawn_capture_rt_promoter();
+            #[cfg(target_os = "linux")]
+            let mut rt_announced = false;
 
-        let shared = Arc::clone(&self.shared);
-        let stream = device
-            .build_input_stream::<f32, _, _>(
+            match device.build_input_stream::<f32, _, _>(
                 &stream_config,
                 move |data: &[f32], _info| {
+                    #[cfg(target_os = "linux")]
+                    if !rt_announced {
+                        rt_announcer.announce_current_thread();
+                        rt_announced = true;
+                    }
                     let frames = data.len() / channel_count.max(1);
                     shared.input_cb_count.fetch_add(1, Ordering::Relaxed);
                     shared
@@ -3312,8 +3330,6 @@ impl EngineInner {
                     let mut last_l = 0.0f32;
                     let mut last_r = 0.0f32;
                     for frame in data.chunks(channel_count) {
-                        // Pick this block's monitor channels; fall back to the
-                        // first sample when a channel index is out of range.
                         let first = frame.first().copied().unwrap_or(0.0);
                         let l = frame
                             .get(mon_l_ch)
@@ -3325,7 +3341,6 @@ impl EngineInner {
                         last_r = r;
                         peak_l = peak_l.max(l.abs());
                         peak_r = peak_r.max(r.abs());
-                        // Layer 4: publish the actual samples to the output side.
                         shared.input_ring.write_stereo(l, r);
                     }
                     shared
@@ -3340,14 +3355,44 @@ impl EngineInner {
                 },
                 |err| eprintln!("[SphereAudio] Live input stream error: {err}"),
                 None,
-            )
-            .map_err(|e| {
-                self.shared.input_ring.set_active(false, 0, 0);
-                SphereAudioError::NativeError(format!("Cannot open live input stream: {e}"))
-            })?;
-        stream
-            .play()
-            .map_err(|e| SphereAudioError::NativeError(format!("Live input play failed: {e}")))?;
+            ) {
+                Ok(stream) => {
+                    if let Err(e) = stream.play() {
+                        last_error = Some(format!("{label} play failed: {e}"));
+                        self.shared.input_ring.set_active(false, 0, 0);
+                        continue;
+                    }
+                    eprintln!(
+                        "[AudioDevice] opening input stream: device='{device_label}' \
+                         candidate='{label}' sample_rate={input_sr} channels={channel_count} \
+                         buffer={:?} monitor_channels=({mon_l_ch},{mon_r_ch})",
+                        stream_config.buffer_size
+                    );
+                    let output_sr = self.shared.sample_rate.load(Ordering::Relaxed);
+                    if output_sr != 0 && input_sr != 0 && output_sr != input_sr {
+                        eprintln!(
+                            "[AudioDevice] ⚠ input sample_rate ({input_sr}) != output sample_rate \
+                             ({output_sr}); monitored audio will be pitch-shifted until resampling \
+                             is added"
+                        );
+                    }
+                    opened = Some((stream_config, stream));
+                    break;
+                }
+                Err(e) => {
+                    last_error = Some(format!("{label}: {e}"));
+                    self.shared.input_ring.set_active(false, 0, 0);
+                }
+            }
+        }
+
+        let (_stream_config, stream) = opened.ok_or_else(|| {
+            self.shared.input_ring.set_active(false, 0, 0);
+            SphereAudioError::NativeError(format!(
+                "Cannot open live input stream: {}",
+                last_error.unwrap_or_else(|| "no candidates".into())
+            ))
+        })?;
         eprintln!("[AudioDevice] input stream started: device='{device_label}'");
 
         *self.live_input.lock() = Some(LiveInputHandle {
@@ -3561,18 +3606,41 @@ impl EngineInner {
         let default_cfg = device.default_input_config().map_err(|e| {
             SphereAudioError::NativeError(format!("Input device config error: {e}"))
         })?;
-        let stream_config = cpal::StreamConfig {
-            channels: default_cfg.channels(),
-            sample_rate: default_cfg.sample_rate(),
-            buffer_size: cpal::BufferSize::Default,
+        let preferred_period = {
+            let st = self.status.lock();
+            if st.buffer_size > 0 {
+                Some(st.buffer_size)
+            } else {
+                self.daux_config.lock().buffer_size.filter(|&p| p > 0)
+            }
         };
+        let preferred_sample_rate = {
+            let out_sr = self.shared.sample_rate.load(Ordering::Relaxed);
+            (out_sr > 0).then_some(out_sr)
+        };
+        let candidates = crate::device::input_stream_config_candidates(
+            &default_cfg,
+            preferred_period,
+            preferred_sample_rate,
+        );
 
         let peak = Arc::new(AtomicU32::new(0));
-        let cb_peak = Arc::clone(&peak);
-        let stream = device
-            .build_input_stream::<f32, _, _>(
+        let mut last_error = None;
+        let mut opened = None;
+        for (label, stream_config) in candidates {
+            let cb_peak = Arc::clone(&peak);
+            #[cfg(target_os = "linux")]
+            let rt_announcer = crate::backend::cpal_backend::spawn_capture_rt_promoter();
+            #[cfg(target_os = "linux")]
+            let mut rt_announced = false;
+            match device.build_input_stream::<f32, _, _>(
                 &stream_config,
                 move |data: &[f32], _info| {
+                    #[cfg(target_os = "linux")]
+                    if !rt_announced {
+                        rt_announcer.announce_current_thread();
+                        rt_announced = true;
+                    }
                     let mut block_peak = 0.0f32;
                     for &s in data {
                         let a = s.abs();
@@ -3599,13 +3667,28 @@ impl EngineInner {
                 },
                 |err| eprintln!("[SphereAudio] Input test stream error: {err}"),
                 None,
-            )
-            .map_err(|e| {
-                SphereAudioError::NativeError(format!("Cannot open input test stream: {e}"))
-            })?;
-        stream
-            .play()
-            .map_err(|e| SphereAudioError::NativeError(format!("Input test play failed: {e}")))?;
+            ) {
+                Ok(stream) => {
+                    if let Err(e) = stream.play() {
+                        last_error = Some(format!("{label} play failed: {e}"));
+                        continue;
+                    }
+                    eprintln!(
+                        "[SphereAudio] input test open via '{label}' buffer={:?}",
+                        stream_config.buffer_size
+                    );
+                    opened = Some(stream);
+                    break;
+                }
+                Err(e) => last_error = Some(format!("{label}: {e}")),
+            }
+        }
+        let stream = opened.ok_or_else(|| {
+            SphereAudioError::NativeError(format!(
+                "Cannot open input test stream: {}",
+                last_error.unwrap_or_else(|| "no candidates".into())
+            ))
+        })?;
 
         *self.input_test.lock() = Some(InputTestHandle {
             _stream: stream,

--- a/crates/SphereDirectAudioEngine/src/recording.rs
+++ b/crates/SphereDirectAudioEngine/src/recording.rs
@@ -211,10 +211,12 @@ pub(crate) fn find_input_device_for_host(
     }
     if let Some(id) = device_id {
         if !id.is_empty() {
+            let open_id = crate::device::resolve_open_id(host, id, true);
             let mut devices = host
                 .input_devices()
                 .map_err(|e| SphereAudioError::NativeError(e.to_string()))?;
-            if let Some(dev) = devices.find(|d| d.name().as_deref().ok() == Some(id)) {
+            if let Some(dev) = devices.find(|d| d.name().as_deref().ok() == Some(open_id.as_str()))
+            {
                 return Ok(dev);
             }
             return Err(SphereAudioError::NativeError(format!(
@@ -501,10 +503,20 @@ fn build_f32_input_stream(
         })
         .collect();
 
+    #[cfg(target_os = "linux")]
+    let rt_announcer = crate::backend::cpal_backend::spawn_capture_rt_promoter();
+    #[cfg(target_os = "linux")]
+    let mut rt_announced = false;
+
     device
         .build_input_stream::<f32, _, _>(
             config,
             move |data: &[f32], info| {
+                #[cfg(target_os = "linux")]
+                if !rt_announced {
+                    rt_announcer.announce_current_thread();
+                    rt_announced = true;
+                }
                 let ch = channels.max(1);
                 let frames = data.len() / ch;
                 shared.input_cb_count.fetch_add(1, Ordering::Relaxed);
@@ -691,7 +703,7 @@ pub fn start_recording(
     monitor_mix: bool,
 ) -> Result<RecordingSession, SphereAudioError> {
     let device = find_input_device(config.input_device_id.as_deref())?;
-    start_recording_with_device(config, shared, monitor_mix, device)
+    start_recording_with_device(config, shared, monitor_mix, device, None)
 }
 
 /// Create the `Recordings` folder and build one RAUF writer per armed track,
@@ -849,21 +861,56 @@ pub(crate) fn start_recording_with_device(
     shared: Arc<crate::engine::SharedState>,
     monitor_mix: bool,
     device: cpal::Device,
+    preferred_period: Option<u32>,
 ) -> Result<RecordingSession, SphereAudioError> {
     let default_cfg = device
         .default_input_config()
         .map_err(|e| SphereAudioError::NativeError(format!("Input device config error: {e}")))?;
 
-    let input_ch = default_cfg.channels() as usize;
-    let sample_rate = default_cfg.sample_rate().0;
-
-    let stream_config = cpal::StreamConfig {
-        channels: default_cfg.channels(),
-        sample_rate: default_cfg.sample_rate(),
-        buffer_size: cpal::BufferSize::Default,
+    let preferred_sample_rate = {
+        let out_sr = shared.sample_rate.load(Ordering::Relaxed);
+        (out_sr > 0).then_some(out_sr)
     };
+    let candidates = crate::device::input_stream_config_candidates(
+        &default_cfg,
+        preferred_period,
+        preferred_sample_rate,
+    );
 
-    let track_writers = build_track_writers(&config, &shared, input_ch, sample_rate)?;
+    let mut last_error = None;
+    for (label, stream_config) in candidates {
+        match start_recording_with_config(
+            &config,
+            Arc::clone(&shared),
+            monitor_mix,
+            &device,
+            stream_config.clone(),
+            label,
+        ) {
+            Ok(session) => return Ok(session),
+            Err(error) => {
+                last_error = Some(format!("{label}: {error}"));
+            }
+        }
+    }
+    Err(SphereAudioError::NativeError(format!(
+        "Cannot open input stream: {}",
+        last_error.unwrap_or_else(|| "no candidates".into())
+    )))
+}
+
+fn start_recording_with_config(
+    config: &JsStartRecordingConfig,
+    shared: Arc<crate::engine::SharedState>,
+    monitor_mix: bool,
+    device: &cpal::Device,
+    stream_config: cpal::StreamConfig,
+    candidate_label: &str,
+) -> Result<RecordingSession, SphereAudioError> {
+    let input_ch = stream_config.channels as usize;
+    let sample_rate = stream_config.sample_rate.0;
+
+    let track_writers = build_track_writers(config, &shared, input_ch, sample_rate)?;
     let track_count = track_writers.len();
 
     let max_record_block_samples = input_ch.saturating_mul(8192).max(input_ch.max(1));
@@ -885,7 +932,6 @@ pub(crate) fn start_recording_with_device(
     let start_beat = config.start_beat;
     let capture_on_transport = config.capture_on_transport.unwrap_or(false);
 
-    // AtomicBool: the input callback checks this before sending.
     let recording_active = Arc::new(AtomicBool::new(true));
     let dropped_blocks = Arc::new(AtomicU64::new(0));
     shared.recording_active.store(true, Ordering::Relaxed);
@@ -905,11 +951,6 @@ pub(crate) fn start_recording_with_device(
         })
         .collect();
 
-    // ── Realtime preview + monitor setup (Parts 1 & 2) ────────────────────
-    // The recording stream is the single capture source during a take: it
-    // feeds the monitor ring, the preview ring, and the file writer. Monitoring
-    // is mixed by the output callback from the ring (clean), not by the old
-    // sample-and-hold path.
     const PREVIEW_PEAKS_PER_SEC: u32 = 150;
     let samples_per_bin = (sample_rate / PREVIEW_PEAKS_PER_SEC).max(1) as usize;
     let preview_channels = monitor_channels.len().max(1) as u32;
@@ -933,12 +974,6 @@ pub(crate) fn start_recording_with_device(
         .recording_preview_active
         .store(true, Ordering::Relaxed);
 
-    // ── Per-track preview setup (Part 1, multi-track) ──────────────────────
-    // Each armed track previews a mono mix of its *own* selected input
-    // channels — mirroring what `build_track_writers` already resolved for
-    // the disk-write path above — instead of everyone sharing the single
-    // global `monitor_channels` mix. `config.tracks` is still available here
-    // because `build_track_writers` only borrowed it.
     let preview_tracks: Vec<(String, usize, usize)> = config
         .tracks
         .iter()
@@ -963,9 +998,6 @@ pub(crate) fn start_recording_with_device(
         shared.preview_rings[slot].reset();
     }
 
-    // Arm the monitor ring for this stream's format and enable output monitoring
-    // when the user requested it. A dedicated capture stream does not share the
-    // output device's callback clock, even when both endpoints are WASAPI.
     shared.monitor_shared_clock.store(false, Ordering::Relaxed);
     shared
         .input_ring
@@ -974,9 +1006,8 @@ pub(crate) fn start_recording_with_device(
         .monitor_enabled_any
         .store(monitor_mix, Ordering::Relaxed);
 
-    // Build the input stream — `audio_tx` is moved into the closure.
     let input_stream = match build_f32_input_stream(
-        &device,
+        device,
         &stream_config,
         audio_tx,
         free_rx,
@@ -1007,8 +1038,9 @@ pub(crate) fn start_recording_with_device(
     }
 
     eprintln!(
-        "[SphereAudio] Recording started: {track_count} track(s), \
-         {input_ch}ch input @ {sample_rate} Hz"
+        "[SphereAudio] Recording started via '{candidate_label}': {track_count} track(s), \
+         {input_ch}ch input @ {sample_rate} Hz buffer={:?}",
+        stream_config.buffer_size
     );
 
     Ok(RecordingSession {


### PR DESCRIPTION
## Summary
- Open live input, recording, and input-test streams with ALSA multi-period buffer geometry instead of the 100 ms device default, aligned to the active output buffer size.
- Promote capture callbacks to realtime on Linux the same way playback is, and prefer the open output sample rate when opening input.
- Format ALSA device labels for Preferences (`Front · PCH`, `PipeWire`, …), filter dmix/surround spam, and resolve open by endpoint id or display name.

## Test plan
- [ ] On Linux, open Preferences → Audio and confirm the input/output lists are short and readable
- [ ] Select a labeled device (not raw `hw:CARD=…`) and confirm output / input reopens successfully
- [ ] Arm + input-monitor an audio track; signal reaches meters without long buffer lag vs the chosen buffer size
- [ ] Record a short take and play it back; no open failure after buffer-size changes
- [ ] Run input level test on the selected input device
- [ ] `cargo test -p sphere_directaudioengine --lib device::` and `buffer_size`


Made with [Cursor](https://cursor.com)