### PR TITLE
Fix realtime buffer-growth violation in audio callback

### DIFF
--- a/crates/SphereDirectAudioEngine/src/backend/cpal_backend.rs
+++ b/crates/SphereDirectAudioEngine/src/backend/cpal_backend.rs
@@ -420,10 +420,11 @@ where
                     callback_glitch_counter.fetch_add(1, Ordering::Relaxed);
                     return;
                 }
+                // `fill_output_f32` fully overwrites every sample of its output
+                // slice on every reachable path (silence branch, audition-only
+                // branch, and the render paths all zero-then-write or write
+                // every frame) — no pre-zero needed here.
                 let scratch = &mut f32_scratch[..f32_len];
-                for s in scratch.iter_mut() {
-                    *s = 0.0;
-                }
 
                 fill_output_f32(scratch, ch, &mut runtime, &shared, &mut local);
 

--- a/crates/SphereDirectAudioEngine/src/backend/wasapi_exclusive.rs
+++ b/crates/SphereDirectAudioEngine/src/backend/wasapi_exclusive.rs
@@ -510,18 +510,24 @@ unsafe fn open_exclusive_stream(
             }
         };
 
-        let total = frames as usize * device_ch;
-        if scratch.len() < total {
-            scratch.resize(total, 0.0f32);
-        }
+        let out_len = frames as usize * device_ch;
+        // `scratch` is preallocated to `actual_buf * device_ch` and `frames`
+        // can never exceed `actual_buf` (`saturating_sub` above), so `out_len`
+        // never exceeds `scratch.len()` here. Clamp defensively instead of
+        // growing — growing would allocate on the audio thread.
+        let total = out_len.min(scratch.len());
         let s = &mut scratch[..total];
-        for x in s.iter_mut() {
-            *x = 0.0;
-        }
+        // `fill_output_f32` fully overwrites every sample of `s` on every
+        // reachable path (see `backend/render.rs`) — no pre-zero needed.
         fill_output_f32(s, device_ch, &mut runtime, shared, &mut local);
 
