### PR TITLE
Rewrite Rodhareist editor UI, add amp/dist/eq/mod/cab models

### DIFF
--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/Header.tsx
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/Header.tsx
@@ -1,5 +1,6 @@
 import logoUrl from "../Assets/logo.svg";
 import type { AbSlot } from "../state/history";
+import { SnapshotDropdown } from "./SnapshotDropdown";
 
 type HeaderProps = {
   presetId: string;
@@ -18,6 +19,11 @@ type HeaderProps = {
   onToggleTest: () => void;
   onSave: () => void;
   onRevert: () => void;
+  snapshotSlots: readonly import("../Editor").Snapshot[];
+  activeSnapshotIndex: number;
+  onSelectSnapshot: (index: number) => void;
+  onSaveSnapshot: (index: number) => void;
+  onRenameSnapshot: (index: number, name: string) => void;
 };
 
 export function Header({
@@ -37,6 +43,11 @@ export function Header({
   onToggleTest,
   onSave,
   onRevert,
+  snapshotSlots,
+  activeSnapshotIndex,
+  onSelectSnapshot,
+  onSaveSnapshot,
+  onRenameSnapshot,
 }: HeaderProps) {
   const otherSlot: AbSlot = abSlot === "A" ? "B" : "A";
   return (
@@ -96,6 +107,14 @@ export function Header({
           {abSlot}→{otherSlot}
         </button>
       </div>
+
+      <SnapshotDropdown
+        slots={snapshotSlots}
+        active={activeSnapshotIndex}
+        onSelect={onSelectSnapshot}
+        onSaveCurrent={onSaveSnapshot}
+        onRename={onRenameSnapshot}
+      />
 
       <div className="preset-nav" aria-label="Rig selector">
         <button

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/ModelPicker.tsx
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/ModelPicker.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { categories, icons, type CategoryId, type Model } from "../data";
+
+type ModelPickerProps = {
+  cat: CategoryId;
+  models: Model[];
+  activeModelId: string;
+  onSelect: (id: string) => void;
+  onClose: () => void;
+};
+
+/**
+ * Full-overlay model browser for a signal-chain block — the Helix-Native-
+ * style replacement for the old inline chip row (`.model-strip`). One
+ * category's models only (the chain's stage slots are fixed; this only
+ * changes which model occupies the active one), shown as a searchable grid
+ * of name + description tiles instead of a cramped, description-less strip.
+ *
+ * Portalled to `document.body` for the same reason `BlockMenu` is: it is
+ * triggered from inside `.faceplate`, which clips overflow, so an in-flow
+ * overlay would be cut off. Structurally it is `DiscardDialog`'s
+ * backdrop/panel pattern, plus the Escape/outside-click/initial-focus
+ * discipline `DiscardDialog` is missing and `BlockMenu` already has.
+ */
+export function ModelPicker({
+  cat,
+  models,
+  activeModelId,
+  onSelect,
+  onClose,
+}: ModelPickerProps) {
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const c = categories[cat];
+
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      if (panelRef.current?.contains(e.target as Node)) return;
+      onClose();
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [onClose]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return models;
+    return models.filter(
+      (m) => m.name.toLowerCase().includes(q) || m.sub.toLowerCase().includes(q),
+    );
+  }, [models, query]);
+
+  return createPortal(
+    <div className="picker-backdrop" role="presentation">
+      <div
+        ref={panelRef}
+        className="picker-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="picker-title"
+        style={{ ["--mc" as string]: c.color }}
+      >
+        <div className="picker-head">
+          <div className="picker-title-wrap">
+            <span className="picker-eyebrow" style={{ color: c.color }}>
+              {c.name}
+            </span>
+            <span id="picker-title" className="picker-title">
+              Choose model
+            </span>
+          </div>
+          <button
+            type="button"
+            className="picker-close"
+            aria-label="Close model picker"
+            onClick={onClose}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="5" y1="5" x2="19" y2="19" />
+              <line x1="19" y1="5" x2="5" y2="19" />
+            </svg>
+          </button>
+        </div>
+
+        <input
+          ref={searchRef}
+          type="text"
+          className="picker-search"
+          placeholder={`Search ${c.name.toLowerCase()} models…`}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label={`Search ${c.name} models`}
+        />
+
+        <div className="picker-grid" role="listbox" aria-label={`${c.name} models`}>
+          {filtered.length === 0 && (
+            <div className="picker-empty">No models match “{query}”.</div>
+          )}
+          {filtered.map((m) => {
+            const active = m.id === activeModelId;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                role="option"
+                aria-selected={active}
+                className={`picker-tile${active ? " active" : ""}`}
+                onClick={() => {
+                  onSelect(m.id);
+                  onClose();
+                }}
+              >
+                <span className="picker-tile-icon">
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    dangerouslySetInnerHTML={{ __html: icons[c.node] ?? "" }}
+                  />
+                </span>
+                <span className="picker-tile-text">
+                  <span className="picker-tile-name">{m.name}</span>
+                  <span className="picker-tile-sub">{m.sub}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/ModuleEditor.tsx
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/ModuleEditor.tsx
@@ -11,6 +11,7 @@ import { onNativeMessage } from "../instanceBridge";
 import { distanceCm, micTypeLabel, positionLabel } from "../globals";
 import { GateMonitor } from "./GateMonitor";
 import { Knob } from "./Knob";
+import { ModelPicker } from "./ModelPicker";
 
 /** Lifecycle of the most recent `.nam` load request. */
 type NamLoadStatus =
@@ -54,6 +55,15 @@ export function ModuleEditor({
   const [namStereo, setNamStereo] = useState(true);
   const [namFullRig, setNamFullRig] = useState(false);
   const [namStatus, setNamStatus] = useState<NamLoadStatus>({ kind: "idle" });
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const canPickModel = list.length > 1;
+
+  // A category switch (or the active model changing out from under an open
+  // picker, e.g. via undo) should not leave a stale picker open over the
+  // wrong category's models.
+  useEffect(() => {
+    setPickerOpen(false);
+  }, [activeCat]);
 
   // Resolve the pending load from the host's async result message.
   useEffect(
@@ -111,7 +121,22 @@ export function ModuleEditor({
             <span className="fp-stage" style={{ color: cat.color }}>
               {cat.name}
             </span>
-            <div className="fp-name">{model?.name ?? "—"}</div>
+            {canPickModel ? (
+              <button
+                type="button"
+                className="fp-name-btn"
+                onClick={() => setPickerOpen(true)}
+                aria-haspopup="dialog"
+                aria-expanded={pickerOpen}
+              >
+                <span className="fp-name">{model?.name ?? "—"}</span>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </button>
+            ) : (
+              <div className="fp-name">{model?.name ?? "—"}</div>
+            )}
             <div className="fp-sub">{model?.sub ?? ""}</div>
           </div>
           <button
@@ -124,28 +149,6 @@ export function ModuleEditor({
             <span>{bypassed ? "Bypassed" : "Active"}</span>
           </button>
         </div>
-
-        {/* A single-model stage has nothing to choose — the identity header
-            already names it, so skip the redundant chip row. Chips are
-            compact (name only); the active model's description lives in the
-            header, the rest surface theirs as a tooltip. */}
-        {list.length > 1 && (
-          <div className="model-strip" role="listbox" aria-label="Model">
-            {list.map((m) => (
-              <button
-                key={m.id}
-                type="button"
-                role="option"
-                aria-selected={m.id === activeModelId}
-                className={`model-chip${m.id === activeModelId ? " active" : ""}`}
-                title={m.sub}
-                onClick={() => onSelectModel(m.id)}
-              >
-                {m.name}
-              </button>
-            ))}
-          </div>
-        )}
 
         {isNamCapture && (
           <div className="nam-capture-controls">
@@ -257,6 +260,16 @@ export function ModuleEditor({
           </div>
         )}
       </div>
+
+      {pickerOpen && canPickModel && (
+        <ModelPicker
+          cat={activeCat}
+          models={list}
+          activeModelId={activeModelId}
+          onSelect={onSelectModel}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
     </section>
   );
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/SnapshotDropdown.tsx
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Components/SnapshotDropdown.tsx
@@ -1,0 +1,242 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { Snapshot } from "../Editor";
+
+type SnapshotDropdownProps = {
+  slots: readonly Snapshot[];
+  active: number;
+  onSelect: (index: number) => void;
+  onSaveCurrent: (index: number) => void;
+  onRename: (index: number, name: string) => void;
+};
+
+const EDGE = 8;
+const GAP = 4;
+
+/**
+ * Compact snapshot selector: a single LCD-style trigger (current slot's
+ * number + name, flanked by step arrows for a quick prev/next recall — the
+ * same family as the header's preset nav) that opens a dropdown of all 8
+ * slots. Recalls bypass + parameter values only, never model choice or
+ * block order (see `Editor.tsx`'s `mergeSnapshotIntoRig`), so switching
+ * rides the existing per-parameter smoothing and stays click-free.
+ *
+ * A slot only changes when explicitly saved into (the row's save icon) —
+ * picking a different slot does not silently carry live edits into it,
+ * matching a real footswitch bank rather than the A/B compare's
+ * auto-sync-on-switch.
+ *
+ * Positioning/dismiss discipline mirrors `BlockMenu`: portalled to
+ * `document.body`, measured and clamped to the viewport, closes on Escape
+ * and outside pointerdown, flips above the trigger if there is no room
+ * below.
+ */
+export function SnapshotDropdown({
+  slots,
+  active,
+  onSelect,
+  onSaveCurrent,
+  onRename,
+}: SnapshotDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const [renaming, setRenaming] = useState<number | null>(null);
+  const [draft, setDraft] = useState("");
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const renameRef = useRef<HTMLInputElement>(null);
+
+  const place = useCallback(() => {
+    const trigger = triggerRef.current;
+    const panel = panelRef.current;
+    if (!trigger || !panel) return;
+    const t = trigger.getBoundingClientRect();
+    const p = panel.getBoundingClientRect();
+
+    let left = t.left;
+    if (left + p.width > window.innerWidth - EDGE) left = window.innerWidth - EDGE - p.width;
+    left = Math.max(EDGE, left);
+
+    let top = t.bottom + GAP;
+    if (top + p.height > window.innerHeight - EDGE) top = t.top - p.height - GAP;
+    top = Math.max(EDGE, top);
+
+    panel.style.left = `${left}px`;
+    panel.style.top = `${top}px`;
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      setOpen(false);
+      setRenaming(null);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        if (renaming !== null) setRenaming(null);
+        else setOpen(false);
+      }
+    };
+    window.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("keydown", onKeyDown, true);
+    window.addEventListener("scroll", place, true);
+    window.addEventListener("resize", place);
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("scroll", place, true);
+      window.removeEventListener("resize", place);
+    };
+  }, [open, place, renaming]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    place();
+  }, [open, place]);
+
+  useEffect(() => {
+    if (renaming !== null) renameRef.current?.select();
+  }, [renaming]);
+
+  const startRename = (index: number) => {
+    setDraft(slots[index]?.name ?? String(index + 1));
+    setRenaming(index);
+  };
+  const commitRename = () => {
+    if (renaming === null) return;
+    const name = draft.trim();
+    if (name) onRename(renaming, name);
+    setRenaming(null);
+  };
+
+  const currentName = slots[active]?.name ?? String(active + 1);
+  const step = (dir: number) => onSelect((active + dir + slots.length) % slots.length);
+
+  return (
+    <div className="snap-select" role="group" aria-label="Snapshots">
+      <button
+        type="button"
+        className="snap-step"
+        onClick={() => step(-1)}
+        aria-label="Previous snapshot"
+        title="Previous snapshot"
+      >
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4">
+          <polyline points="15 18 9 12 15 6" />
+        </svg>
+      </button>
+
+      <button
+        ref={triggerRef}
+        type="button"
+        className="snap-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        title="Choose a snapshot"
+      >
+        <span className="snap-trigger-badge">{active + 1}</span>
+        <span className="snap-trigger-name">{currentName}</span>
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" className="snap-trigger-chevron" aria-hidden>
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      <button
+        type="button"
+        className="snap-step"
+        onClick={() => step(1)}
+        aria-label="Next snapshot"
+        title="Next snapshot"
+      >
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4">
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </button>
+
+      {open &&
+        createPortal(
+          <div ref={panelRef} className="snap-panel" role="listbox" aria-label="Snapshots">
+            <div className="snap-panel-head">
+              <span>Snapshots</span>
+              <span className="snap-panel-hint">recall bypass + params</span>
+            </div>
+            {slots.map((slot, index) => {
+              const isActive = index === active;
+              const isRenaming = renaming === index;
+              return (
+                <div key={index} className={`snap-row${isActive ? " active" : ""}`} role="option" aria-selected={isActive}>
+                  {isRenaming ? (
+                    // A plain div, not a button: an <input> is not valid content
+                    // inside a <button> and browsers handle the nesting
+                    // inconsistently (focus/Enter did not reliably reach the
+                    // input). Mutually exclusive with the button below instead.
+                    <div className="snap-row-main renaming">
+                      <span className="snap-row-num">{index + 1}</span>
+                      <input
+                        ref={renameRef}
+                        type="text"
+                        className="snap-row-rename"
+                        value={draft}
+                        maxLength={20}
+                        onChange={(e) => setDraft(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") commitRename();
+                          if (e.key === "Escape") setRenaming(null);
+                        }}
+                        onBlur={commitRename}
+                      />
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className="snap-row-main"
+                      onClick={() => {
+                        onSelect(index);
+                        setOpen(false);
+                      }}
+                    >
+                      <span className="snap-row-num">{index + 1}</span>
+                      <span className="snap-row-name">{slot.name}</span>
+                    </button>
+                  )}
+                  <div className="snap-row-actions">
+                    <button
+                      type="button"
+                      className="snap-row-icon"
+                      title={`Rename snapshot ${index + 1}`}
+                      aria-label={`Rename snapshot ${index + 1}`}
+                      onClick={() => startRename(index)}
+                    >
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M12 20h9" />
+                        <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      className="snap-row-icon"
+                      title={`Save current settings into slot ${index + 1}`}
+                      aria-label={`Save current settings into slot ${index + 1}`}
+                      onClick={() => onSaveCurrent(index)}
+                    >
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2Z" />
+                        <polyline points="17 21 17 13 7 13 7 21" />
+                        <polyline points="7 3 7 8 15 8" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Editor.tsx
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Editor.tsx
@@ -35,6 +35,7 @@ import {
 import { postGlobalCommand } from "./instanceBridge";
 import { POWER_PARAM_ID } from "./globals";
 import {
+  activeBankSlot,
   activeSnapshot,
   canRedo as historyCanRedo,
   canUndo as historyCanUndo,
@@ -44,10 +45,13 @@ import {
   createHistory,
   redo as historyRedo,
   reset as historyReset,
+  saveBankSlot,
   setActive,
+  setActiveBankSlot,
   undo as historyUndo,
   type AbSlot,
   type AbState,
+  type BankState,
   type History,
 } from "./state/history";
 import {
@@ -60,6 +64,7 @@ import {
   presetFileName,
   serializePreset,
   type PresetFile,
+  type SerializedSnapshotBank,
 } from "./presetFiles";
 import "./Styles/Editor.css";
 import { HashRouter, Routes, Route } from "react-router-dom";
@@ -90,6 +95,22 @@ export type RigSnapshot = {
   parameters: Record<string, Param[]>;
   globals: GlobalState;
 };
+
+/**
+ * One Helix-style performance snapshot: bypass + parameter values only.
+ * Deliberately narrower than {@link RigSnapshot} — no `pathOrder` or
+ * `stageModels` — so recalling a snapshot can never change which model
+ * occupies a stage or reorder the chain, which is what keeps switching
+ * click-free (see `mergeSnapshotIntoRig`).
+ */
+export type Snapshot = {
+  name: string;
+  bypassed: Partial<Record<CategoryId, boolean>>;
+  parameters: Record<string, Param[]>;
+};
+
+/** Fixed bank size — matches the number of slots `SnapshotBar` renders. */
+export const SNAPSHOT_COUNT = 8;
 
 /**
  * Undo coalescing window. A fader drag emits an edit per pointer move; without
@@ -171,6 +192,77 @@ function applySnapshotToDsp(snap: RigSnapshot) {
   // A snapshot is one logical transaction. Do not leave it waiting on a CEF
   // animation frame (which may be throttled while the window is rebinding).
   flushParamEditsNow();
+}
+
+function snapshotContentFromRig(rig: RigSnapshot, name: string): Snapshot {
+  return {
+    name,
+    bypassed: { ...rig.bypassed },
+    parameters: cloneParameters(rig.parameters),
+  };
+}
+
+/** A fresh bank with all 8 slots seeded identically from `rig` — the state
+ * every new preset/instance starts from before anything is explicitly saved
+ * into a slot. */
+function defaultSnapshotBank(rig: RigSnapshot): BankState<Snapshot> {
+  return {
+    active: 0,
+    slots: Array.from({ length: SNAPSHOT_COUNT }, (_, i) =>
+      snapshotContentFromRig(rig, String(i + 1)),
+    ),
+  };
+}
+
+/**
+ * Resolve a persisted snapshot bank from a preset file against the current
+ * schema, defensively: missing/short/malformed entries fall back to a fresh
+ * slot seeded from `fallbackRig`, exactly as `completeParameters` already
+ * does for a `RigSnapshot`'s own parameters.
+ */
+function normalizeSnapshotBank(
+  persisted: SerializedSnapshotBank | undefined,
+  fallbackRig: RigSnapshot,
+): BankState<Snapshot> {
+  if (!persisted) return defaultSnapshotBank(fallbackRig);
+  const slots = Array.from({ length: SNAPSHOT_COUNT }, (_, i) => {
+    const saved = persisted.slots?.[i];
+    const fallback = snapshotContentFromRig(fallbackRig, String(i + 1));
+    if (!saved || typeof saved !== "object") return fallback;
+    return {
+      name: typeof saved.name === "string" && saved.name ? saved.name : fallback.name,
+      bypassed:
+        saved.bypassed && typeof saved.bypassed === "object"
+          ? { ...saved.bypassed }
+          : fallback.bypassed,
+      parameters:
+        saved.parameters && typeof saved.parameters === "object"
+          ? completeParameters(saved.parameters)
+          : fallback.parameters,
+    };
+  });
+  const active =
+    typeof persisted.active === "number" &&
+    persisted.active >= 0 &&
+    persisted.active < SNAPSHOT_COUNT
+      ? Math.floor(persisted.active)
+      : 0;
+  return { active, slots };
+}
+
+/**
+ * Overlay a snapshot's bypass/parameters onto an otherwise-unchanged rig.
+ * Model choice, chain order, active category and global trims all pass
+ * through from `rig` untouched — a snapshot recall is never a topology
+ * change, which is why it can go through the same DSP push as any other
+ * param edit and stay click-free.
+ */
+function mergeSnapshotIntoRig(rig: RigSnapshot, content: Snapshot): RigSnapshot {
+  return {
+    ...rig,
+    bypassed: { ...content.bypassed },
+    parameters: completeParameters(content.parameters),
+  };
 }
 
 function factorySnapshot(id: string): RigSnapshot | null {
@@ -275,6 +367,9 @@ export function RodhareistEditor({
   const [ab, setAb] = useState<AbState<RigSnapshot>>(() =>
     createAb(initialSnapshot),
   );
+  const [snapshots, setSnapshots] = useState<BankState<Snapshot>>(() =>
+    defaultSnapshotBank(initialSnapshot),
+  );
 
   const audioRef = useRef<{
     ctx: AudioContext;
@@ -298,6 +393,7 @@ export function RodhareistEditor({
     pendingSwitchId,
     history,
     ab,
+    snapshots,
   });
   liveRef.current = {
     currentPresetId,
@@ -314,6 +410,7 @@ export function RodhareistEditor({
     pendingSwitchId,
     history,
     ab,
+    snapshots,
   };
 
   /** Snapshot of the live editor state. */
@@ -508,6 +605,48 @@ export function RodhareistEditor({
   }, [currentSnapshot]);
 
   // -------------------------------------------------------------------------
+  // Snapshots — instant bypass/param recall within the current preset
+  // -------------------------------------------------------------------------
+
+  /** Recall a slot: bypass + parameter values only, model/path untouched. */
+  const recallSnapshot = useCallback(
+    (index: number) => {
+      const live = liveRef.current;
+      if (index === live.snapshots.active) return;
+      flushCommit();
+      const nextBank = setActiveBankSlot(live.snapshots, index);
+      liveRef.current.snapshots = nextBank;
+      setSnapshots(nextBank);
+      const merged = mergeSnapshotIntoRig(currentSnapshot(), activeBankSlot(nextBank));
+      restoreSnapshot(merged, true);
+    },
+    [currentSnapshot, flushCommit, restoreSnapshot],
+  );
+
+  /** "Save Current Here" — overwrite one slot's bypass/params, keep its name. */
+  const saveCurrentToSnapshot = useCallback(
+    (index: number) => {
+      const live = liveRef.current;
+      const rig = currentSnapshot();
+      const name = live.snapshots.slots[index]?.name ?? String(index + 1);
+      const next = saveBankSlot(live.snapshots, index, snapshotContentFromRig(rig, name));
+      liveRef.current.snapshots = next;
+      setSnapshots(next);
+      markDirty();
+    },
+    [currentSnapshot, markDirty],
+  );
+
+  const renameSnapshot = useCallback((index: number, name: string) => {
+    const live = liveRef.current;
+    const slot = live.snapshots.slots[index];
+    if (!slot) return;
+    const next = saveBankSlot(live.snapshots, index, { ...slot, name });
+    liveRef.current.snapshots = next;
+    setSnapshots(next);
+  }, []);
+
+  // -------------------------------------------------------------------------
   // Preset handling
   // -------------------------------------------------------------------------
 
@@ -532,16 +671,21 @@ export function RodhareistEditor({
         nextDrafts[id] ?? live.savedRigs[id] ?? factorySnapshot(id);
       if (!snap) return;
 
-      // A preset load is a new baseline, not an edit: history and both A/B
-      // slots restart from it.
+      // A preset load is a new baseline, not an edit: history, both A/B
+      // slots and the snapshot bank all restart from it. Factory/saved-rig
+      // presets never carry a snapshot bank of their own (only a preset
+      // *file* can — see `loadPresetFile`), so this always reseeds fresh.
       suppressCommitRef.current = true;
       applyLocalSnapshot(snap, id, !!nextDrafts[id]);
       const freshHistory = historyReset(live.history, snap);
       const freshAb = createAb(snap);
+      const freshSnapshots = defaultSnapshotBank(snap);
       liveRef.current.history = freshHistory;
       liveRef.current.ab = freshAb;
+      liveRef.current.snapshots = freshSnapshots;
       setHistory(freshHistory);
       setAb(freshAb);
+      setSnapshots(freshSnapshots);
       setPendingSwitchId(null);
       window.setTimeout(() => {
         suppressCommitRef.current = false;
@@ -574,10 +718,13 @@ export function RodhareistEditor({
       applyLocalSnapshot(file.snapshot, file.id, false);
       const freshHistory = historyReset(liveRef.current.history, file.snapshot);
       const freshAb = createAb(file.snapshot);
+      const freshSnapshots = normalizeSnapshotBank(file.snapshots, file.snapshot);
       liveRef.current.history = freshHistory;
       liveRef.current.ab = freshAb;
+      liveRef.current.snapshots = freshSnapshots;
       setHistory(freshHistory);
       setAb(freshAb);
+      setSnapshots(freshSnapshots);
       setPendingSwitchId(null);
       window.setTimeout(() => {
         suppressCommitRef.current = false;
@@ -594,7 +741,7 @@ export function RodhareistEditor({
       const id = `U${Date.now().toString(36).toUpperCase().slice(-4)}`;
       return {
         fileName: presetFileName(id, name),
-        content: serializePreset(id, name, snap.activeCat, snap),
+        content: serializePreset(id, name, snap.activeCat, snap, liveRef.current.snapshots),
       };
     },
     [currentSnapshot],
@@ -901,8 +1048,11 @@ export function RodhareistEditor({
     suppressCommitRef.current = true;
     applyLocalSnapshot(snap, live.currentPresetId, false);
     const freshHistory = historyReset(live.history, snap);
+    const freshSnapshots = defaultSnapshotBank(snap);
     liveRef.current.history = freshHistory;
+    liveRef.current.snapshots = freshSnapshots;
     setHistory(freshHistory);
+    setSnapshots(freshSnapshots);
     window.setTimeout(() => {
       suppressCommitRef.current = false;
     }, 0);
@@ -1116,6 +1266,11 @@ export function RodhareistEditor({
       canUndo={historyCanUndo(history)}
       canRedo={historyCanRedo(history)}
       abSlot={ab.active}
+      snapshotSlots={snapshots.slots}
+      activeSnapshotIndex={snapshots.active}
+      onSelectSnapshot={recallSnapshot}
+      onSaveSnapshot={saveCurrentToSnapshot}
+      onRenameSnapshot={renameSnapshot}
       clipboardCat={clipboard?.cat ?? null}
       discardPrompt={
         pendingSwitchId

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Layout.tsx
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Layout.tsx
@@ -120,6 +120,11 @@ export type LayoutProps = {
   canUndo: boolean;
   canRedo: boolean;
   abSlot: AbSlot;
+  snapshotSlots: readonly import("./Editor").Snapshot[];
+  activeSnapshotIndex: number;
+  onSelectSnapshot: (index: number) => void;
+  onSaveSnapshot: (index: number) => void;
+  onRenameSnapshot: (index: number, name: string) => void;
   clipboardCat: CategoryId | null;
   discardPrompt: DiscardPrompt | null;
   onUndo: () => void;
@@ -169,6 +174,11 @@ export function Layout({
   canUndo,
   canRedo,
   abSlot,
+  snapshotSlots,
+  activeSnapshotIndex,
+  onSelectSnapshot,
+  onSaveSnapshot,
+  onRenameSnapshot,
   clipboardCat,
   discardPrompt,
   onUndo,
@@ -227,6 +237,11 @@ export function Layout({
         onToggleTest={onToggleTest}
         onSave={onSave}
         onRevert={onRevert}
+        snapshotSlots={snapshotSlots}
+        activeSnapshotIndex={activeSnapshotIndex}
+        onSelectSnapshot={onSelectSnapshot}
+        onSaveSnapshot={onSaveSnapshot}
+        onRenameSnapshot={onRenameSnapshot}
       />
 
       <div className="workspace" ref={workspaceRef}>

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Styles/Editor.css
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/Styles/Editor.css
@@ -248,6 +248,121 @@ body {
 }
 .di-btn.on .led { background: var(--accent); }
 
+/* ── Snapshot selector ──────────────────────────── */
+/* Lives in the header, the same family as `.preset-nav`: step arrows flank
+   an LCD-style trigger. Compact enough to sit inline (a dropdown, not a
+   whole extra strip) — the eight slots themselves live in the portalled
+   `.snap-panel`, not in the header row. */
+.snap-select { display: flex; align-items: center; gap: 2px; flex-shrink: 0; }
+.snap-step {
+  width: 24px; height: 24px; padding: 0;
+  background: transparent; border: none; border-radius: var(--radius-sm);
+  color: var(--text-faint); cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: color 0.12s var(--ease), background 0.12s var(--ease);
+}
+.snap-step:hover { color: var(--text-hi); background: var(--bg-raised); }
+
+.snap-trigger {
+  display: flex; align-items: center; gap: 7px;
+  background: var(--bg-raised); border: 1px solid var(--stroke-2);
+  border-radius: var(--radius-sm);
+  padding: 6px 9px 6px 7px; cursor: pointer;
+  color: var(--text); font-family: inherit;
+  transition: border-color 0.12s var(--ease), color 0.12s var(--ease), background 0.12s var(--ease);
+}
+.snap-trigger:hover { border-color: var(--stroke-3); color: var(--text-hi); }
+.snap-trigger[aria-expanded="true"] {
+  border-color: rgba(232,162,58,0.45); background: var(--accent-soft); color: var(--text-hi);
+}
+.snap-trigger-badge {
+  display: flex; align-items: center; justify-content: center;
+  width: 17px; height: 17px; border-radius: 50%;
+  background: var(--accent); color: var(--bg-panel);
+  font-size: 10px; font-weight: 700; font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.snap-trigger-name {
+  font-size: 12.5px; font-weight: 600;
+  max-width: 108px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.snap-trigger-chevron { color: var(--text-faint); flex-shrink: 0; transition: transform 0.12s var(--ease); }
+.snap-trigger[aria-expanded="true"] .snap-trigger-chevron { transform: rotate(180deg); color: var(--accent); }
+
+/* Portalled to <body> — see SnapshotDropdown.tsx. Between the block-menu
+   popover (z-index 45) and the full modal overlays (50/60): a header
+   dropdown, not a document-level menu or an editor takeover. */
+.snap-panel {
+  position: fixed; top: 0; left: 0; z-index: 46;
+  width: 258px; max-height: min(420px, 80vh); overflow-y: auto;
+  background: var(--bg-panel); border: 1px solid var(--stroke-2);
+  border-radius: var(--radius);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.6);
+  padding: 4px;
+  scrollbar-width: thin;
+}
+.snap-panel::-webkit-scrollbar { width: 6px; }
+.snap-panel::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 3px; }
+
+.snap-panel-head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
+  padding: 7px 8px 6px;
+}
+.snap-panel-head > span:first-child {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text-dim);
+}
+.snap-panel-hint { font-size: 10px; color: var(--text-faint); }
+
+.snap-row {
+  display: flex; align-items: stretch; gap: 2px;
+  border-radius: var(--radius-sm);
+}
+.snap-row-main {
+  flex: 1; min-width: 0;
+  display: flex; align-items: center; gap: 9px;
+  background: none; border: none; border-radius: var(--radius-sm);
+  padding: 7px 8px; cursor: pointer; text-align: left;
+  color: var(--text); font-family: inherit;
+  transition: background 0.1s var(--ease);
+}
+.snap-row-main:hover { background: rgba(255,255,255,0.04); }
+.snap-row.active .snap-row-main { background: var(--accent-soft); }
+.snap-row-num {
+  display: flex; align-items: center; justify-content: center;
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--bg-inset); color: var(--text-dim);
+  font-size: 10px; font-weight: 700; font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.snap-row.active .snap-row-num { background: var(--accent); color: var(--bg-panel); }
+.snap-row-name {
+  font-size: 12.5px; font-weight: 500; color: var(--text);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.snap-row.active .snap-row-name { color: var(--text-hi); font-weight: 600; }
+.snap-row-rename {
+  flex: 1; min-width: 0;
+  background: var(--bg-inset); border: 1px solid var(--stroke-3);
+  border-radius: var(--radius-sm); padding: 3px 6px;
+  color: var(--text-hi); font-family: inherit; font-size: 12.5px; outline: none;
+}
+
+.snap-row-actions {
+  display: flex; align-items: center; gap: 1px;
+  padding-right: 4px; flex-shrink: 0;
+}
+.snap-row-icon {
+  width: 22px; height: 22px; padding: 0;
+  display: flex; align-items: center; justify-content: center;
+  background: none; border: none; border-radius: 2px;
+  color: var(--text-faint); cursor: pointer;
+  opacity: 0; transition: opacity 0.1s var(--ease), color 0.12s var(--ease), background 0.12s var(--ease);
+}
+.snap-row:hover .snap-row-icon,
+.snap-row-icon:focus-visible { opacity: 1; }
+.snap-row-icon:hover { color: var(--text-hi); background: rgba(255,255,255,0.07); }
+
 /* ── Workspace ──────────────────────────────────── */
 .workspace {
   display: grid;
@@ -796,48 +911,108 @@ body {
 .bypass.off { color: var(--text-dim); }
 .bypass.off .led { background: var(--text-faint); }
 
-.model-strip {
-  /* Compact single-line chips (name only; description is the tooltip and the
-     active model's lives in the header) — even the ten amp models fit one or
-     two tidy rows without a scrollbar. Wrap instead of clipping the tail. */
-  display: flex; flex-wrap: wrap; gap: 6px;
-  /* Safety cap for extreme cases so the strip can't squeeze the knobs out. */
-  max-height: 76px; overflow-y: auto; overflow-x: hidden;
-  padding: 0 0 2px;
+/* The model name doubles as the picker trigger whenever a stage has more
+   than one model to choose from (`ModuleEditor`'s `canPickModel`) — a single-
+   model stage keeps the plain, non-interactive `.fp-name` div. */
+.fp-name-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: none; border: none; padding: 0; margin-top: 3px;
+  cursor: pointer; color: var(--text-hi); font-family: inherit;
+  border-radius: var(--radius-sm);
+}
+.fp-name-btn .fp-name { margin-top: 0; }
+.fp-name-btn svg { color: var(--text-dim); flex-shrink: 0; transition: color 0.12s var(--ease), transform 0.12s var(--ease); }
+.fp-name-btn:hover svg, .fp-name-btn[aria-expanded="true"] svg {
+  color: var(--cat-color, var(--text-hi));
+}
+.fp-name-btn[aria-expanded="true"] svg { transform: rotate(180deg); }
+
+/* ── Model picker overlay ──────────────────────────
+   Portalled to <body> (see ModelPicker.tsx) because its trigger lives inside
+   `.faceplate`, which clips overflow. Fixed, not absolute, for the same
+   reason — it must escape every clipped/positioned ancestor, not just the
+   plugin chassis `DiscardDialog`'s in-flow `.modal-backdrop` sits inside. */
+.picker-backdrop {
+  position: fixed; inset: 0; z-index: 60;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex; align-items: center; justify-content: center;
+  padding: 32px;
+}
+.picker-panel {
+  width: min(640px, 100%);
+  max-height: min(560px, 100%);
+  display: flex; flex-direction: column;
+  background: var(--bg-panel);
+  border: 1px solid var(--stroke-2);
+  border-radius: var(--radius);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+}
+.picker-head {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: 12px; padding: 16px 16px 10px; flex-shrink: 0;
+}
+.picker-title-wrap { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.picker-eyebrow {
+  font-size: 11px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase;
+}
+.picker-title { font-size: 16px; font-weight: 600; color: var(--text-hi); }
+.picker-close {
+  background: var(--bg-raised); border: 1px solid var(--stroke-2);
+  color: var(--text-dim); cursor: pointer; border-radius: var(--radius-sm);
+  width: 28px; height: 28px; display: flex; align-items: center; justify-content: center;
   flex-shrink: 0;
+  transition: color 0.12s var(--ease), border-color 0.12s var(--ease);
+}
+.picker-close:hover { color: var(--text-hi); border-color: var(--stroke-3); }
+
+.picker-search {
+  margin: 0 16px 12px;
+  background: var(--bg-inset);
+  border: 1px solid var(--stroke-1); border-radius: var(--radius-sm);
+  padding: 9px 12px; color: var(--text-hi);
+  font-family: inherit; font-size: 13px; outline: none;
+  flex-shrink: 0;
+  transition: border-color 0.12s var(--ease);
+}
+.picker-search::placeholder { color: var(--text-faint); }
+.picker-search:focus { border-color: var(--stroke-3); }
+
+.picker-grid {
+  flex: 1; min-height: 0; overflow-y: auto;
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+  gap: 8px; padding: 0 16px 16px;
   scrollbar-width: thin;
 }
-.model-strip::-webkit-scrollbar { width: 5px; height: 5px; }
-.model-strip::-webkit-scrollbar-thumb {
-  background: rgba(255,255,255,0.1);
-  border-radius: 3px;
+.picker-grid::-webkit-scrollbar { width: 6px; }
+.picker-grid::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 3px; }
+
+.picker-empty {
+  grid-column: 1 / -1;
+  padding: 24px 8px; text-align: center;
+  color: var(--text-dim); font-size: 12.5px;
 }
 
-.model-chip {
-  flex: 0 0 auto;
-  background: var(--bg-panel);
-  border: 1px solid var(--stroke-1);
-  border-radius: var(--radius);
-  padding: 7px 14px;
-  cursor: pointer;
-  color: var(--text); font-family: inherit;
-  font-size: 12.5px; font-weight: 500;
-  white-space: nowrap;
-  transition: border-color 0.12s var(--ease), background 0.12s var(--ease),
-    color 0.12s var(--ease);
+.picker-tile {
+  display: flex; align-items: flex-start; gap: 10px;
+  background: var(--bg-raised); border: 1px solid var(--stroke-1);
+  border-radius: var(--radius); padding: 10px 12px;
+  cursor: pointer; text-align: left; color: inherit; font-family: inherit;
+  transition: border-color 0.12s var(--ease), background 0.12s var(--ease);
 }
-.model-chip:hover {
-  border-color: var(--stroke-3);
-  background: var(--bg-raised);
-  color: var(--text-hi);
+.picker-tile:hover { border-color: var(--stroke-3); }
+.picker-tile.active {
+  border-color: color-mix(in srgb, var(--mc) 45%, var(--stroke-2));
+  background: color-mix(in srgb, var(--mc) 10%, var(--bg-raised));
+  box-shadow: inset 0 -2px 0 var(--mc);
 }
-.model-chip.active {
-  border-color: color-mix(in srgb, var(--cat-color) 45%, var(--stroke-2));
-  background: color-mix(in srgb, var(--cat-color) 10%, var(--bg-panel));
-  color: var(--text-hi);
-  font-weight: 600;
-  box-shadow: inset 0 -2px 0 var(--cat-color);
+.picker-tile-icon {
+  flex-shrink: 0; color: var(--mc);
+  width: 20px; height: 20px; margin-top: 1px;
 }
+.picker-tile-text { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.picker-tile-name { font-size: 13px; font-weight: 600; color: var(--text-hi); }
+.picker-tile-sub { font-size: 11.5px; color: var(--text-dim); line-height: 1.35; }
 
 .nam-capture-controls {
   display: flex; align-items: center; flex-wrap: wrap; gap: 10px 16px;

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/bridge.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/bridge.test.ts
@@ -9,6 +9,7 @@ import {
   CAB_MODEL_INDEX,
   DRIVE_MODEL_INDEX,
   DELAY_MODEL_INDEX,
+  EQ_MODEL_INDEX,
   REVERB_MODEL_INDEX,
   TONE_ENGINE_INDEX,
   __flushParamEditsForTest,
@@ -58,6 +59,9 @@ describe("model-select wire values", () => {
       jcm: 5,
       slate: 6,
       bassman: 7,
+      boutique: 8,
+      invader: 9,
+      tweed_combo: 10,
     });
   });
 
@@ -73,6 +77,8 @@ describe("model-select wire values", () => {
       super_drive: 7,
       metal_core: 8,
       tight_rift: 9,
+      amber_crunch: 10,
+      copper_fuzz: 11,
     });
   });
 
@@ -90,6 +96,8 @@ describe("model-select wire values", () => {
       uber_412: 9,
       slo_412: 10,
       ir: 11,
+      modern_212: 12,
+      american_1x12: 13,
     });
   });
 
@@ -110,6 +118,21 @@ describe("model-select wire values", () => {
       ping_pong: 3,
       dual: 4,
     });
+  });
+
+  test("eq map mirrors EqModel::ALL order", () => {
+    expect(EQ_MODEL_INDEX).toEqual({
+      parametric: 0,
+      vintage_eq: 1,
+      modern_eq: 2,
+    });
+  });
+
+  test("postModel forwards an eq voicing as eq_model", () => {
+    const batches = captureBatches();
+    postModel("eq", "modern_eq");
+    __flushParamEditsForTest();
+    expect(batches).toEqual([[{ id: "eq_model", value: 2 }]]);
   });
 
   test("postModel forwards a delay voicing as delay_model", () => {

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/bridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/bridge.ts
@@ -197,6 +197,9 @@ export const AMP_MODEL_INDEX: Record<string, number> = {
   jcm: 5,
   slate: 6,
   bassman: 7,
+  boutique: 8,
+  invader: 9,
+  tweed_combo: 10,
 };
 
 export const DRIVE_MODEL_INDEX: Record<string, number> = {
@@ -210,6 +213,8 @@ export const DRIVE_MODEL_INDEX: Record<string, number> = {
   super_drive: 7,
   metal_core: 8,
   tight_rift: 9,
+  amber_crunch: 10,
+  copper_fuzz: 11,
 };
 
 export const CAB_MODEL_INDEX: Record<string, number> = {
@@ -225,6 +230,8 @@ export const CAB_MODEL_INDEX: Record<string, number> = {
   uber_412: 9,
   slo_412: 10,
   ir: 11,
+  modern_212: 12,
+  american_1x12: 13,
 };
 
 /** `ReverbModel` indices (mirrors Rust `ReverbModel::ALL`). */
@@ -257,12 +264,26 @@ export const MOD_MODEL_INDEX: Record<string, number> = {
   khaen_swirl: 6,
   bi_lam: 7,
   isan_jet: 8,
+  soft_phase: 9,
+  wide_vibe: 10,
 };
 
 /** `WahModel` indices (mirrors Rust `WahModel::ALL`). */
 export const WAH_MODEL_INDEX: Record<string, number> = {
   cry_wah: 0,
   touch_wah: 1,
+};
+
+/**
+ * `EqModel` indices (mirrors Rust `EqModel::ALL`). `parametric` is the
+ * editor's original (and, until the model select was added, only) EQ id —
+ * kept as Studio's id rather than renamed, so every existing preset keeps
+ * its exact voicing.
+ */
+export const EQ_MODEL_INDEX: Record<string, number> = {
+  parametric: 0,
+  vintage_eq: 1,
+  modern_eq: 2,
 };
 
 /** `ToneEngineKind` indices (Classic=0, NamCapture=1, Bypass=2). */
@@ -295,6 +316,11 @@ export function postModel(category: string, modelId: string): void {
     case "delay2": {
       const i = DELAY_MODEL_INDEX[baseModelId(modelId)];
       if (i !== undefined) postParam("delay2_model", i);
+      return;
+    }
+    case "eq2": {
+      const i = EQ_MODEL_INDEX[baseModelId(modelId)];
+      if (i !== undefined) postParam("eq2_model", i);
       return;
     }
     case "amp": {
@@ -334,6 +360,11 @@ export function postModel(category: string, modelId: string): void {
       if (i !== undefined) postParam("wah_model", i);
       return;
     }
+    case "eq": {
+      const i = EQ_MODEL_INDEX[modelId];
+      if (i !== undefined) postParam("eq_model", i);
+      return;
+    }
     case "verb":
     case "reverb": {
       const i = REVERB_MODEL_INDEX[modelId];
@@ -346,7 +377,7 @@ export function postModel(category: string, modelId: string): void {
       return;
     }
     default:
-      // Single-algorithm stages (gate/comp/eq and their B blocks) have no
+      // Single-algorithm stages (gate/comp and their B blocks) have no
       // model select.
       return;
   }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/data.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/data.ts
@@ -866,6 +866,82 @@ export const presetsData: Preset[] = [
     },
     path: ["amp", "mod", "delay", "verb", "cab"],
   },
+  {
+    id: "13A",
+    name: "Singing Sustain",
+    outputTrim: -1.5,
+    category: "amp",
+    model: "boutique",
+    stageModels: { amp: "boutique", verb: "room", cab: "vintage_212" },
+    values: {
+      // Boutique territory: gain stays low enough that the amp's own touch
+      // compression — not clipping — is doing the sustaining, mids pushed for
+      // the singing upper-mid this voice leads with.
+      amp_gain: 3.5,
+      amp_bass: 5,
+      amp_middle: 6.8,
+      amp_treble: 5,
+      amp_presence: 5.2,
+      amp_master: 7.5,
+      reverb_decay: 1.6,
+      reverb_mix: 14,
+      cab_mic_type: 0,
+      cab_mic: 40,
+      cab_dist: 26,
+    },
+    path: ["amp", "verb", "cab"],
+  },
+  {
+    id: "13B",
+    name: "Invader Chug",
+    outputTrim: 4.5,
+    category: "amp",
+    model: "invader",
+    stageModels: { dyn: "gate", amp: "invader", eq: "parametric", cab: "uber_412" },
+    values: {
+      gate_thresh: -50,
+      amp_gain: 8.2,
+      amp_bass: 4.5,
+      amp_middle: 3,
+      amp_treble: 6,
+      amp_presence: 6.5,
+      amp_master: 4.5,
+      eq_low_gain: -1.5,
+      eq_mid1_freq: 280,
+      eq_mid1_gain: -1.5,
+      eq_mid2_freq: 1700,
+      eq_mid2_gain: 1.5,
+      eq_high_gain: 0.5,
+      cab_mic_type: 0,
+      cab_mic: 48,
+      cab_dist: 12,
+    },
+    path: ["dyn", "amp", "eq", "cab"],
+  },
+  {
+    id: "13C",
+    name: "Tweed Breakup",
+    outputTrim: -4.0,
+    category: "amp",
+    model: "tweed_combo",
+    stageModels: { amp: "tweed_combo", verb: "room", cab: "tweed_1x12" },
+    values: {
+      // A small combo's own power stage is the breakup here — gain sits at
+      // the point where picking harder pushes it over, not maxed out.
+      amp_gain: 6.5,
+      amp_bass: 5.5,
+      amp_middle: 5.5,
+      amp_treble: 6,
+      amp_presence: 4,
+      amp_master: 6.5,
+      reverb_decay: 1.3,
+      reverb_mix: 11,
+      cab_mic_type: 1,
+      cab_mic: 30,
+      cab_dist: 34,
+    },
+    path: ["amp", "verb", "cab"],
+  },
 ];
 
 const primaryCategories: Record<PrimaryCategoryId, Category> = {
@@ -989,6 +1065,18 @@ const primaryModels: Record<PrimaryCategoryId, Model[]> = {
       short: "EQ",
       sub: "4-band parametric tone shaping",
     },
+    {
+      id: "vintage_eq",
+      name: "Vintage EQ",
+      short: "Vintage",
+      sub: "Passive-console character, wide smooth bells",
+    },
+    {
+      id: "modern_eq",
+      name: "Modern EQ",
+      short: "Modern",
+      sub: "Surgical digital character, narrow precise bells",
+    },
   ],
   dist: [
     {
@@ -1051,6 +1139,18 @@ const primaryModels: Record<PrimaryCategoryId, Model[]> = {
       short: "Rift",
       sub: "Modern tight high-gain, djent-ready",
     },
+    {
+      id: "amber_crunch",
+      name: "Amber Crunch",
+      short: "Amber",
+      sub: "Bright silicon blues/rock rhythm crunch",
+    },
+    {
+      id: "copper_fuzz",
+      name: "Copper Fuzz",
+      short: "Copper",
+      sub: "Tight aggressive silicon fuzz",
+    },
   ],
   amp: [
     {
@@ -1100,6 +1200,24 @@ const primaryModels: Record<PrimaryCategoryId, Model[]> = {
       name: "Bassman",
       short: "Bassman",
       sub: "Loose American bass-heavy head",
+    },
+    {
+      id: "boutique",
+      name: "Overdrive Special",
+      short: "Boutique",
+      sub: "Smooth boutique low/mid-gain sustain",
+    },
+    {
+      id: "invader",
+      name: "Invader 5150",
+      short: "Invader",
+      sub: "Tight, scooped modern high-gain stack",
+    },
+    {
+      id: "tweed_combo",
+      name: "Tweed Deluxe",
+      short: "Tweed",
+      sub: "Small, early-breakup single-speaker combo",
     },
     {
       id: "nam_capture",
@@ -1182,6 +1300,18 @@ const primaryModels: Record<PrimaryCategoryId, Model[]> = {
       name: "Isan Jet",
       short: "IsanJet",
       sub: "6-stage, hard regeneration — lively jet, not a helicopter",
+    },
+    {
+      id: "soft_phase",
+      name: "Soft Phase",
+      short: "SoftPh",
+      sub: "2-stage, one gentle notch — the subtle end of the range",
+    },
+    {
+      id: "wide_vibe",
+      name: "Wide Vibe",
+      short: "WideV",
+      sub: "Real linked stereo spread — lush and wide, not mono",
     },
   ],
   delay: [
@@ -1310,6 +1440,18 @@ const primaryModels: Record<PrimaryCategoryId, Model[]> = {
       short: "IR",
       sub: "Convolution with a loaded .wav cabinet IR",
     },
+    {
+      id: "modern_212",
+      name: "Modern 2x12",
+      short: "Mod 2x12",
+      sub: "Tight closed-back pair, scaled-down modern scoop",
+    },
+    {
+      id: "american_1x12",
+      name: "American 1x12 Combo",
+      short: "Am 1x12",
+      sub: "Small, bright, open single speaker",
+    },
   ],
 };
 
@@ -1361,7 +1503,26 @@ const primaryParameterDefaults: Record<string, Param[]> = {
     { id: "comp_release", name: "Release", min: 10, max: 1000, val: 120, unit: "ms" },
     { id: "comp_makeup", name: "Makeup", min: 0, max: 24, val: 0, unit: "dB" },
   ],
+  // All three EQ models share this exact param set — the model only changes
+  // the fixed shelf corners and bell Q inside the DSP (`eq::EqProfile`), not
+  // what these six knobs mean or where they default.
   parametric: [
+    { id: "eq_low_gain", name: "Low", min: -15, max: 15, val: 0, unit: "dB" },
+    { id: "eq_mid1_freq", name: "Mid1 Freq", min: 100, max: 1000, val: 400, unit: "Hz" },
+    { id: "eq_mid1_gain", name: "Mid1", min: -15, max: 15, val: 0, unit: "dB" },
+    { id: "eq_mid2_freq", name: "Mid2 Freq", min: 600, max: 6000, val: 2000, unit: "Hz" },
+    { id: "eq_mid2_gain", name: "Mid2", min: -15, max: 15, val: 0, unit: "dB" },
+    { id: "eq_high_gain", name: "High", min: -15, max: 15, val: 0, unit: "dB" },
+  ],
+  vintage_eq: [
+    { id: "eq_low_gain", name: "Low", min: -15, max: 15, val: 0, unit: "dB" },
+    { id: "eq_mid1_freq", name: "Mid1 Freq", min: 100, max: 1000, val: 400, unit: "Hz" },
+    { id: "eq_mid1_gain", name: "Mid1", min: -15, max: 15, val: 0, unit: "dB" },
+    { id: "eq_mid2_freq", name: "Mid2 Freq", min: 600, max: 6000, val: 2000, unit: "Hz" },
+    { id: "eq_mid2_gain", name: "Mid2", min: -15, max: 15, val: 0, unit: "dB" },
+    { id: "eq_high_gain", name: "High", min: -15, max: 15, val: 0, unit: "dB" },
+  ],
+  modern_eq: [
     { id: "eq_low_gain", name: "Low", min: -15, max: 15, val: 0, unit: "dB" },
     { id: "eq_mid1_freq", name: "Mid1 Freq", min: 100, max: 1000, val: 400, unit: "Hz" },
     { id: "eq_mid1_gain", name: "Mid1", min: -15, max: 15, val: 0, unit: "dB" },
@@ -1459,6 +1620,16 @@ const primaryParameterDefaults: Record<string, Param[]> = {
   tight_rift: [
     { id: "drive_gain", name: "Gain", min: 0, max: 10, val: 7.0, unit: "" },
     { id: "drive_tone", name: "Tone", min: 0, max: 10, val: 5.5, unit: "" },
+    { id: "drive_level", name: "Level", min: 0, max: 10, val: 5.5, unit: "" },
+  ],
+  amber_crunch: [
+    { id: "drive_gain", name: "Gain", min: 0, max: 10, val: 4.5, unit: "" },
+    { id: "drive_tone", name: "Tone", min: 0, max: 10, val: 6.0, unit: "" },
+    { id: "drive_level", name: "Level", min: 0, max: 10, val: 6.5, unit: "" },
+  ],
+  copper_fuzz: [
+    { id: "drive_gain", name: "Fuzz", min: 0, max: 10, val: 7.5, unit: "" },
+    { id: "drive_tone", name: "Tone", min: 0, max: 10, val: 4.5, unit: "" },
     { id: "drive_level", name: "Level", min: 0, max: 10, val: 5.5, unit: "" },
   ],
   mandarin: [
@@ -1609,6 +1780,30 @@ const primaryParameterDefaults: Record<string, Param[]> = {
     { id: "amp_presence", name: "Presence", min: 0, max: 10, val: 4.5, unit: "" },
     { id: "amp_master", name: "Master", min: 0, max: 10, val: 6.0, unit: "" },
   ],
+  boutique: [
+    { id: "amp_gain", name: "Drive", min: 0, max: 10, val: 3.5, unit: "" },
+    { id: "amp_bass", name: "Bass", min: 0, max: 10, val: 5.0, unit: "" },
+    { id: "amp_middle", name: "Mid", min: 0, max: 10, val: 6.5, unit: "" },
+    { id: "amp_treble", name: "Treble", min: 0, max: 10, val: 5.0, unit: "" },
+    { id: "amp_presence", name: "Presence", min: 0, max: 10, val: 5.0, unit: "" },
+    { id: "amp_master", name: "Master", min: 0, max: 10, val: 6.5, unit: "" },
+  ],
+  invader: [
+    { id: "amp_gain", name: "Drive", min: 0, max: 10, val: 8.0, unit: "" },
+    { id: "amp_bass", name: "Bass", min: 0, max: 10, val: 4.5, unit: "" },
+    { id: "amp_middle", name: "Mid", min: 0, max: 10, val: 3.5, unit: "" },
+    { id: "amp_treble", name: "Treble", min: 0, max: 10, val: 6.0, unit: "" },
+    { id: "amp_presence", name: "Presence", min: 0, max: 10, val: 6.5, unit: "" },
+    { id: "amp_master", name: "Master", min: 0, max: 10, val: 5.0, unit: "" },
+  ],
+  tweed_combo: [
+    { id: "amp_gain", name: "Drive", min: 0, max: 10, val: 6.0, unit: "" },
+    { id: "amp_bass", name: "Bass", min: 0, max: 10, val: 5.5, unit: "" },
+    { id: "amp_middle", name: "Mid", min: 0, max: 10, val: 5.5, unit: "" },
+    { id: "amp_treble", name: "Treble", min: 0, max: 10, val: 6.0, unit: "" },
+    { id: "amp_presence", name: "Presence", min: 0, max: 10, val: 4.0, unit: "" },
+    { id: "amp_master", name: "Master", min: 0, max: 10, val: 6.0, unit: "" },
+  ],
   nam_capture: [
     { id: "nam_input_trim", name: "Input Trim", min: -24, max: 24, val: 0, unit: "dB" },
     { id: "nam_output_trim", name: "Output Trim", min: -24, max: 24, val: 0, unit: "dB" },
@@ -1657,6 +1852,16 @@ const primaryParameterDefaults: Record<string, Param[]> = {
     { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 7.0, unit: "" },
     { id: "chorus_depth", name: "Depth", min: 0, max: 10, val: 6.5, unit: "" },
     { id: "chorus_mix", name: "Mix", min: 0, max: 100, val: 65, unit: "%" },
+  ],
+  soft_phase: [
+    { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 3.0, unit: "" },
+    { id: "chorus_depth", name: "Depth", min: 0, max: 10, val: 5.0, unit: "" },
+    { id: "chorus_mix", name: "Mix", min: 0, max: 100, val: 45, unit: "%" },
+  ],
+  wide_vibe: [
+    { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 3.2, unit: "" },
+    { id: "chorus_depth", name: "Depth", min: 0, max: 10, val: 7.0, unit: "" },
+    { id: "chorus_mix", name: "Mix", min: 0, max: 100, val: 62, unit: "%" },
   ],
   flanger: [
     { id: "chorus_rate", name: "Rate", min: 0, max: 10, val: 2.5, unit: "" },

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/instanceBridge.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/instanceBridge.ts
@@ -41,10 +41,11 @@ export type SelectInstanceMessage = {
   display: InstanceDisplayMetadata;
   stateRevision: number;
   /**
-   * TODO(phase5): rodharerist has no serialized per-insert DSP state yet
-   * (native's `SelectInstanceMsg.state` is always `{}` today — see that
-   * struct's doc comment). Treat this as opaque until the native side has
-   * something real to put in it.
+   * The bound insert's persisted DSP state (native's `decode_state_bytes`) —
+   * a real `RodhareistState` blob for an insert with something to restore,
+   * `{}` for a fresh insert. Untyped here because it is untrusted
+   * boundary data: `stateMap.ts`'s `snapshotFromRodhareistState` validates
+   * its shape structurally before use.
    */
   state: unknown;
 };

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/presetFiles.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/presetFiles.test.ts
@@ -6,7 +6,8 @@ import {
   serializePreset,
 } from "./presetFiles";
 import { presetsData } from "./data";
-import type { RigSnapshot } from "./Editor";
+import type { RigSnapshot, Snapshot } from "./Editor";
+import type { SerializedSnapshotBank } from "./presetFiles";
 
 const SNAPSHOT: RigSnapshot = {
   activeCat: "amp",
@@ -44,6 +45,37 @@ describe("preset files", () => {
     expect(parsed?.category).toBe("amp");
     expect(parsed?.snapshot.pathOrder).toEqual(["dyn", "dist", "amp", "cab"]);
     expect(parsed?.snapshot.globals.outputTrim).toBe(-2);
+  });
+
+  test("snapshot bank round-trips when present", () => {
+    const bank: SerializedSnapshotBank = {
+      active: 2,
+      slots: Array.from({ length: 8 }, (_, i): Snapshot => ({
+        name: `Slot ${i}`,
+        bypassed: i === 2 ? { comp: true } : {},
+        parameters: { recto: [{ id: "amp_gain", name: "Drive", min: 0, max: 10, val: i, unit: "" }] },
+      })),
+    };
+    const text = serializePreset("U1", "Chug Machine", "amp", SNAPSHOT, bank);
+    const parsed = parsePresetFile(text);
+    expect(parsed?.snapshots?.active).toBe(2);
+    expect(parsed?.snapshots?.slots).toHaveLength(8);
+    expect(parsed?.snapshots?.slots[2]?.bypassed).toEqual({ comp: true });
+    expect(parsed?.snapshots?.slots[5]?.parameters.recto?.[0]?.val).toBe(5);
+  });
+
+  test("omitted snapshot bank stays absent, not a default", () => {
+    const text = serializePreset("U1", "Chug Machine", "amp", SNAPSHOT);
+    const parsed = parsePresetFile(text);
+    expect(parsed?.snapshots).toBeUndefined();
+  });
+
+  test("a malformed snapshot bank is dropped, not rejected as an invalid file", () => {
+    const file = JSON.parse(serializePreset("U1", "Chug Machine", "amp", SNAPSHOT));
+    file.snapshots = { active: "not a number", slots: "not an array" };
+    const parsed = parsePresetFile(JSON.stringify(file));
+    expect(parsed).not.toBeNull();
+    expect(parsed?.snapshots).toBeUndefined();
   });
 
   test("rejects junk, foreign JSON and future versions", () => {

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/presetFiles.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/presetFiles.ts
@@ -6,10 +6,21 @@ import {
   presetsData,
   type CategoryId,
 } from "./data";
-import type { RigSnapshot } from "./Editor";
+import type { RigSnapshot, Snapshot } from "./Editor";
 
 export const PRESET_FILE_FORMAT = "rodhareist-preset";
 export const PRESET_FILE_VERSION = 1;
+
+/**
+ * A persisted snapshot bank. Optional on `PresetFile` — additive to v1, so
+ * older files (and older builds reading a newer file) round-trip fine: an
+ * absent/malformed block just means the editor reseeds a fresh bank from
+ * `snapshot` (see `Editor.tsx`'s `normalizeSnapshotBank`).
+ */
+export type SerializedSnapshotBank = {
+  active: number;
+  slots: readonly Snapshot[];
+};
 
 export type PresetFile = {
   format: typeof PRESET_FILE_FORMAT;
@@ -18,6 +29,7 @@ export type PresetFile = {
   name: string;
   category: CategoryId;
   snapshot: RigSnapshot;
+  snapshots?: SerializedSnapshotBank;
 };
 
 export function serializePreset(
@@ -25,6 +37,7 @@ export function serializePreset(
   name: string,
   category: CategoryId,
   snapshot: RigSnapshot,
+  snapshots?: SerializedSnapshotBank,
 ): string {
   const file: PresetFile = {
     format: PRESET_FILE_FORMAT,
@@ -33,6 +46,7 @@ export function serializePreset(
     name,
     category,
     snapshot,
+    ...(snapshots ? { snapshots } : {}),
   };
   return JSON.stringify(file, null, 2);
 }
@@ -59,7 +73,17 @@ export function parsePresetFile(text: string): PresetFile | null {
   if (!snap.parameters || typeof snap.parameters !== "object") return null;
   if (!snap.stageModels || typeof snap.stageModels !== "object") return null;
   if (!snap.globals || typeof snap.globals !== "object") return null;
-  return file as PresetFile;
+
+  // `snapshots` is optional and additive: a missing or structurally invalid
+  // block is dropped rather than rejecting an otherwise-valid preset file —
+  // the rig itself is still good, and the editor reseeds a fresh bank.
+  const bank = file.snapshots;
+  const validBank =
+    bank &&
+    typeof bank === "object" &&
+    typeof bank.active === "number" &&
+    Array.isArray(bank.slots);
+  return { ...file, snapshots: validBank ? bank : undefined } as PresetFile;
 }
 
 /**

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/state/history.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/state/history.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   HISTORY_LIMIT,
+  activeBankSlot,
   activeSnapshot,
   canRedo,
   canUndo,
@@ -10,8 +11,11 @@ import {
   createHistory,
   redo,
   reset,
+  saveBankSlot,
+  setActiveBankSlot,
   switchSlot,
   undo,
+  type BankState,
 } from "./history";
 
 describe("undo/redo history", () => {
@@ -134,5 +138,36 @@ describe("A/B compare", () => {
     expect(ab.active).toBe("B");
     expect(ab.B).toBe("b-edit");
     expect(ab.A).toBe("b-edit");
+  });
+});
+
+describe("snapshot bank", () => {
+  const bank: BankState<string> = { active: 0, slots: ["one", "two", "three"] };
+
+  test("switching slots never touches stored contents (unlike A/B, a live edit is discarded, not synced)", () => {
+    const next = setActiveBankSlot(bank, 2);
+    expect(next.active).toBe(2);
+    expect(activeBankSlot(next)).toBe("three");
+    // The slot we switched away from is untouched — no "current" was ever
+    // passed in to sync, matching a real footswitch bank.
+    expect(next.slots).toEqual(["one", "two", "three"]);
+  });
+
+  test("switching to the already-active slot or an out-of-range index is a no-op", () => {
+    expect(setActiveBankSlot(bank, 0)).toBe(bank);
+    expect(setActiveBankSlot(bank, -1)).toBe(bank);
+    expect(setActiveBankSlot(bank, 3)).toBe(bank);
+  });
+
+  test("saving overwrites exactly one slot and leaves the rest and the active index alone", () => {
+    const next = saveBankSlot(bank, 1, "two-edited");
+    expect(next.active).toBe(0);
+    expect(next.slots).toEqual(["one", "two-edited", "three"]);
+    // Original is untouched.
+    expect(bank.slots).toEqual(["one", "two", "three"]);
+  });
+
+  test("saving to an out-of-range index is a no-op", () => {
+    expect(saveBankSlot(bank, 9, "x")).toBe(bank);
   });
 });

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/state/history.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/state/history.ts
@@ -132,3 +132,38 @@ export function setActive<T>(ab: AbState<T>, slot: AbSlot, current: T): AbState<
   if (ab.active === slot) return ab;
   return switchSlot(ab, current);
 }
+
+// ---------------------------------------------------------------------------
+// Snapshot bank (Helix-style performance snapshots)
+// ---------------------------------------------------------------------------
+
+/**
+ * A fixed-size bank of named slots with one active. Unlike {@link AbState},
+ * switching never writes the live state back into the outgoing slot: a
+ * snapshot only changes when explicitly saved into (see {@link saveBankSlot}).
+ * Live edits made while a slot is active and not saved are simply live —
+ * switching away discards them from the bank, same as real footswitchable
+ * snapshots.
+ */
+export type BankState<T> = {
+  readonly active: number;
+  readonly slots: readonly T[];
+};
+
+export function activeBankSlot<T>(bank: BankState<T>): T {
+  return bank.slots[bank.active]!;
+}
+
+/** Switch the active slot. Out-of-range or already-active indices are a no-op. */
+export function setActiveBankSlot<T>(bank: BankState<T>, index: number): BankState<T> {
+  if (index === bank.active || index < 0 || index >= bank.slots.length) return bank;
+  return { ...bank, active: index };
+}
+
+/** Overwrite one slot's contents — the "save current into this slot" gesture. */
+export function saveBankSlot<T>(bank: BankState<T>, index: number, value: T): BankState<T> {
+  if (index < 0 || index >= bank.slots.length) return bank;
+  const slots = bank.slots.slice();
+  slots[index] = value;
+  return { ...bank, slots };
+}

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/stateMap.test.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/stateMap.test.ts
@@ -7,6 +7,7 @@ import {
   AMP_VARIANT_TO_MODEL,
   CAB_VARIANT_TO_MODEL,
   DRIVE_VARIANT_TO_MODEL,
+  EQ_VARIANT_TO_MODEL,
   MOD_VARIANT_TO_MODEL,
   DELAY_VARIANT_TO_MODEL,
   REVERB_VARIANT_TO_MODEL,
@@ -15,7 +16,13 @@ import {
   snapshotFromRodhareistState,
 } from "./stateMap";
 import { defaultValueFor, models, parameterDefaults } from "./data";
-import { MOD_MODEL_INDEX } from "./bridge";
+import {
+  AMP_MODEL_INDEX,
+  CAB_MODEL_INDEX,
+  DRIVE_MODEL_INDEX,
+  EQ_MODEL_INDEX,
+  MOD_MODEL_INDEX,
+} from "./bridge";
 
 /** A serde-shaped `RodhareistState` fixture (variant-name enum strings). */
 const FIXTURE = {
@@ -96,10 +103,11 @@ describe("snapshotFromRodhareistState", () => {
   test("variant tables cover every Rust enum variant", () => {
     // 10 stages + the 5 second instances (`StageKind::Drive2` …).
     expect(Object.keys(STAGE_VARIANT_TO_CATEGORY)).toHaveLength(15);
-    expect(Object.keys(AMP_VARIANT_TO_MODEL)).toHaveLength(8);
-    expect(Object.keys(DRIVE_VARIANT_TO_MODEL)).toHaveLength(10);
-    expect(Object.keys(CAB_VARIANT_TO_MODEL)).toHaveLength(12);
-    expect(Object.keys(MOD_VARIANT_TO_MODEL)).toHaveLength(9);
+    expect(Object.keys(AMP_VARIANT_TO_MODEL)).toHaveLength(11);
+    expect(Object.keys(DRIVE_VARIANT_TO_MODEL)).toHaveLength(12);
+    expect(Object.keys(CAB_VARIANT_TO_MODEL)).toHaveLength(14);
+    expect(Object.keys(MOD_VARIANT_TO_MODEL)).toHaveLength(11);
+    expect(Object.keys(EQ_VARIANT_TO_MODEL)).toHaveLength(3);
     expect(Object.keys(WAH_VARIANT_TO_MODEL)).toHaveLength(2);
     expect(Object.keys(REVERB_VARIANT_TO_MODEL)).toHaveLength(4);
     expect(Object.keys(DELAY_VARIANT_TO_MODEL)).toHaveLength(5);
@@ -127,6 +135,84 @@ describe("snapshotFromRodhareistState", () => {
         "chorus_mix",
       ]);
     }
+  });
+
+  // Same wiring hazard as the mod test above, for the two other stages with
+  // per-model tuned voicings sharing one shared knob set.
+  test("every classic amp model is wired end to end and its indices are contiguous", () => {
+    // `models.amp` also lists `nam_capture`/`bypass` — special `ToneEngineKind`
+    // engines, not `AmpModel` variants, so they carry no wire index/variant
+    // entry here by design. `AMP_MODEL_INDEX`'s keys are the classic models only.
+    const listed = Object.keys(AMP_MODEL_INDEX);
+    const byIndex = Object.entries(AMP_MODEL_INDEX).sort((a, b) => a[1] - b[1]);
+
+    expect(byIndex.map(([, i]) => i)).toEqual(listed.map((_, i) => i));
+    expect(Object.values(AMP_VARIANT_TO_MODEL).sort()).toEqual([...listed].sort());
+
+    for (const id of listed) {
+      const table = parameterDefaults[id];
+      expect(table, `no parameter table for amp model \`${id}\``).toBeDefined();
+      expect(table?.map((p) => p.id)).toEqual([
+        "amp_gain",
+        "amp_bass",
+        "amp_middle",
+        "amp_treble",
+        "amp_presence",
+        "amp_master",
+      ]);
+    }
+  });
+
+  test("every drive model is wired end to end and its indices are contiguous", () => {
+    const listed = models.dist.map((m) => m.id);
+    const byIndex = Object.entries(DRIVE_MODEL_INDEX).sort((a, b) => a[1] - b[1]);
+
+    expect(byIndex.map(([, i]) => i)).toEqual(listed.map((_, i) => i));
+    expect(byIndex.map(([id]) => id)).toEqual(listed);
+    expect(Object.values(DRIVE_VARIANT_TO_MODEL).sort()).toEqual([...listed].sort());
+
+    for (const id of listed) {
+      const table = parameterDefaults[id];
+      expect(table, `no parameter table for drive model \`${id}\``).toBeDefined();
+      expect(table?.map((p) => p.id)).toEqual([
+        "drive_gain",
+        "drive_tone",
+        "drive_level",
+      ]);
+    }
+  });
+
+  test("every eq model is wired end to end and its indices are contiguous", () => {
+    const listed = models.eq.map((m) => m.id);
+    const byIndex = Object.entries(EQ_MODEL_INDEX).sort((a, b) => a[1] - b[1]);
+
+    expect(byIndex.map(([, i]) => i)).toEqual(listed.map((_, i) => i));
+    expect(byIndex.map(([id]) => id)).toEqual(listed);
+    expect(Object.values(EQ_VARIANT_TO_MODEL).sort()).toEqual([...listed].sort());
+
+    for (const id of listed) {
+      const table = parameterDefaults[id];
+      expect(table, `no parameter table for eq model \`${id}\``).toBeDefined();
+      expect(table?.map((p) => p.id)).toEqual([
+        "eq_low_gain",
+        "eq_mid1_freq",
+        "eq_mid1_gain",
+        "eq_mid2_freq",
+        "eq_mid2_gain",
+        "eq_high_gain",
+      ]);
+    }
+  });
+
+  // Cab has no per-model parameter table (mic type/position/distance are
+  // shared across every voicing), so this checks index/variant wiring only.
+  test("every cab model is wired end to end and its indices are contiguous", () => {
+    const listed = models.cab.map((m) => m.id);
+    const byIndex = Object.entries(CAB_MODEL_INDEX).sort((a, b) => a[1] - b[1]);
+
+    expect(byIndex.map(([, i]) => i)).toEqual(listed.map((_, i) => i));
+    expect(byIndex.map(([id]) => id)).toEqual(listed);
+    expect(Object.values(CAB_VARIANT_TO_MODEL).sort()).toEqual([...listed].sort());
   });
 
   test("maps a serde fixture field-for-field", () => {

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/stateMap.ts
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/editorui/src/stateMap.ts
@@ -48,6 +48,9 @@ export const AMP_VARIANT_TO_MODEL: Record<string, string> = {
   Jcm: "jcm",
   Slate: "slate",
   Bassman: "bassman",
+  Boutique: "boutique",
+  Invader: "invader",
+  TweedCombo: "tweed_combo",
 };
 
 /** Rust `DriveModel` variant → editor model id. */
@@ -62,6 +65,8 @@ export const DRIVE_VARIANT_TO_MODEL: Record<string, string> = {
   SuperDrive: "super_drive",
   MetalCore: "metal_core",
   TightRift: "tight_rift",
+  AmberCrunch: "amber_crunch",
+  CopperFuzz: "copper_fuzz",
 };
 
 /** Rust `CabModel` variant → editor model id. */
@@ -78,6 +83,8 @@ export const CAB_VARIANT_TO_MODEL: Record<string, string> = {
   Uber4x12: "uber_412",
   Slo4x12: "slo_412",
   Ir: "ir",
+  Modern2x12: "modern_212",
+  American1x12: "american_1x12",
 };
 
 /** Rust `ReverbModel` variant → editor model id. */
@@ -99,6 +106,8 @@ export const MOD_VARIANT_TO_MODEL: Record<string, string> = {
   KhaenSwirl: "khaen_swirl",
   BiLam: "bi_lam",
   IsanJet: "isan_jet",
+  SoftPhase: "soft_phase",
+  WideVibe: "wide_vibe",
 };
 
 /** Rust `DelayModel` variant → editor model id. */
@@ -114,6 +123,18 @@ export const DELAY_VARIANT_TO_MODEL: Record<string, string> = {
 export const WAH_VARIANT_TO_MODEL: Record<string, string> = {
   CryWah: "cry_wah",
   TouchWah: "touch_wah",
+};
+
+/**
+ * Rust `EqModel` variant → editor model id. `Studio` maps to `parametric`,
+ * the editor's original (and, until the model select was added, only) EQ
+ * id — kept rather than renamed, so every existing preset keeps its exact
+ * voicing.
+ */
+export const EQ_VARIANT_TO_MODEL: Record<string, string> = {
+  Studio: "parametric",
+  Vintage: "vintage_eq",
+  Modern: "modern_eq",
 };
 
 type ParamsJson = Record<string, unknown>;
@@ -178,6 +199,10 @@ export function snapshotFromRodhareistState(state: unknown): RigSnapshot | null 
   if (WAH_VARIANT_TO_MODEL[wahVariant]) {
     stageModels.wah = WAH_VARIANT_TO_MODEL[wahVariant]!;
   }
+  const eqVariant = typeof p.eq_model === "string" ? p.eq_model : "";
+  if (EQ_VARIANT_TO_MODEL[eqVariant]) {
+    stageModels.eq = EQ_VARIANT_TO_MODEL[eqVariant]!;
+  }
   const delayVariant = typeof p.delay_model === "string" ? p.delay_model : "";
   if (DELAY_VARIANT_TO_MODEL[delayVariant]) {
     stageModels.delay = DELAY_VARIANT_TO_MODEL[delayVariant]!;
@@ -204,6 +229,10 @@ export function snapshotFromRodhareistState(state: unknown): RigSnapshot | null 
   const delayBVariant = typeof b.delay_model === "string" ? b.delay_model : "";
   if (DELAY_VARIANT_TO_MODEL[delayBVariant]) {
     stageModels.delay2 = secondInstanceModelId(DELAY_VARIANT_TO_MODEL[delayBVariant]!);
+  }
+  const eqBVariant = typeof b.eq_model === "string" ? b.eq_model : "";
+  if (EQ_VARIANT_TO_MODEL[eqBVariant]) {
+    stageModels.eq2 = secondInstanceModelId(EQ_VARIANT_TO_MODEL[eqBVariant]!);
   }
   const ampVariant = typeof p.amp_model === "string" ? p.amp_model : "";
   const toneEngine = typeof p.tone_engine === "string" ? p.tone_engine : "Classic";
@@ -271,13 +300,15 @@ export function snapshotFromRodhareistState(state: unknown): RigSnapshot | null 
   setVal(softknee, "comp_attack", num(p, "comp_attack_ms"));
   setVal(softknee, "comp_release", num(p, "comp_release_ms"));
   setVal(softknee, "comp_makeup", num(p, "comp_makeup_db"));
-  const parametric = parameters.parametric;
-  setVal(parametric, "eq_low_gain", num(p, "eq_low_gain_db"));
-  setVal(parametric, "eq_mid1_freq", num(p, "eq_mid1_freq_hz"));
-  setVal(parametric, "eq_mid1_gain", num(p, "eq_mid1_gain_db"));
-  setVal(parametric, "eq_mid2_freq", num(p, "eq_mid2_freq_hz"));
-  setVal(parametric, "eq_mid2_gain", num(p, "eq_mid2_gain_db"));
-  setVal(parametric, "eq_high_gain", num(p, "eq_high_gain_db"));
+  // The Eq slot's models share the eq_* ids; only the selected model
+  // receives the blob values (same rule as dist/cab/mod above).
+  const eqParams = parameters[stageModels.eq];
+  setVal(eqParams, "eq_low_gain", num(p, "eq_low_gain_db"));
+  setVal(eqParams, "eq_mid1_freq", num(p, "eq_mid1_freq_hz"));
+  setVal(eqParams, "eq_mid1_gain", num(p, "eq_mid1_gain_db"));
+  setVal(eqParams, "eq_mid2_freq", num(p, "eq_mid2_freq_hz"));
+  setVal(eqParams, "eq_mid2_gain", num(p, "eq_mid2_gain_db"));
+  setVal(eqParams, "eq_high_gain", num(p, "eq_high_gain_db"));
   // The Mod slot's models share the chorus_* ids; only the selected model
   // receives the blob values (same rule as dist/cab above).
   const modParams = parameters[stageModels.mod];
@@ -322,13 +353,13 @@ export function snapshotFromRodhareistState(state: unknown): RigSnapshot | null 
   setVal(softkneeB, "comp2_attack", num(b, "comp_attack_ms"));
   setVal(softkneeB, "comp2_release", num(b, "comp_release_ms"));
   setVal(softkneeB, "comp2_makeup", num(b, "comp_makeup_db"));
-  const parametricB = parameters.parametric_2;
-  setVal(parametricB, "eq2_low_gain", num(b, "eq_low_gain_db"));
-  setVal(parametricB, "eq2_mid1_freq", num(b, "eq_mid1_freq_hz"));
-  setVal(parametricB, "eq2_mid1_gain", num(b, "eq_mid1_gain_db"));
-  setVal(parametricB, "eq2_mid2_freq", num(b, "eq_mid2_freq_hz"));
-  setVal(parametricB, "eq2_mid2_gain", num(b, "eq_mid2_gain_db"));
-  setVal(parametricB, "eq2_high_gain", num(b, "eq_high_gain_db"));
+  const eqB = parameters[stageModels.eq2];
+  setVal(eqB, "eq2_low_gain", num(b, "eq_low_gain_db"));
+  setVal(eqB, "eq2_mid1_freq", num(b, "eq_mid1_freq_hz"));
+  setVal(eqB, "eq2_mid1_gain", num(b, "eq_mid1_gain_db"));
+  setVal(eqB, "eq2_mid2_freq", num(b, "eq_mid2_freq_hz"));
+  setVal(eqB, "eq2_mid2_gain", num(b, "eq_mid2_gain_db"));
+  setVal(eqB, "eq2_high_gain", num(b, "eq_high_gain_db"));
   const modB = parameters[stageModels.mod2];
   setVal(modB, "chorus2_rate", num(b, "chorus_rate"));
   setVal(modB, "chorus2_depth", num(b, "chorus_depth"));

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/examples/preset_audit.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/examples/preset_audit.rs
@@ -346,7 +346,7 @@ fn band_energy(spectrum: &[f32], lo: f32, hi: f32) -> f32 {
 /// Amp models in `AmpModel::ALL` order, with the cab each one is normally
 /// paired with in the bank — the map has to include the cab, because a preset
 /// is never auditioned without one.
-const AMP_MAP: [(&str, &str); 8] = [
+const AMP_MAP: [(&str, &str); 11] = [
     ("mandarin", "vintage_212"),
     ("plexi", "brit_412"),
     ("twin", "american_2x12"),
@@ -355,6 +355,9 @@ const AMP_MAP: [(&str, &str); 8] = [
     ("jcm", "brit_412"),
     ("slate", "slo_412"),
     ("bassman", "tweed_1x12"),
+    ("boutique", "vintage_212"),
+    ("invader", "uber_412"),
+    ("tweed_combo", "tweed_1x12"),
 ];
 
 /// Where each amp model actually sits on its Gain and Master travel, measured

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/amp.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/amp.rs
@@ -373,6 +373,125 @@ impl AmpProfile {
                 shape_seed: 3,
                 clean_low_blend: 0.24,
             },
+            // Boutique low/mid-gain sustain: low bias movement and low
+            // pre-compression keep the note singing rather than crunching, but
+            // real sag and a soft power-stage headroom give the touch-sensitive
+            // clean-to-mild-overdrive transition the style is built around.
+            // American family for the rich, present upper mid this voice leads
+            // with instead of a scoop.
+            AmpModel::Boutique => Self {
+                stages: 3,
+                oversample: 4,
+                tone: ToneFamily::American,
+                input_hpf: 18.0,
+                input_lpf: 19_500.0,
+                coupling_hpf: 62.0,
+                stage_lpf: 10_500.0,
+                pre_gain: 1.65,
+                inter_gain: 1.30,
+                bias: 0.05,
+                bias_move: 0.07,
+                pre_compression: 0.10,
+                tightness: 0.14,
+                pi_drive: 1.20,
+                pi_compression: 0.14,
+                power_drive: 1.70,
+                power_headroom: 1.30,
+                power_asymmetry: 0.035,
+                feedback: 0.38,
+                presence_depth: 0.40,
+                resonance: 0.16,
+                damping: 0.44,
+                // The long, singing sustain this style is known for is a slow,
+                // deep sag: the note's own attack compresses the rail, then the
+                // rail recovers under the decaying signal instead of snapping
+                // back — closer to a limiter's release than a crunch amp's.
+                sag_amount: 0.16,
+                sag_attack: 0.020,
+                sag_release: 0.220,
+                transformer_memory: 0.13,
+                transformer_compression: 0.12,
+                output_gain: 0.80,
+                shape_seed: 1,
+                clean_low_blend: 0.10,
+            },
+            // Aggressive modern high-gain: tighter and more scooped than Recto
+            // or Slate rather than merely louder — the highest tightness in the
+            // lineup keeps palm mutes articulate under a lot of gain, and a very
+            // low sag/fast recovery makes the power stage itself the tight,
+            // percussive part of the voice.
+            AmpModel::Invader => Self {
+                stages: 4,
+                oversample: 8,
+                tone: ToneFamily::Modern,
+                input_hpf: 32.0,
+                input_lpf: 17_500.0,
+                coupling_hpf: 118.0,
+                stage_lpf: 8_200.0,
+                pre_gain: 3.85,
+                inter_gain: 2.30,
+                bias: 0.115,
+                bias_move: 0.19,
+                pre_compression: 0.24,
+                tightness: 0.94,
+                pi_drive: 1.95,
+                pi_compression: 0.26,
+                power_drive: 2.55,
+                power_headroom: 0.98,
+                power_asymmetry: 0.05,
+                // Even less global feedback than Recto/Slate: the power section
+                // stays raw at the top of Gain, which is where this voice lives.
+                feedback: 0.16,
+                presence_depth: 0.85,
+                resonance: 0.34,
+                damping: 0.70,
+                sag_amount: 0.045,
+                sag_attack: 0.0025,
+                sag_release: 0.024,
+                transformer_memory: 0.065,
+                transformer_compression: 0.13,
+                output_gain: 0.52,
+                shape_seed: 3,
+                clean_low_blend: 0.0,
+            },
+            // Small single-speaker combo: two stages only (a real Deluxe-class
+            // amp has far less cascade than a modern high-gain head), low power
+            // headroom so the *output pair* breaks up early rather than the
+            // preamp, and a spongier, slower sag than Bassman — this is the
+            // amp's own compression doing the work, at a level a small combo
+            // actually reaches, not a bigger head turned down.
+            AmpModel::TweedCombo => Self {
+                stages: 2,
+                oversample: 4,
+                tone: ToneFamily::American,
+                input_hpf: 22.0,
+                input_lpf: 15_500.0,
+                coupling_hpf: 68.0,
+                stage_lpf: 7_600.0,
+                pre_gain: 2.05,
+                inter_gain: 1.55,
+                bias: 0.095,
+                bias_move: 0.15,
+                pre_compression: 0.20,
+                tightness: 0.10,
+                pi_drive: 1.50,
+                pi_compression: 0.22,
+                power_drive: 2.05,
+                power_headroom: 0.85,
+                power_asymmetry: 0.09,
+                feedback: 0.22,
+                presence_depth: 0.32,
+                resonance: 0.20,
+                damping: 0.40,
+                sag_amount: 0.24,
+                sag_attack: 0.014,
+                sag_release: 0.150,
+                transformer_memory: 0.19,
+                transformer_compression: 0.19,
+                output_gain: 0.74,
+                shape_seed: 2,
+                clean_low_blend: 0.06,
+            },
         }
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/cab.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/cab.rs
@@ -326,6 +326,56 @@ impl CabProfile {
             // active. A profile is still needed so the standby lane holds
             // something valid — the most neutral voicing in the set.
             CabModel::Ir => Self::for_model(CabModel::Vintage4x12),
+            // Modern 2x12: the closed, scooped, extended-top family shared
+            // with Modern/Uber/Slo 4x12, scaled down — a higher box
+            // resonance and a milder scoop than any of the 4x12s.
+            CabModel::Modern2x12 => Self {
+                topology: CabTopology::ModernClosed,
+                hpf_hz: 78.0,
+                resonance_hz: 112.0,
+                resonance_damping: 0.62,
+                resonance_gain: 0.30,
+                second_mode_hz: 220.0,
+                second_mode_gain: 0.05,
+                body_hz: 580.0,
+                body_gain: -0.06,
+                breakup_hz: 3_500.0,
+                breakup_damping: 0.50,
+                breakup_gain: 0.22,
+                notch_hz: 2_300.0,
+                notch_gain: 0.14,
+                cutoff_hz: 6_800.0,
+                slope: 3,
+                rear_delay_ms: 0.0,
+                rear_gain: 0.0,
+                compression: 0.10,
+                output_gain: 0.91,
+            },
+            // American 1x12 Combo: `OpenBack` family, but a single small
+            // speaker — higher resonance, brighter and more extended top,
+            // a shorter/weaker rear path than the 2-speaker Open Back.
+            CabModel::American1x12 => Self {
+                topology: CabTopology::OpenBack,
+                hpf_hz: 105.0,
+                resonance_hz: 165.0,
+                resonance_damping: 0.55,
+                resonance_gain: 0.30,
+                second_mode_hz: 400.0,
+                second_mode_gain: -0.08,
+                body_hz: 800.0,
+                body_gain: 0.05,
+                breakup_hz: 3_600.0,
+                breakup_damping: 0.40,
+                breakup_gain: 0.17,
+                notch_hz: 2_000.0,
+                notch_gain: 0.09,
+                cutoff_hz: 7_200.0,
+                slope: 2,
+                rear_delay_ms: 0.85,
+                rear_gain: -0.16,
+                compression: 0.05,
+                output_gain: 0.95,
+            },
         }
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/drive.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/drive.rs
@@ -123,6 +123,18 @@ impl DiodeVoicing {
             DriveModel::Centurion => {
                 Self::new(1.0, 0.975, 0.160, 0.158, 8.0e-7, 1.05e-6, 14_000.0, 540.0)
             }
+            // Near-matched silicon, harder knee than Breaker and a brighter,
+            // higher corner than Rat — a blues/rock rhythm crunch, not a
+            // filth pedal.
+            DriveModel::AmberCrunch => {
+                Self::new(1.0, 0.98, 0.055, 0.053, 2.2e-7, 2.6e-7, 10_000.0, 260.0)
+            }
+            // Silicon fuzz: fast junctions (no germanium leak) and a hard
+            // asymmetric pair, so it stays tight and immediate where Face
+            // Fuzz's germanium pair is soft and smeary.
+            DriveModel::CopperFuzz => {
+                Self::new(0.65, 1.35, 0.130, 0.120, 2.5e-7, 4.5e-7, 6_500.0, 105.0)
+            }
             // Dedicated-topology models never reach this table.
             _ => Self::new(1.0, 1.0, 0.075, 0.075, 2.0e-8, 2.0e-8, 12_000.0, 400.0),
         }
@@ -298,6 +310,8 @@ impl Drive {
             DriveModel::Breaker => (0.45 + g * 14.0, 0.21 + lvl * 0.68, 0.92),
             DriveModel::Fuzz => (0.35 + g * 54.0, 0.10 + lvl * 0.55, 1.0),
             DriveModel::Centurion => (0.42 + g * 16.0, 0.20 + lvl * 0.74, 0.88),
+            DriveModel::AmberCrunch => (0.42 + g * 20.0, 0.19 + lvl * 0.72, 0.90),
+            DriveModel::CopperFuzz => (0.35 + g * 58.0, 0.12 + lvl * 0.58, 1.0),
             // Dedicated-topology models returned above.
             _ => (1.0, 1.0, 1.0),
         };
@@ -374,6 +388,25 @@ impl Drive {
                     0.707,
                     sr,
                 ));
+            }
+            DriveModel::AmberCrunch => {
+                self.mid_boost
+                    .set(make_eq_coefficients("bell", 850.0, 4.0, 0.8, sr));
+                let cutoff = 3_800.0 + t * 7_500.0;
+                self.tone_lpf.set(make_eq_coefficients(
+                    "lowpass",
+                    cutoff.min(sr * 0.45),
+                    0.0,
+                    0.707,
+                    sr,
+                ));
+            }
+            DriveModel::CopperFuzz => {
+                self.mid_boost
+                    .set(make_eq_coefficients("bell", 500.0, 3.5, 0.65, sr));
+                let cutoff = (1_500.0 + t * 5_200.0).min(sr * 0.45);
+                self.tone_lpf
+                    .set(make_eq_coefficients("lowpass", cutoff, 0.0, 0.707, sr));
             }
             // Dedicated-topology models returned above.
             _ => {}

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/eq.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/eq.rs
@@ -2,14 +2,54 @@
 //! sweepable bells, high shelf) on the crate's [`StereoBiquad`], same
 //! cascade pattern as the cabinet sim. Flat settings are bit-transparent by
 //! construction: a band at 0 dB installs no filter at all.
+//!
+//! Three models share this one architecture and the same six knobs (the
+//! sweepable bells keep their user-set frequencies regardless of model) —
+//! only the fixed shelf corners and bell Q, i.e. the character of the
+//! curve, change per model. This is the same "one engine, tuned profiles"
+//! shape as the amp/cab/drive stages.
 
 use builtin_dsp_core::make_eq_coefficients;
 
-use super::StereoBiquad;
+use super::{EqModel, StereoBiquad};
 
-const LOW_SHELF_HZ: f32 = 120.0;
-const HIGH_SHELF_HZ: f32 = 6_000.0;
-const BELL_Q: f32 = 0.9;
+const SHELF_Q: f32 = 0.707;
+
+#[derive(Debug, Clone, Copy)]
+struct EqProfile {
+    low_shelf_hz: f32,
+    high_shelf_hz: f32,
+    bell_q: f32,
+}
+
+impl EqProfile {
+    fn for_model(model: EqModel) -> Self {
+        match model {
+            // The original curve: unchanged so existing projects/presets
+            // sound exactly as they always have.
+            EqModel::Studio => Self {
+                low_shelf_hz: 120.0,
+                high_shelf_hz: 6_000.0,
+                bell_q: 0.9,
+            },
+            // Passive-console character: a lower shelf corner (broader,
+            // "bigger" low control) and an earlier top roll-off point, with
+            // wide, smooth bells instead of surgical notches.
+            EqModel::Vintage => Self {
+                low_shelf_hz: 90.0,
+                high_shelf_hz: 4_500.0,
+                bell_q: 0.7,
+            },
+            // Surgical/digital character: extended shelf range and narrow
+            // bells for precise, small-area cuts and boosts.
+            EqModel::Modern => Self {
+                low_shelf_hz: 150.0,
+                high_shelf_hz: 8_000.0,
+                bell_q: 1.4,
+            },
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(super) struct EqStage {
@@ -44,8 +84,10 @@ impl EqStage {
 
     /// Editor units: gains ±15 dB, `mid1_freq` 100..1000 Hz,
     /// `mid2_freq` 600..6000 Hz.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn configure(
         &mut self,
+        model: EqModel,
         low_gain: f32,
         mid1_freq: f32,
         mid1_gain: f32,
@@ -54,6 +96,7 @@ impl EqStage {
         high_gain: f32,
     ) {
         let sr = self.sample_rate;
+        let profile = EqProfile::for_model(model);
         // A 0 dB band is a true bypass (no biquad), so a flat EQ adds zero
         // filter state and is exactly transparent.
         let band = |kind: &str, freq: f32, gain: f32, q: f32| {
@@ -64,21 +107,21 @@ impl EqStage {
             }
         };
         self.low
-            .set(band("lowshelf", LOW_SHELF_HZ, low_gain, 0.707));
+            .set(band("lowshelf", profile.low_shelf_hz, low_gain, SHELF_Q));
         self.mid1.set(band(
             "bell",
             mid1_freq.clamp(100.0, 1_000.0),
             mid1_gain,
-            BELL_Q,
+            profile.bell_q,
         ));
         self.mid2.set(band(
             "bell",
             mid2_freq.clamp(600.0, 6_000.0),
             mid2_gain,
-            BELL_Q,
+            profile.bell_q,
         ));
         self.high
-            .set(band("highshelf", HIGH_SHELF_HZ, high_gain, 0.707));
+            .set(band("highshelf", profile.high_shelf_hz, high_gain, SHELF_Q));
     }
 
     #[inline]
@@ -96,18 +139,20 @@ mod tests {
 
     #[test]
     fn flat_eq_is_bit_transparent() {
-        let mut eq = EqStage::new(48_000.0);
-        eq.configure(0.0, 400.0, 0.0, 2_000.0, 0.0, 0.0);
-        for n in 0..1_000 {
-            let x = (n as f32 * 0.05).sin() * 0.7;
-            assert_eq!(eq.process(x, -x), (x, -x));
+        for model in [EqModel::Studio, EqModel::Vintage, EqModel::Modern] {
+            let mut eq = EqStage::new(48_000.0);
+            eq.configure(model, 0.0, 400.0, 0.0, 2_000.0, 0.0, 0.0);
+            for n in 0..1_000 {
+                let x = (n as f32 * 0.05).sin() * 0.7;
+                assert_eq!(eq.process(x, -x), (x, -x), "{model:?}");
+            }
         }
     }
 
     #[test]
     fn boosts_change_the_signal_and_stay_finite() {
         let mut eq = EqStage::new(48_000.0);
-        eq.configure(6.0, 400.0, -4.0, 2_000.0, 3.0, 5.0);
+        eq.configure(EqModel::Studio, 6.0, 400.0, -4.0, 2_000.0, 3.0, 5.0);
         let mut differs = false;
         for n in 0..4_000 {
             let x = (n as f32 * 0.05).sin() * 0.5;
@@ -118,5 +163,32 @@ mod tests {
             }
         }
         assert!(differs, "non-flat EQ left the signal untouched");
+    }
+
+    /// Same knobs, different model, must sound different — otherwise the
+    /// model select is a relabel, not a real voicing change.
+    #[test]
+    fn models_are_distinct_at_identical_knob_settings() {
+        let render = |model: EqModel| {
+            let mut eq = EqStage::new(48_000.0);
+            eq.configure(model, 6.0, 400.0, -4.0, 2_000.0, 3.0, 5.0);
+            (0..2_000)
+                .map(|n| eq.process((n as f32 * 0.05).sin() * 0.5, 0.0).0)
+                .collect::<Vec<_>>()
+        };
+        let models = [EqModel::Studio, EqModel::Vintage, EqModel::Modern];
+        let rendered: Vec<_> = models.iter().map(|m| render(*m)).collect();
+        for i in 0..rendered.len() {
+            for j in (i + 1)..rendered.len() {
+                let rms = (rendered[i]
+                    .iter()
+                    .zip(rendered[j].iter())
+                    .map(|(a, b)| (a - b).powi(2))
+                    .sum::<f32>()
+                    / rendered[i].len() as f32)
+                    .sqrt();
+                assert!(rms > 1.0e-4, "{:?} == {:?}: {rms}", models[i], models[j]);
+            }
+        }
     }
 }

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/mod.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/mod.rs
@@ -221,6 +221,11 @@ pub enum DriveModel {
     MetalCore,
     /// "Tight Rift" — modern multi-stage tight high-gain (Neural-style).
     TightRift,
+    /// "Amber Crunch" — bright silicon hard-clip blues/rock rhythm OD.
+    AmberCrunch,
+    /// "Copper Fuzz" — silicon fuzz, tighter and more aggressive than the
+    /// germanium Face Fuzz.
+    CopperFuzz,
 }
 
 impl DriveModel {
@@ -235,6 +240,9 @@ impl DriveModel {
         Self::SuperDrive,
         Self::MetalCore,
         Self::TightRift,
+        // Append-only past this point (wire ABI).
+        Self::AmberCrunch,
+        Self::CopperFuzz,
     ];
 
     /// Map the editor model id.
@@ -250,6 +258,8 @@ impl DriveModel {
             "super_drive" => Some(Self::SuperDrive),
             "metal_core" => Some(Self::MetalCore),
             "tight_rift" => Some(Self::TightRift),
+            "amber_crunch" => Some(Self::AmberCrunch),
+            "copper_fuzz" => Some(Self::CopperFuzz),
             _ => None,
         }
     }
@@ -278,6 +288,12 @@ pub enum AmpModel {
     Slate,
     /// "Bassman" — loose American bass-heavy.
     Bassman,
+    /// "Overdrive Special" — smooth, singing boutique low/mid-gain sustain.
+    Boutique,
+    /// "Invader 5150" — tight, scooped modern high-gain full stack.
+    Invader,
+    /// "Tweed Deluxe" — small, early-breakup single-speaker combo.
+    TweedCombo,
 }
 
 impl AmpModel {
@@ -290,6 +306,10 @@ impl AmpModel {
         Self::Jcm,
         Self::Slate,
         Self::Bassman,
+        // Append-only past this point (wire ABI) — see `from_index`.
+        Self::Boutique,
+        Self::Invader,
+        Self::TweedCombo,
     ];
 
     pub fn from_model_id(id: &str) -> Option<Self> {
@@ -302,6 +322,9 @@ impl AmpModel {
             "jcm" => Some(Self::Jcm),
             "slate" => Some(Self::Slate),
             "bassman" => Some(Self::Bassman),
+            "boutique" => Some(Self::Boutique),
+            "invader" => Some(Self::Invader),
+            "tweed_combo" => Some(Self::TweedCombo),
             _ => None,
         }
     }
@@ -344,6 +367,12 @@ pub enum CabModel {
     /// distance knobs do not apply — the IR already is a miked cabinet — and
     /// the slot passes dry until a file is loaded.
     Ir,
+    /// "Modern 2x12" — tight closed-back pair: the `ModernClosed` family's
+    /// scoop and extended top, scaled down from the 4x12s.
+    Modern2x12,
+    /// "American 1x12 Combo" — small, bright, open single speaker; brighter
+    /// and less boxy than the Tweed 1x12.
+    American1x12,
 }
 
 impl CabModel {
@@ -360,6 +389,9 @@ impl CabModel {
         Self::Uber4x12,
         Self::Slo4x12,
         Self::Ir,
+        // Append-only past this point (wire ABI).
+        Self::Modern2x12,
+        Self::American1x12,
     ];
 
     /// The modeled voicings only — [`Self::ALL`] minus [`Self::Ir`], which is
@@ -377,6 +409,8 @@ impl CabModel {
         Self::Brit4x12,
         Self::Uber4x12,
         Self::Slo4x12,
+        Self::Modern2x12,
+        Self::American1x12,
     ];
 
     pub fn from_model_id(id: &str) -> Option<Self> {
@@ -393,6 +427,8 @@ impl CabModel {
             "uber_412" => Some(Self::Uber4x12),
             "slo_412" => Some(Self::Slo4x12),
             "ir" => Some(Self::Ir),
+            "modern_212" => Some(Self::Modern2x12),
+            "american_1x12" => Some(Self::American1x12),
             _ => None,
         }
     }
@@ -455,6 +491,11 @@ pub enum ModModel {
     BiLam,
     /// "Isan Jet" — six stages, hard regeneration, fast and narrow up top.
     IsanJet,
+    /// "Soft Phase" — two stages, one gentle notch: the subtle end of the
+    /// range.
+    SoftPhase,
+    /// "Wide Vibe" — linked stereo spread for a genuinely wide swirl.
+    WideVibe,
 }
 
 impl ModModel {
@@ -471,6 +512,8 @@ impl ModModel {
         Self::KhaenSwirl,
         Self::BiLam,
         Self::IsanJet,
+        Self::SoftPhase,
+        Self::WideVibe,
     ];
 
     pub fn from_model_id(id: &str) -> Option<Self> {
@@ -484,6 +527,8 @@ impl ModModel {
             "khaen_swirl" => Some(Self::KhaenSwirl),
             "bi_lam" => Some(Self::BiLam),
             "isan_jet" => Some(Self::IsanJet),
+            "soft_phase" => Some(Self::SoftPhase),
+            "wide_vibe" => Some(Self::WideVibe),
             _ => None,
         }
     }
@@ -498,6 +543,8 @@ impl ModModel {
             Self::KhaenSwirl => Some(V::KhaenSwirl),
             Self::BiLam => Some(V::BiLam),
             Self::IsanJet => Some(V::IsanJet),
+            Self::SoftPhase => Some(V::SoftPhase),
+            Self::WideVibe => Some(V::WideVibe),
             Self::Chorus | Self::Flanger | Self::Tremolo => None,
         }
     }
@@ -532,6 +579,46 @@ impl WahModel {
 
     pub fn from_index(i: u32) -> Self {
         Self::ALL.get(i as usize).copied().unwrap_or(Self::CryWah)
+    }
+}
+
+/// EQ voicing in the Eq slot, matching the editor's `eq` models. All three
+/// share the same six `eq_*` knobs (low shelf, two sweepable bells, high
+/// shelf) — only the fixed shelf corners and bell Q differ, see
+/// `eq::EqProfile`.
+///
+/// APPEND-ONLY: index into `ALL` is the `eq_model` wire value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum EqModel {
+    /// "Studio EQ" — the original curve.
+    #[default]
+    Studio,
+    /// "Vintage EQ" — passive-console character: lower shelf corner, earlier
+    /// top roll-off, wide smooth bells.
+    Vintage,
+    /// "Modern EQ" — surgical/digital character: extended shelf range,
+    /// narrow precise bells.
+    Modern,
+}
+
+impl EqModel {
+    pub const ALL: &'static [Self] = &[Self::Studio, Self::Vintage, Self::Modern];
+
+    pub fn from_model_id(id: &str) -> Option<Self> {
+        match id {
+            // "parametric" — the editor's original (and, until now, only) EQ
+            // model id, predating the model select. Kept as Studio's id
+            // rather than renamed, so every existing preset/project
+            // referencing it keeps its exact voicing.
+            "parametric" => Some(Self::Studio),
+            "vintage_eq" => Some(Self::Vintage),
+            "modern_eq" => Some(Self::Modern),
+            _ => None,
+        }
+    }
+
+    pub fn from_index(i: u32) -> Self {
+        Self::ALL.get(i as usize).copied().unwrap_or(Self::Studio)
     }
 }
 
@@ -662,6 +749,9 @@ pub struct Params {
     pub mod_model: ModModel,
     #[serde(default)]
     pub wah_model: WahModel,
+    /// Which voicing the Eq slot runs (shares the `eq_*` knobs).
+    #[serde(default)]
+    pub eq_model: EqModel,
     /// Which algorithm the Reverb slot runs (shares the `reverb_*` knobs).
     #[serde(default)]
     pub reverb_model: ReverbModel,
@@ -830,6 +920,7 @@ pub struct StageBParams {
     pub delay_tone: f32,
 
     pub eq_on: bool,
+    pub eq_model: EqModel,
     pub eq_low_gain_db: f32,
     pub eq_mid1_freq_hz: f32,
     pub eq_mid1_gain_db: f32,
@@ -880,6 +971,7 @@ impl Default for StageBParams {
             delay_tone: default_delay_tone(),
 
             eq_on: true,
+            eq_model: EqModel::Studio,
             eq_low_gain_db: 0.0,
             eq_mid1_freq_hz: default_eq_mid1_freq(),
             eq_mid1_gain_db: 0.0,
@@ -923,6 +1015,7 @@ impl StageBParams {
             delay_tone: clamp(self.delay_tone, 0.0, 10.0),
 
             eq_on: self.eq_on,
+            eq_model: self.eq_model,
             eq_low_gain_db: clamp(self.eq_low_gain_db, -15.0, 15.0),
             eq_mid1_freq_hz: clamp(self.eq_mid1_freq_hz, 100.0, 1_000.0),
             eq_mid1_gain_db: clamp(self.eq_mid1_gain_db, -15.0, 15.0),
@@ -999,6 +1092,7 @@ pub fn default_params() -> Params {
         mic_model: MicModel::Dynamic,
         mod_model: ModModel::Chorus,
         wah_model: WahModel::CryWah,
+        eq_model: EqModel::Studio,
         reverb_model: ReverbModel::Plate,
         delay_model: DelayModel::Tape,
         tone_engine: ToneEngineKind::Classic,
@@ -1570,6 +1664,7 @@ impl Dsp {
             mic_model: params.mic_model,
             mod_model: params.mod_model,
             wah_model: params.wah_model,
+            eq_model: params.eq_model,
             reverb_model: params.reverb_model,
             delay_model: params.delay_model,
             tone_engine: params.tone_engine,
@@ -1738,6 +1833,7 @@ impl Dsp {
             p.comp_makeup_db,
         );
         self.eq_stage.configure(
+            p.eq_model,
             p.eq_low_gain_db,
             p.eq_mid1_freq_hz,
             p.eq_mid1_gain_db,
@@ -1796,6 +1892,7 @@ impl Dsp {
         self.drive_b
             .configure(b.drive_model, b.drive_gain, b.drive_tone, b.drive_level);
         self.eq_b.configure(
+            b.eq_model,
             b.eq_low_gain_db,
             b.eq_mid1_freq_hz,
             b.eq_mid1_gain_db,
@@ -1969,6 +2066,7 @@ pub fn apply_to_params(p: &mut Params, id: &str, value: f32) -> bool {
         "drive_model" => p.drive_model = DriveModel::from_index(value.round() as u32),
         "mod_model" => p.mod_model = ModModel::from_index(value.round() as u32),
         "wah_model" => p.wah_model = WahModel::from_index(value.round() as u32),
+        "eq_model" => p.eq_model = EqModel::from_index(value.round() as u32),
         "reverb_model" => p.reverb_model = ReverbModel::from_index(value.round() as u32),
         "delay_model" => p.delay_model = DelayModel::from_index(value.round() as u32),
         "amp_model" => {
@@ -2054,6 +2152,7 @@ pub fn apply_to_params(p: &mut Params, id: &str, value: f32) -> bool {
         "delay2_mix" => p.stage_b.delay_mix = value,
         "delay2_tone" => p.stage_b.delay_tone = value,
         "eq2_on" => p.stage_b.eq_on = on,
+        "eq2_model" => p.stage_b.eq_model = EqModel::from_index(value.round() as u32),
         "eq2_low_gain" => p.stage_b.eq_low_gain_db = value,
         "eq2_mid1_freq" => p.stage_b.eq_mid1_freq_hz = value,
         "eq2_mid1_gain" => p.stage_b.eq_mid1_gain_db = value,
@@ -2104,6 +2203,7 @@ pub fn ui_values(p: &Params) -> Vec<(&'static str, f32)> {
     out.push(("cab_model", model_index(CabModel::ALL, p.cab_model)));
     out.push(("mod_model", model_index(ModModel::ALL, p.mod_model)));
     out.push(("wah_model", model_index(WahModel::ALL, p.wah_model)));
+    out.push(("eq_model", model_index(EqModel::ALL, p.eq_model)));
     out.push((
         "reverb_model",
         model_index(ReverbModel::ALL, p.reverb_model),
@@ -2193,6 +2293,7 @@ pub fn ui_values(p: &Params) -> Vec<(&'static str, f32)> {
     out.push(("delay2_mix", sb.delay_mix));
     out.push(("delay2_tone", sb.delay_tone));
     out.push(("eq2_on", b(sb.eq_on)));
+    out.push(("eq2_model", model_index(EqModel::ALL, sb.eq_model)));
     out.push(("eq2_low_gain", sb.eq_low_gain_db));
     out.push(("eq2_mid1_freq", sb.eq_mid1_freq_hz));
     out.push(("eq2_mid1_gain", sb.eq_mid1_gain_db));
@@ -4096,6 +4197,8 @@ mod tests {
             ModModel::KhaenSwirl => "khaen_swirl",
             ModModel::BiLam => "bi_lam",
             ModModel::IsanJet => "isan_jet",
+            ModModel::SoftPhase => "soft_phase",
+            ModModel::WideVibe => "wide_vibe",
         }
     }
 

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/phaser.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/dsp/phaser.rs
@@ -78,6 +78,12 @@ pub(super) enum PhaserVoice {
     BiLam,
     /// "Isan Jet" — six stages, hard regeneration, fast and narrow up top.
     IsanJet,
+    /// "Soft Phase" — two stages, one gentle notch: the subtle end nothing
+    /// else in the lineup covers (a Phase-45 rather than a Phase-90).
+    SoftPhase,
+    /// "Wide Vibe" — real linked stereo spread (unlike every mono voice
+    /// above), staggered corners, a lush width-forward swirl.
+    WideVibe,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -205,6 +211,37 @@ impl PhaserVoice {
                 skew: 1.0,
                 spread: 0.06,
                 rate_scale: 1.35,
+                max_blend: MAX_BLEND,
+                mono: false,
+            },
+            // One notch, gentle regeneration, narrow sweep: the subtle "just
+            // a little movement" voice — everything else in the lineup is at
+            // least a two-notch swirl.
+            Self::SoftPhase => Profile {
+                stages: 2,
+                feedback: 0.30,
+                sweep_lo: 250.0,
+                sweep_hi: 1_800.0,
+                stagger: 1.0,
+                skew: 1.0,
+                spread: 0.0,
+                rate_scale: 0.75,
+                max_blend: MAX_BLEND,
+                mono: true,
+            },
+            // The one voice that actually runs linked-but-independent L/R
+            // sweeps at a musical width — every other voice here is mono for
+            // exactly the ghosted-double reason explained above; this one
+            // spends that risk deliberately for a genuinely wide swirl.
+            Self::WideVibe => Profile {
+                stages: 4,
+                feedback: 0.38,
+                sweep_lo: 180.0,
+                sweep_hi: 2_100.0,
+                stagger: 1.35,
+                skew: 1.30,
+                spread: 0.22,
+                rate_scale: 0.60,
                 max_blend: MAX_BLEND,
                 mono: false,
             },
@@ -474,13 +511,15 @@ impl Phaser {
 mod tests {
     use super::*;
 
-    const ALL: [PhaserVoice; 6] = [
+    const ALL: [PhaserVoice; 8] = [
         PhaserVoice::Phase90,
         PhaserVoice::MolamSwirl,
         PhaserVoice::PhinVibe,
         PhaserVoice::KhaenSwirl,
         PhaserVoice::BiLam,
         PhaserVoice::IsanJet,
+        PhaserVoice::SoftPhase,
+        PhaserVoice::WideVibe,
     ];
 
     /// Peak-to-null depth of the parked cascade's magnitude response, in dB.
@@ -728,6 +767,7 @@ mod tests {
             PhaserVoice::PhinVibe,
             PhaserVoice::KhaenSwirl,
             PhaserVoice::BiLam,
+            PhaserVoice::SoftPhase,
         ] {
             let mut p = Phaser::new(48_000.0);
             p.configure(voice, 4.0, 7.0, 100.0);

--- a/crates/BuiltinAudioPlugins/crates/rodharerist/src/wire.rs
+++ b/crates/BuiltinAudioPlugins/crates/rodharerist/src/wire.rs
@@ -123,6 +123,8 @@ pub const UI_PARAM_IDS: &[&str] = &[
     "comp2_attack",  // 104
     "comp2_release", // 105
     "comp2_makeup",  // 106
+    "eq_model",      // 107
+    "eq2_model",     // 108
 ];
 
 /// String id → wire index. Linear scan over a small table — control/UI
@@ -141,7 +143,7 @@ pub fn ui_param_id(index: u32) -> Option<&'static str> {
 mod tests {
     use super::*;
     use crate::dsp::{
-        AmpModel, CabModel, DelayModel, DriveModel, Dsp, ModModel, ReverbModel, StageKind,
+        AmpModel, CabModel, DelayModel, DriveModel, Dsp, EqModel, ModModel, ReverbModel, StageKind,
         ToneEngineKind, WahModel, apply_to_params, default_params, ui_values,
     };
 
@@ -174,7 +176,7 @@ mod tests {
     /// accidental reorder/insert must fail here, loudly.
     #[test]
     fn wire_indices_are_pinned() {
-        assert_eq!(UI_PARAM_IDS.len(), 107);
+        assert_eq!(UI_PARAM_IDS.len(), 109);
         assert_eq!(ui_param_index("power"), Some(0));
         assert_eq!(ui_param_index("gate_on"), Some(3));
         assert_eq!(ui_param_index("drive_model"), Some(10));
@@ -218,6 +220,8 @@ mod tests {
         assert_eq!(ui_param_index("eq2_on"), Some(94));
         assert_eq!(ui_param_index("comp2_on"), Some(101));
         assert_eq!(ui_param_index("comp2_makeup"), Some(106));
+        assert_eq!(ui_param_index("eq_model"), Some(107));
+        assert_eq!(ui_param_index("eq2_model"), Some(108));
     }
 
     /// `ui_values` must cover every wire id except `clear_clip` (an action,
@@ -293,7 +297,17 @@ mod tests {
     #[test]
     fn model_select_wire_values_match_editor_ids() {
         let amp = [
-            "mandarin", "plexi", "twin", "topboost", "recto", "jcm", "slate", "bassman",
+            "mandarin",
+            "plexi",
+            "twin",
+            "topboost",
+            "recto",
+            "jcm",
+            "slate",
+            "bassman",
+            "boutique",
+            "invader",
+            "tweed_combo",
         ];
         for (i, id) in amp.iter().enumerate() {
             assert_eq!(
@@ -313,6 +327,8 @@ mod tests {
             "super_drive",
             "metal_core",
             "tight_rift",
+            "amber_crunch",
+            "copper_fuzz",
         ];
         for (i, id) in drive.iter().enumerate() {
             assert_eq!(
@@ -335,6 +351,8 @@ mod tests {
             "slo_412",
             // Not a modeled voicing — the convolution engine (`dsp::ir`).
             "ir",
+            "modern_212",
+            "american_1x12",
         ];
         for (i, id) in cab.iter().enumerate() {
             assert_eq!(
@@ -363,6 +381,8 @@ mod tests {
             "khaen_swirl",
             "bi_lam",
             "isan_jet",
+            "soft_phase",
+            "wide_vibe",
         ];
         for (i, id) in mod_models.iter().enumerate() {
             assert_eq!(
@@ -385,6 +405,14 @@ mod tests {
                 WahModel::from_model_id(id),
                 Some(WahModel::ALL[i]),
                 "wah `{id}`"
+            );
+        }
+        let eq = ["parametric", "vintage_eq", "modern_eq"];
+        for (i, id) in eq.iter().enumerate() {
+            assert_eq!(
+                EqModel::from_model_id(id),
+                Some(EqModel::ALL[i]),
+                "eq `{id}`"
             );
         }
         // bridge.ts sends tone_engine=1 for nam_capture, 2 for bypass.

--- a/crates/SphereUIComponents/src/components/builtin_plugin_editor_window.rs
+++ b/crates/SphereUIComponents/src/components/builtin_plugin_editor_window.rs
@@ -175,11 +175,11 @@ struct SelectInstanceMsg {
     binding_generation: u64,
     display: InstanceDisplayMetadata,
     state_revision: u64,
-    /// TODO(phase5): rodharerist has no serialized per-insert DSP state yet
-    /// (confirmed by audit — no `Serialize` impl anywhere in the DSP crate,
-    /// no project-file schema, no engine wiring). Until that lands this is
-    /// always `{}`; React has nothing real to bind to, only the identity and
-    /// display metadata.
+    /// The insert's persisted DSP state, decoded from `PluginInstanceDescriptor::state_bytes`
+    /// by `decode_state_bytes` — real per-plugin state (e.g. rodharerist's
+    /// `RodhareistState`) for a bound insert with something to restore, `{}`
+    /// for a fresh insert or unparseable bytes. See `decode_state_bytes`'s
+    /// doc comment for the fallback rules.
     state: serde_json::Value,
 }
 


### PR DESCRIPTION
## Summary
- Replace the model chip strip with a searchable, Helix-Native-style picker overlay for choosing a block's model
- Add a Helix-style Snapshot system (bypass + parameter recall, click-free via the existing per-parameter smoothing) as a compact dropdown in the header, next to A/B compare
- Add 3 new amp models (Overdrive Special, Invader 5150, Tweed Deluxe), 2 new distortion models (Amber Crunch, Copper Fuzz), 2 new modulation voices (Soft Phase, Wide Vibe), 2 new cabinets (Modern 2x12, American 1x12 Combo), and the EQ slot's first-ever model select (Studio/Vintage/Modern)
- Fix two stale `TODO(phase5)` comments describing per-instance state persistence as unimplemented — it has been fully wired for a while

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p rodharerist` / `cargo check -p BuiltinAudioPlugins` / `cargo check -p sphere_ui_components` / `cargo check -p sphere-plugin-host`
- [x] `cargo test -p rodharerist` (159 tests)
- [x] `bun run typecheck` / `bun test` (85 tests) / `bun run build` in `editorui`
- [x] Manual pass in a headless browser: model picker (open/search/select/Escape/outside-click) for amp/dist/eq/mod/cab, snapshot dropdown (switch/save/rename), new models all present and selectable