### PR TITLE
Fix invalid WGSL if-expression crashing wgpu renderer on Linux

### DIFF
--- a/crates/gpui/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui/crates/gpui_wgpu/src/shaders.wgsl
@@ -313,11 +313,7 @@ fn oklab_to_linear_srgb(color: vec4<f32>) -> vec4<f32> {
 fn over(below: vec4<f32>, above: vec4<f32>) -> vec4<f32> {
     let alpha = above.a + below.a * (1.0 - above.a);
     let composited_rgb = above.rgb * above.a + below.rgb * below.a * (1.0 - above.a);
-    let color = if (alpha > 0.000001) {
-        composited_rgb / alpha
-    } else {
-        vec3<f32>(0.0)
-    };
+    let color = select(vec3<f32>(0.0), composited_rgb / alpha, alpha > 0.000001);
     return vec4<f32>(color, alpha);
 }
 


### PR DESCRIPTION
## Summary
- `over()` in `crates/gpui/crates/gpui_wgpu/src/shaders.wgsl` used `let color = if (...) { } else { };`, an if/else-as-expression form that WGSL does not support.
- This caused a shader parse error at startup (`expected ';', found "{"` at `wgsl:316:39`), which wgpu surfaces as a validation panic, aborting the app on launch (observed on the Wayland/wgpu backend).
- Replaced the if-expression with `select(vec3<f32>(0.0), composited_rgb / alpha, alpha > 0.000001)`, preserving the divide-by-zero guard introduced in e7c45ca.

## Test plan
- [x] `cargo check -p gpui_wgpu` passes
- [x] Runtime verification (launching the app past the previous panic) — pending, user is building/running locally to confirm