-        let out: &mut [f32] = std::slice::from_raw_parts_mut(buf_ptr as *mut f32, total);
-        out.copy_from_slice(s);
+        let out: &mut [f32] = std::slice::from_raw_parts_mut(buf_ptr as *mut f32, out_len);
+        out[..total].copy_from_slice(s);
+        if total < out_len {
+            // Unreachable in practice (see above) — silence rather than leave
+            // the tail of the exclusive-mode buffer holding stale samples.
+            out[total..].fill(0.0);
+        }
 
         if let Err(e) = render.ReleaseBuffer(frames, 0) {
             eprintln!("[DAUx WASAPI Excl] ReleaseBuffer: {e}");

--- a/crates/SphereDirectAudioEngine/src/backend/wdm_ks.rs
+++ b/crates/SphereDirectAudioEngine/src/backend/wdm_ks.rs
@@ -809,9 +809,9 @@ unsafe fn render_into_ring(
     while remaining > 0 {
         let chunk = remaining.min(stream.period_frames) as usize;
         let n = chunk * ch;
-        for x in scratch[..n].iter_mut() {
-            *x = 0.0;
-        }
+        // `fill_output_f32` fully overwrites every sample of its output slice
+        // on every reachable path (see `backend/render.rs`) — no pre-zero
+        // needed.
         fill_output_f32(&mut scratch[..n], ch, runtime, shared, local);
 
         for (i, &s) in scratch[..n].iter().enumerate() {

--- a/crates/SphereDirectAudioEngine/src/engine/render.rs
+++ b/crates/SphereDirectAudioEngine/src/engine/render.rs
@@ -1819,16 +1819,29 @@ pub(crate) fn apply_external_bridge_insert_block(
         // 0). Every active VST3 output bus routes to an explicit child mixer
         // track, including bus 0. With explicit children present the parent
         // instrument track does not receive a fallback downmix.
-        const MAX_BRIDGE_CHANNELS: usize = 32;
-        let channels = (sink.plugin_output_channels() as usize).clamp(1, MAX_BRIDGE_CHANNELS);
+        let channels = (sink.plugin_output_channels() as usize)
+            .clamp(1, crate::runtime::MAX_VSTI_OUTPUT_CHANNELS as usize);
         let needed = frames * channels;
-        insert.scratch_multi.resize(needed, 0.0);
-        let (got, channels) =
-            sink.read_output_multichannel(&mut insert.scratch_multi[..needed], frames);
-        let _ = channels;
-        insert.scratch_l[..got].fill(0.0);
-        insert.scratch_r[..got].fill(0.0);
-        got
+        // `resolve_bridge_sinks` reserves `scratch_multi`'s *capacity* on the
+        // control thread for every insert with `vsti_output_children`, so
+        // `resize` below only ever adjusts `.len()` within that reserved
+        // capacity — it does not allocate on the audio thread.
+        // `scatter_vsti_output_children` recovers the channel stride from
+        // `scratch_multi.len() / frames`, so the resize must still land at
+        // exactly `needed`; skip the read entirely (leaving length/capacity
+        // untouched) in the otherwise-unreached case where capacity falls
+        // short, rather than growing here.
+        if insert.scratch_multi.capacity() < needed {
+            0
+        } else {
+            insert.scratch_multi.resize(needed, 0.0);
+            let (got, channels) =
+                sink.read_output_multichannel(&mut insert.scratch_multi[..needed], frames);
+            let _ = channels;
+            insert.scratch_l[..got].fill(0.0);
+            insert.scratch_r[..got].fill(0.0);
+            got
+        }
     };
 
     // A miss can mean the host still owns the previous request's input buffer.

--- a/crates/SphereDirectAudioEngine/src/runtime.rs
+++ b/crates/SphereDirectAudioEngine/src/runtime.rs
@@ -830,7 +830,9 @@ pub type InsertDspState = AudioPluginDspState;
 
 const DEFAULT_AUDIO_BLOCK_CAPACITY: usize = 8192;
 const ENABLED_AUDIO_OUTPUT_CHANNELS_PARAM: &str = "enabledAudioOutputChannels";
-const MAX_VSTI_OUTPUT_CHANNELS: u64 = 32;
+/// Also bounds `scratch_multi` pre-sizing in [`RuntimeProject::resolve_bridge_sinks`]
+/// and the audio-thread read in `apply_external_bridge_insert_block` — keep in sync.
+pub(crate) const MAX_VSTI_OUTPUT_CHANNELS: u64 = 32;
 
 fn bridge_enabled_output_channels_from_params(params: &HashMap<String, Value>) -> Vec<u8> {
     let Some(values) = params
@@ -1288,6 +1290,8 @@ impl RuntimeProject {
         let sinks = &self.plugin_bridge_sinks;
         let min_scratch =
             DEFAULT_AUDIO_BLOCK_CAPACITY.max(crate::plugin_bridge::MAX_BRIDGE_BLOCK_FRAMES);
+        // Worst-case interleaved multi-out read: every bridge channel enabled.
+        let min_scratch_multi = min_scratch * MAX_VSTI_OUTPUT_CHANNELS as usize;
         for track in &mut self.tracks {
             for insert in &mut track.inserts {
                 if insert.kind_tag == RuntimeInsertKind::ExternalBridge {
@@ -1297,6 +1301,25 @@ impl RuntimeProject {
                     if insert.scratch_l.len() < min_scratch {
                         insert.scratch_l.resize(min_scratch, 0.0);
                         insert.scratch_r.resize(min_scratch, 0.0);
+                    }
+                    // Only inserts actually routing to child "Out Ch" tracks read
+                    // through `scratch_multi` (see `apply_external_bridge_insert_block`);
+                    // pre-reserving every bridge insert would waste ~1 MiB each on
+                    // the common single-track-fold path.
+                    //
+                    // Reserve *capacity* only, never touch `.len()`: the audio
+                    // thread's `resize(needed, 0.0)` must land `scratch_multi` at
+                    // exactly `frames * channels`, which `scatter_vsti_output_children`
+                    // relies on to recover the channel stride. Reserving capacity
+                    // here makes that `resize` allocation-free without disturbing
+                    // that invariant.
+                    if !insert.vsti_output_children.is_empty() {
+                        let len = insert.scratch_multi.len();
+                        if insert.scratch_multi.capacity() < min_scratch_multi {
+                            insert
+                                .scratch_multi
+                                .reserve(min_scratch_multi.saturating_sub(len));
+                        }
                     }
                 }
             }

--- a/crates/SphereDirectAudioEngine/vst2bridge/src/vst2_processor.cpp
+++ b/crates/SphereDirectAudioEngine/vst2bridge/src/vst2_processor.cpp
@@ -19,6 +19,8 @@
 #include <windows.h>
 #elif defined(__APPLE__)
 #include <CoreFoundation/CoreFoundation.h>
+#else
+#include <dlfcn.h>
 #endif
 
 namespace {


### PR DESCRIPTION
## Summary
- `scratch_multi` was `resize()`'d on the **audio thread** every block for multi-out bridged plugin inserts — a real-time-safety violation (buffer growth in the audio callback). Fixed by pre-reserving its capacity on the control thread in `resolve_bridge_sinks`, so the audio-thread `resize` never reallocates, while keeping the exact `.len()` invariant `scatter_vsti_output_children` depends on to recover the channel stride.
- Removed redundant manual zero-loops in the cpal (Linux ALSA / macOS CoreAudio / Windows WASAPI Shared / ASIO), WASAPI Exclusive, and WDM-KS output callbacks — `fill_output_f32` already overwrites every sample of its output slice on every reachable path, so the pre-zero was dead work every block.
- Clamped (instead of grew) a defensively-sized scratch buffer in the WASAPI Exclusive path for the same reason (provably unreachable in practice, but still violated the no-growth rule as written).
- Unrelated one-line fix: `vst2_processor.cpp` was missing `#include <dlfcn.h>`, which broke the whole crate's build on Linux (pre-existing on `main`, unrelated to the buffer work — included only because it blocked verifying everything else).

## Test plan
- [x] `cargo test -p sphere_directaudioengine --lib` — 236 passed, including `vsti_output_children_scatter_demuxes_channel_pairs` (the test that depends on the `scratch_multi.len()` invariant)
- [x] `cargo check --workspace` — clean
- [x] `cargo fmt -p sphere_directaudioengine -- --check` — clean
- [x] `wasapi_exclusive.rs` / `wdm_ks.rs` are Windows-only and could not be compile-checked or runtime-tested on this Linux machine — needs a Windows build/runtime check before merge