### PR TITLE
Fix VST3 editor crash on Linux for stack-heavy plugin GL init

### DIFF
--- a/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
+++ b/crates/SphereDirectAudioEngine/vst3bridge/src/editor_linux.cpp
@@ -332,6 +332,17 @@ void install_transport_key_handlers(GtkWidget* window) {
 
 /// Entry point for the dedicated GTK event-loop thread.
 void gtk_thread_main() {
+    // Must run before any other Xlib call in the process. Xlib is not
+    // thread-safe by default, and a plug-in editor may open its own GLX
+    // context on its own render thread once attached (e.g. a baseview/glow
+    // editor), concurrently with GDK's own X11 traffic on this thread.
+    // Defensive: the specific SIGSEGV-in-glXChooseFBConfig crash this file was
+    // last debugged for turned out to be a plug-in-thread stack overflow (see
+    // `raise_default_thread_stack_for_plugin_editors` in
+    // futureboard_plugin_host.rs), not an unguarded-Xlib race — but running two
+    // X11 clients on separate threads in one process without this is still
+    // undefined per the Xlib spec, so it stays.
+    XInitThreads();
     gtk_init(); // GTK4: no argc/argv
 
     {

--- a/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
+++ b/crates/SpherePluginHost/src/bin/futureboard_plugin_host.rs
@@ -112,7 +112,44 @@ fn parse_parent_pid() -> Option<u32> {
     None
 }
 
+/// Widen the default stack new Rust threads get in this process, before any
+/// plugin is loaded or its threads spawned.
+///
+/// A VST3 editor opens on the GTK thread (`editor_linux.cpp`'s
+/// `gtk_thread_main`), which calls into the plug-in's `IPlugView::attached()`.
+/// A Rust-built plug-in whose editor spawns its own thread on Rust's default
+/// (2 MiB, `std::thread::spawn` with no explicit `stack_size`) can overflow it
+/// there: Mesa's GLX/DRI path — `glXChooseFBConfig` walking into driver setup
+/// that parses `drirc` via libexpat — is far deeper on Linux than the
+/// equivalent WGL call on Windows, which never re-enters into a Rust-thread
+/// stack budget like this at all. Confirmed by reproduction: EQUZX.vst3
+/// (nih_plug + baseview + egui_glow) segfaults inside `glXChooseFBConfig`
+/// with the fault address landing on the thread's own stack pointer — the
+/// signature of exhausting it, not a data race — and setting `RUST_MIN_STACK`
+/// before that thread exists prevents the crash.
+///
+/// `RUST_MIN_STACK` is read from the process environment (via libc getenv),
+/// which is shared by every `dlopen`'d plug-in in this process regardless of
+/// which copy of the Rust runtime it statically links, so setting it here
+/// covers any Rust-built plug-in that relies on the default rather than just
+/// this one. Only raises it — an explicit caller override always wins.
+#[cfg(target_os = "linux")]
+fn raise_default_thread_stack_for_plugin_editors() {
+    const MIN_STACK_BYTES: &str = "16777216"; // 16 MiB, well past the ~2 MiB default.
+    if std::env::var_os("RUST_MIN_STACK").is_none() {
+        // SAFETY: called first thing in `main`, before any other thread
+        // (including the plug-in threads this exists to protect) is spawned.
+        unsafe {
+            std::env::set_var("RUST_MIN_STACK", MIN_STACK_BYTES);
+        }
+        eprintln!("[plugin-host] RUST_MIN_STACK={MIN_STACK_BYTES} (linux GLX/DRI stack headroom)");
+    }
+}
+
 fn main() {
+    #[cfg(target_os = "linux")]
+    raise_default_thread_stack_for_plugin_editors();
+
     let selftest = std::env::args().any(|a| a == "--selftest");
     let parent_pid = parse_parent_pid();
 


### PR DESCRIPTION
## Summary
- Opening a VST3 editor whose plugin spawns its own Rust thread with the default 2 MiB stack (e.g. EQUZX.vst3, built with `nih-plug`/`baseview`/`egui_glow`) segfaulted the plugin host process on Linux, inside `glXChooseFBConfig`'s Mesa/DRI-config parsing path — deep enough on Linux to overflow the 2 MiB default, unlike the shallower WGL path on Windows.
- `futureboard_plugin_host.rs` now sets `RUST_MIN_STACK=16777216` before any plugin can load or spawn threads, on Linux only. Since env vars are process-wide, this covers any `dlopen`'d Rust plugin relying on the default, not just this one.
- `editor_linux.cpp` now calls `XInitThreads()` before `gtk_init()` — defensive correctness, since GDK and a plugin's own GL thread both touch Xlib concurrently in this process; not what caused this specific crash, but undefined behavior without it regardless.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p sphere-plugin-host --features plugin-host-bin`
- [x] Reproduced the crash directly over the plugin host's stdin/stdout IPC (`LoadPlugin` + `OpenEditorWithParentHwnd` against `/usr/lib/vst3/EQUZX.vst3`), confirmed 100%-reproducible `SIGSEGV` before the fix, confirmed via gdb the fault address matched the crashing thread's stack pointer inside a ~2.1 MiB mapping
- [x] Same repro against the rebuilt binary: `EditorAttached` + clean exit, stable across 3 repeated runs
- [ ] Manual check through the actual Studio UI (plugin browser → open EQUZX) not yet done — only the plugin host's IPC surface was exercised directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)