### PR TITLE
EQUZ8: stronger bypass visuals after computer-use test

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/Editor.scss
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/Editor.scss
@@ -87,8 +87,27 @@ select:focus-visible,
     linear-gradient(180deg, #0c1016 0%, var(--surface-panel) 42%, #070a0e 100%);
 }
 
-.editor.is-bypassed .stage {
-  filter: saturate(0.35);
+.editor.is-bypassed {
+  .stage {
+    filter: saturate(0.2) brightness(0.72);
+    opacity: 0.62;
+  }
+
+  .curve-line,
+  .curve-glow,
+  .curve-fill,
+  .band-curve {
+    opacity: 0.18 !important;
+  }
+
+  .node {
+    opacity: 0.28 !important;
+  }
+
+  .power-button:not(.is-on) {
+    color: var(--text-muted);
+    background: rgba(255, 255, 255, 0.04);
+  }
 }
 
 /* Header — thin Pro-Q chrome */

--- a/crates/BuiltinAudioPlugins/crates/equz8/editor/src/lib/motion.ts
+++ b/crates/BuiltinAudioPlugins/crates/equz8/editor/src/lib/motion.ts
@@ -80,15 +80,12 @@ export function snapKnobDial(dial: HTMLElement | null) {
   })
 }
 
-/** Power / bypass: dim the stage without hiding structure. */
-export function tweenBypass(stage: HTMLElement | null, bypassed: boolean) {
-  if (!stage || reducedMotion) {
-    if (stage) stage.style.opacity = bypassed ? '0.55' : '1'
-    return null
-  }
+/** Power / bypass: brief brightness flash; steady look is CSS `.is-bypassed`. */
+export function tweenBypass(stage: HTMLElement | null, _bypassed: boolean) {
+  if (!stage || reducedMotion) return null
   return animate(stage, {
-    opacity: bypassed ? 0.55 : 1,
+    filter: ['brightness(1.12)', 'brightness(1)'],
     duration: 280,
-    ease: 'inOutQuad',
+    ease: 'outQuad',
   })
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up from computer-use testing of the merged EQUZ8 Pro-Q/Serum UI rewrite (#110).

Bypass (power-off) was too subtle in the first browser pass. This strengthens the steady-state `.is-bypassed` look (desaturate + dim curve/nodes) and keeps anime.js as a brief brightness flash only, so it does not override CSS.

## Computer-use evidence

Preview at `http://127.0.0.1:5178/`:

- Band chips, node drag, knobs, Dyn, presets — pass on #110 build
- Power/bypass — fail initially (weak visual), pass after this fix

[Power on](https://cursor.com/agents/bc-9223a98e-e49e-46cf-8bd8-2d46e9b5bb25/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F11-power-on.webp)
[Power bypass](https://cursor.com/agents/bc-9223a98e-e49e-46cf-8bd8-2d46e9b5bb25/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F12-power-bypass.webp)
[Vocal Clarity preset](https://cursor.com/agents/bc-9223a98e-e49e-46cf-8bd8-2d46e9b5bb25/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F09-preset-vocal-clarity.webp)

## Validation
- `bun run build` (equz8 editor) — pass
- Computer-use retest of power on/off/recovery — pass
- Native CEF in Studio — not run here


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9223a98e-e49e-46cf-8bd8-2d46e9b5bb25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9223a98e-e49e-46cf-8bd8-2d46e9b5bb25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

