### PR TITLE
fix(linux): ALSA small-buffer xruns + CLAP editor GUI on Linux

### DIFF
--- a/crates/SphereDirectAudioEngine/build.rs
+++ b/crates/SphereDirectAudioEngine/build.rs
@@ -110,6 +110,7 @@ fn build_clap_bridge(manifest_dir: &std::path::Path, vst3_bridge_root: &std::pat
         "src/clap_processor.cpp",
         "src/clap_editor_windows.cpp",
         "src/clap_editor_mac.mm",
+        "src/clap_editor_linux.cpp",
         "src/clap_editor_stub.cpp",
     ] {
         println!("cargo:rerun-if-changed={}", root.join(name).display());
@@ -139,9 +140,25 @@ fn build_clap_bridge(manifest_dir: &std::path::Path, vst3_bridge_root: &std::pat
                 .flag("-fobjc-arc")
                 .file(root.join("src/clap_editor_mac.mm"));
         }
+        "linux" => {
+            build.file(root.join("src/clap_editor_linux.cpp"));
+
+            let gtk4 = pkg_config::probe_library("gtk4").expect(
+                "GTK4 not found — install libgtk-4-dev (Debian/Ubuntu) or gtk4-devel (Fedora)",
+            );
+            for path in &gtk4.include_paths {
+                build.include(path);
+            }
+            for (key, val) in &gtk4.defines {
+                build.define(key, val.as_deref());
+            }
+
+            println!("cargo:rustc-link-lib=dl");
+            println!("cargo:rustc-link-lib=X11");
+        }
         _ => {
-            // Linux and anything else: CLAP plug-ins still load and process;
-            // only the embedded editor is stubbed out.
+            // Anything else: CLAP plug-ins still load and process; only the
+            // embedded editor is stubbed out.
             build.file(root.join("src/clap_editor_stub.cpp"));
         }
     }

--- a/crates/SphereDirectAudioEngine/clapbridge/include/clap_processor_internal.hpp
+++ b/crates/SphereDirectAudioEngine/clapbridge/include/clap_processor_internal.hpp
@@ -75,6 +75,26 @@ unsigned long long clap_embed_editor_mac(SphereDauxClapProcessor *,
 void clap_embed_set_bounds_mac(SphereDauxClapProcessor *, int, int, int, int);
 void clap_close_editor_mac(SphereDauxClapProcessor *);
 int clap_focus_editor_mac(SphereDauxClapProcessor *);
+#elif defined(__linux__)
+unsigned long long clap_open_editor_linux(SphereDauxClapProcessor *,
+                                          const char *, const char *, int,
+                                          int);
+void clap_close_editor_linux(SphereDauxClapProcessor *);
+int clap_focus_editor_linux(SphereDauxClapProcessor *);
+
+// Host side of clap.posix-fd-support / clap.timer-support — CLAP's Linux
+// equivalent of VST3's Linux::IRunLoop, for the minority of GUI-bearing
+// plug-ins that register fds/timers with the host instead of running their
+// own loop. Implemented in clap_editor_linux.cpp (bridged onto the GTK
+// thread's GLib main context); advertised from clap_processor.cpp's
+// host_get_extension only on this platform, since Win32/Cocoa editors don't
+// need it.
+bool clap_host_register_fd_linux(const clap_host_t *, int,
+                                 clap_posix_fd_flags_t);
+bool clap_host_modify_fd_linux(const clap_host_t *, int, clap_posix_fd_flags_t);
+bool clap_host_unregister_fd_linux(const clap_host_t *, int);
+bool clap_host_register_timer_linux(const clap_host_t *, uint32_t, clap_id *);
+bool clap_host_unregister_timer_linux(const clap_host_t *, clap_id);
 #endif
 
 /// One CLAP event as it sits in our preallocated input list. CLAP events are a
@@ -256,6 +276,8 @@ struct SphereDauxClapProcessor {
   void *editor_native_window{nullptr};   // NSWindow*
   void *editor_native_embed{nullptr};    // NSView* handed to gui->set_parent
   void *editor_native_delegate{nullptr}; // DauxClapEditorWindowDelegate*
+#elif defined(__linux__)
+  void *editor_native_window{nullptr}; // GtkWidget* (GtkWindow), g_object_ref'd
 #endif
 
   // ── Lifecycle ────────────────────────────────────────────────────────────

--- a/crates/SphereDirectAudioEngine/clapbridge/src/clap_editor_linux.cpp
+++ b/crates/SphereDirectAudioEngine/clapbridge/src/clap_editor_linux.cpp
@@ -1,0 +1,663 @@
+// clap_editor_linux.cpp — GTK4 + X11 CLAP GUI hosting for Linux.
+//
+// CLAP's Linux embedding uses CLAP_WINDOW_API_X11 ("x11", XEmbed, physical
+// pixels) — there is no standardized Wayland embedding surface for a foreign
+// plug-in window (clap/ext/gui.h says so directly: "embed is currently not
+// supported, use floating windows" for CLAP_WINDOW_API_WAYLAND), so this
+// mirrors what vst3bridge/src/editor_linux.cpp already does for VST3 on
+// Linux: a host-owned top-level GtkWindow realized on X11 (XWayland when the
+// Studio itself runs under pure Wayland), never a GPUI-embedded child.
+//
+// Architecture, shared with editor_linux.cpp:
+//  - GTK4 and its GLib main loop run on a dedicated background thread (the
+//    "GTK thread"), started lazily on first editor open.
+//  - Every GTK/GLib call is executed on that thread via g_idle_add(),
+//    synchronised with a mutex + condvar so the IPC/main thread can wait for
+//    the result.
+//
+// Unlike VST3, CLAP has no per-plugin "run loop" object queried off a host
+// frame. A GUI-bearing plug-in instead advertises clap.posix-fd-support /
+// clap.timer-support on itself and expects the *host* to offer the matching
+// host-side extension (queried through clap_host_t::get_extension, which is
+// shared cross-platform code in clap_processor.cpp). Those host extension
+// callbacks are implemented below and bridge straight onto this file's GTK
+// thread — the direct analogue of vst3bridge's LinuxRunLoopFrame.
+
+#if defined(_WIN32) || defined(__APPLE__)
+#error "clap_editor_linux.cpp must not be compiled on Windows or macOS"
+#endif
+
+#include "clap_processor_internal.hpp"
+
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include <gtk/gtk.h>
+#include <glib-unix.h>
+
+#ifdef GDK_WINDOWING_X11
+#include <gdk/x11/gdkx.h>
+#include <X11/Xlib.h>
+#endif
+
+namespace {
+
+// ── GTK main-loop thread ────────────────────────────────────────────────────
+// Identical pattern to vst3bridge/src/editor_linux.cpp::gtk_thread_main /
+// ensure_gtk — kept as a separate instance here (not shared) because the two
+// bridges are independent static libraries with no common runtime, matching
+// how Windows/macOS already give each format its own editor TU.
+
+GMainLoop *s_main_loop = nullptr;
+std::mutex s_init_mutex;
+std::condition_variable s_init_cv;
+bool s_gtk_ready = false;
+
+void gtk_thread_main() {
+  // Must run before any other Xlib call in the process — see the identical
+  // comment in vst3bridge/src/editor_linux.cpp::gtk_thread_main. Both bridges
+  // can have an editor open at once, so both independently guard this.
+  XInitThreads();
+  gtk_init(); // GTK4: no argc/argv
+
+  {
+    std::lock_guard<std::mutex> lk(s_init_mutex);
+    s_main_loop = g_main_loop_new(nullptr, FALSE);
+    s_gtk_ready = true;
+  }
+  s_init_cv.notify_all();
+
+  g_main_loop_run(s_main_loop); // blocks until g_main_loop_quit()
+
+  g_main_loop_unref(s_main_loop);
+  s_main_loop = nullptr;
+}
+
+bool ensure_gtk() {
+  static std::once_flag once;
+  std::call_once(once, [] { std::thread(gtk_thread_main).detach(); });
+
+  std::unique_lock<std::mutex> lk(s_init_mutex);
+  return s_init_cv.wait_for(lk, std::chrono::seconds(5),
+                            [] { return s_gtk_ready; });
+}
+
+// ── clap.posix-fd-support / clap.timer-support (host side) ─────────────────
+//
+// Every registration/callback here runs on the GTK thread: CLAP's GUI-related
+// calls are main-thread-only, and for these instances "main thread" is the
+// GTK thread once an editor is open (register_fd/register_timer typically
+// arrive from inside clap_plugin_gui->create(), which we already call from
+// there). CLAP gives no explicit "instance is gone" fd/timer teardown, unlike
+// VST3's removed()/IRunLoop pairing, so the host sweeps every registration
+// for a processor when its editor closes.
+
+struct RunLoopReg {
+  SphereDauxClapProcessor *proc{nullptr};
+  int fd{-1};          // -1 for timer registrations
+  clap_id timer_id{0}; // 0 for fd registrations
+  guint source_id{0};
+};
+
+std::mutex s_run_loop_mutex;
+std::unordered_map<SphereDauxClapProcessor *, std::vector<RunLoopReg *>>
+    s_run_loop_regs;
+std::atomic<clap_id> s_next_timer_id{1};
+
+gboolean run_loop_fd_cb(gint fd, GIOCondition condition, gpointer user_data) {
+  auto *reg = static_cast<RunLoopReg *>(user_data);
+  SphereDauxClapProcessor *proc = reg->proc;
+  if (proc && proc->plugin) {
+    const auto *ext = static_cast<const clap_plugin_posix_fd_support_t *>(
+        proc->plugin->get_extension(proc->plugin, CLAP_EXT_POSIX_FD_SUPPORT));
+    if (ext && ext->on_fd) {
+      clap_posix_fd_flags_t flags = 0;
+      if (condition & G_IO_IN)
+        flags |= CLAP_POSIX_FD_READ;
+      if (condition & G_IO_OUT)
+        flags |= CLAP_POSIX_FD_WRITE;
+      if (condition & (G_IO_ERR | G_IO_HUP))
+        flags |= CLAP_POSIX_FD_ERROR;
+      ext->on_fd(proc->plugin, fd, flags);
+    }
+  }
+  return G_SOURCE_CONTINUE;
+}
+
+gboolean run_loop_timer_cb(gpointer user_data) {
+  auto *reg = static_cast<RunLoopReg *>(user_data);
+  SphereDauxClapProcessor *proc = reg->proc;
+  if (proc && proc->plugin) {
+    const auto *ext = static_cast<const clap_plugin_timer_support_t *>(
+        proc->plugin->get_extension(proc->plugin, CLAP_EXT_TIMER_SUPPORT));
+    if (ext && ext->on_timer) {
+      ext->on_timer(proc->plugin, reg->timer_id);
+    }
+  }
+  return G_SOURCE_CONTINUE;
+}
+
+void register_run_loop_reg(SphereDauxClapProcessor *proc, RunLoopReg *reg) {
+  std::lock_guard<std::mutex> lk(s_run_loop_mutex);
+  s_run_loop_regs[proc].push_back(reg);
+}
+
+/// Remove and delete every registration belonging to `proc`. Called from
+/// close_editor_on_gtk_thread so a closed editor cannot leave a plug-in's
+/// fd/timer callbacks firing into a destroyed GUI.
+void release_run_loop_regs(SphereDauxClapProcessor *proc) {
+  std::vector<RunLoopReg *> regs;
+  {
+    std::lock_guard<std::mutex> lk(s_run_loop_mutex);
+    auto it = s_run_loop_regs.find(proc);
+    if (it == s_run_loop_regs.end()) {
+      return;
+    }
+    regs = std::move(it->second);
+    s_run_loop_regs.erase(it);
+  }
+  for (auto *reg : regs) {
+    if (reg->source_id) {
+      g_source_remove(reg->source_id);
+    }
+    delete reg;
+  }
+}
+
+} // namespace
+
+bool clap_host_register_fd_linux(const clap_host_t *host, int fd,
+                                 clap_posix_fd_flags_t flags) {
+  auto *proc = host ? static_cast<SphereDauxClapProcessor *>(host->host_data)
+                    : nullptr;
+  if (!proc || fd < 0) {
+    return false;
+  }
+  GIOCondition condition = static_cast<GIOCondition>(G_IO_ERR | G_IO_HUP);
+  if (flags & CLAP_POSIX_FD_READ) {
+    condition = static_cast<GIOCondition>(condition | G_IO_IN);
+  }
+  if (flags & CLAP_POSIX_FD_WRITE) {
+    condition = static_cast<GIOCondition>(condition | G_IO_OUT);
+  }
+  auto *reg = new RunLoopReg{proc, fd, 0, 0};
+  reg->source_id = g_unix_fd_add_full(G_PRIORITY_DEFAULT, fd, condition,
+                                      run_loop_fd_cb, reg, nullptr);
+  register_run_loop_reg(proc, reg);
+  return true;
+}
+
+bool clap_host_unregister_fd_linux(const clap_host_t *host, int fd) {
+  auto *proc = host ? static_cast<SphereDauxClapProcessor *>(host->host_data)
+                    : nullptr;
+  if (!proc) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lk(s_run_loop_mutex);
+  auto it = s_run_loop_regs.find(proc);
+  if (it == s_run_loop_regs.end()) {
+    return false;
+  }
+  auto &regs = it->second;
+  for (auto vit = regs.begin(); vit != regs.end(); ++vit) {
+    if ((*vit)->timer_id == 0 && (*vit)->fd == fd) {
+      if ((*vit)->source_id) {
+        g_source_remove((*vit)->source_id);
+      }
+      delete *vit;
+      regs.erase(vit);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool clap_host_modify_fd_linux(const clap_host_t *host, int fd,
+                               clap_posix_fd_flags_t flags) {
+  // GLib has no in-place condition update for a live g_unix_fd_add_full
+  // source, so the simplest correct implementation is unregister + re-add.
+  if (!clap_host_unregister_fd_linux(host, fd)) {
+    return false;
+  }
+  return clap_host_register_fd_linux(host, fd, flags);
+}
+
+bool clap_host_register_timer_linux(const clap_host_t *host,
+                                    uint32_t period_ms, clap_id *timer_id) {
+  auto *proc = host ? static_cast<SphereDauxClapProcessor *>(host->host_data)
+                    : nullptr;
+  if (!proc || !timer_id) {
+    return false;
+  }
+  const clap_id id = s_next_timer_id.fetch_add(1, std::memory_order_relaxed);
+  auto *reg = new RunLoopReg{proc, -1, id, 0};
+  reg->source_id =
+      g_timeout_add_full(G_PRIORITY_DEFAULT, period_ms == 0 ? 1 : period_ms,
+                         run_loop_timer_cb, reg, nullptr);
+  register_run_loop_reg(proc, reg);
+  *timer_id = id;
+  return true;
+}
+
+bool clap_host_unregister_timer_linux(const clap_host_t *host,
+                                      clap_id timer_id) {
+  auto *proc = host ? static_cast<SphereDauxClapProcessor *>(host->host_data)
+                    : nullptr;
+  if (!proc) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lk(s_run_loop_mutex);
+  auto it = s_run_loop_regs.find(proc);
+  if (it == s_run_loop_regs.end()) {
+    return false;
+  }
+  auto &regs = it->second;
+  for (auto vit = regs.begin(); vit != regs.end(); ++vit) {
+    if ((*vit)->fd < 0 && (*vit)->timer_id == timer_id) {
+      if ((*vit)->source_id) {
+        g_source_remove((*vit)->source_id);
+      }
+      delete *vit;
+      regs.erase(vit);
+      return true;
+    }
+  }
+  return false;
+}
+
+// ── Window open/close/focus ─────────────────────────────────────────────────
+
+namespace {
+
+void close_editor_on_gtk_thread(SphereDauxClapProcessor *proc);
+
+struct OpenTask {
+  SphereDauxClapProcessor *proc{nullptr};
+  const char *window_id{nullptr};
+  const char *title{nullptr};
+  int width{0};
+  int height{0};
+
+  unsigned long long result{0};
+  std::mutex done_mutex;
+  std::condition_variable done_cv;
+  bool done{false};
+};
+
+gboolean idle_open_editor(gpointer user_data) {
+  auto *task = static_cast<OpenTask *>(user_data);
+  SphereDauxClapProcessor *p = task->proc;
+
+  if (!p->plugin || !p->ext_gui) {
+    clap_set_last_error("CLAP editor: plug-in exposes no GUI");
+    goto done;
+  }
+
+#ifndef GDK_WINDOWING_X11
+  clap_set_last_error(
+      "DAUx CLAP editor: built without GDK X11 backend support");
+  goto done;
+#else
+  if (!p->ext_gui->is_api_supported ||
+      !p->ext_gui->is_api_supported(p->plugin, CLAP_WINDOW_API_X11, false)) {
+    clap_set_last_error("CLAP plug-in does not support an embedded X11 GUI");
+    goto done;
+  }
+
+  {
+    p->editor_window_id = task->window_id ? task->window_id : "";
+    if (task->title && *task->title) {
+      p->editor_title = task->title;
+    }
+    const char *title_str =
+        p->editor_title.empty() ? "Plug-in Editor" : p->editor_title.c_str();
+
+    int w = task->width > 0 ? task->width : 640;
+    int h = task->height > 0 ? task->height : 480;
+
+    GtkWidget *window = gtk_window_new();
+    gtk_window_set_title(GTK_WINDOW(window), title_str);
+    gtk_window_set_default_size(GTK_WINDOW(window), w, h);
+    gtk_window_set_resizable(GTK_WINDOW(window), TRUE);
+
+    GtkCssProvider *css = gtk_css_provider_new();
+    gtk_css_provider_load_from_string(css, "window { background-color: #0b0f14; }");
+    gtk_style_context_add_provider_for_display(
+        gtk_widget_get_display(window), GTK_STYLE_PROVIDER(css),
+        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    g_object_unref(css);
+
+    // Realize before querying/attaching: forces the underlying X11 window
+    // (and XID) to exist, matching editor_linux.cpp's VST3 sequence.
+    gtk_widget_realize(window);
+
+    GdkSurface *surface = gtk_native_get_surface(GTK_NATIVE(window));
+    if (!GDK_IS_X11_SURFACE(surface)) {
+      clap_set_last_error(
+          "DAUx CLAP editor: GDK backend is not X11 — CLAP embedding "
+          "requires an X11 display (set GDK_BACKEND=x11)");
+      gtk_window_destroy(GTK_WINDOW(window));
+      goto done;
+    }
+    Window xid = gdk_x11_surface_get_xid(surface);
+
+    if (!p->gui_created) {
+      if (!p->ext_gui->create ||
+          !p->ext_gui->create(p->plugin, CLAP_WINDOW_API_X11, false)) {
+        clap_set_last_error("clap_plugin_gui->create() returned false");
+        gtk_window_destroy(GTK_WINDOW(window));
+        goto done;
+      }
+      p->gui_created = true;
+    }
+
+    if (p->ext_gui->set_scale) {
+      const double scale = gdk_surface_get_scale_factor(surface);
+      p->ext_gui->set_scale(p->plugin, scale > 0.0 ? scale : 1.0);
+    }
+
+    p->preferred_gui_size(&w, &h);
+    gtk_window_set_default_size(GTK_WINDOW(window), w, h);
+
+    clap_window_t clap_window{};
+    clap_window.api = CLAP_WINDOW_API_X11;
+    clap_window.x11 = xid;
+    if (!p->ext_gui->set_parent ||
+        !p->ext_gui->set_parent(p->plugin, &clap_window)) {
+      clap_set_last_error("clap_plugin_gui->set_parent() returned false");
+      if (p->ext_gui->destroy) {
+        p->ext_gui->destroy(p->plugin);
+      }
+      p->gui_created = false;
+      gtk_window_destroy(GTK_WINDOW(window));
+      goto done;
+    }
+
+    gtk_window_present(GTK_WINDOW(window));
+
+    if (p->ext_gui->show) {
+      p->ext_gui->show(p->plugin);
+    }
+
+    // Re-query after show: some plug-ins only settle their size once visible.
+    p->preferred_gui_size(&w, &h);
+    if (w > 0 && h > 0) {
+      p->embed_content_w = w;
+      p->embed_content_h = h;
+      gtk_window_set_default_size(GTK_WINDOW(window), w, h);
+    }
+
+    p->editor_attached = true;
+    p->embed_mode = false;
+    p->embed_host_kind = 2; // detached top-level, matches clap_editor_mac.mm
+
+    g_object_ref(window);
+    p->editor_native_window = window;
+    p->editor_handle = clap_next_editor_handle();
+
+    struct CloseCtx {
+      SphereDauxClapProcessor *proc;
+    };
+    auto *close_ctx = new CloseCtx{p};
+    g_signal_connect_data(
+        window, "close-request",
+        G_CALLBACK(+[](GtkWindow *, gpointer ud) -> gboolean {
+          auto *ctx = static_cast<CloseCtx *>(ud);
+          if (ctx->proc) {
+            ctx->proc->embed_user_closed.store(true, std::memory_order_release);
+            close_editor_on_gtk_thread(ctx->proc);
+          }
+          return TRUE; // we tear the window down ourselves
+        }),
+        close_ctx,
+        [](gpointer data, GClosure *) { delete static_cast<CloseCtx *>(data); },
+        G_CONNECT_DEFAULT);
+
+    std::fprintf(stderr,
+                 "[clap-editor/linux] opened handle=%llu xid=0x%lx size=%dx%d\n",
+                 p->editor_handle, xid, w, h);
+
+    task->result = p->editor_handle;
+  }
+#endif // GDK_WINDOWING_X11
+
+done:
+  {
+    std::lock_guard<std::mutex> lk(task->done_mutex);
+    task->done = true;
+  }
+  task->done_cv.notify_all();
+  return G_SOURCE_REMOVE;
+}
+
+struct DestroyWindowTask {
+  GtkWidget *window{nullptr};
+};
+
+// Deferred destroy, off the close-request call stack: GTK4/GDK can assert if
+// the surface still has a live EGL native window (common right after a
+// GL-backed plug-in editor detaches) — see the identical rationale in
+// vst3bridge/src/editor_linux.cpp::idle_destroy_editor_window.
+gboolean idle_destroy_editor_window(gpointer user_data) {
+  auto *task = static_cast<DestroyWindowTask *>(user_data);
+  for (int i = 0; i < 8; ++i) {
+    if (!g_main_context_iteration(nullptr, FALSE))
+      break;
+  }
+  if (task->window) {
+    gtk_widget_set_visible(task->window, FALSE);
+    for (int i = 0; i < 4; ++i) {
+      if (!g_main_context_iteration(nullptr, FALSE))
+        break;
+    }
+    gtk_window_destroy(GTK_WINDOW(task->window));
+    g_object_unref(task->window); // matches g_object_ref in idle_open_editor
+    task->window = nullptr;
+  }
+  delete task;
+  std::fprintf(stderr, "[clap-editor/linux] closed\n");
+  return G_SOURCE_REMOVE;
+}
+
+// Shared by idle_close_editor (cross-thread close request) and the window's
+// own close-request handler (both already run on the GTK thread). Must NOT
+// go through clap_close_editor_linux() from the close-request handler — that
+// g_idle_add()s and blocks waiting for an idle source that can only run once
+// the handler returns (self-deadlock). Idempotent.
+void close_editor_on_gtk_thread(SphereDauxClapProcessor *proc) {
+  if (!proc->editor_native_window) {
+    return;
+  }
+  auto *window = static_cast<GtkWidget *>(proc->editor_native_window);
+
+  if (proc->gui_created && proc->plugin && proc->ext_gui) {
+    if (proc->ext_gui->hide) {
+      proc->ext_gui->hide(proc->plugin);
+    }
+    if (proc->ext_gui->destroy) {
+      proc->ext_gui->destroy(proc->plugin);
+    }
+    proc->gui_created = false;
+  }
+  proc->editor_attached = false;
+  proc->embed_mode = false;
+  proc->editor_native_window = nullptr;
+  proc->editor_handle = 0;
+
+  release_run_loop_regs(proc);
+
+  auto *task = new DestroyWindowTask{window};
+  g_idle_add(idle_destroy_editor_window, task);
+}
+
+struct CloseTask {
+  SphereDauxClapProcessor *proc{nullptr};
+  std::mutex done_mutex;
+  std::condition_variable done_cv;
+  bool done{false};
+};
+
+gboolean idle_close_editor(gpointer user_data) {
+  auto *task = static_cast<CloseTask *>(user_data);
+  close_editor_on_gtk_thread(task->proc);
+  {
+    std::lock_guard<std::mutex> lk(task->done_mutex);
+    task->done = true;
+  }
+  task->done_cv.notify_all();
+  return G_SOURCE_REMOVE;
+}
+
+} // namespace
+
+unsigned long long clap_open_editor_linux(SphereDauxClapProcessor *proc,
+                                          const char *window_id,
+                                          const char *title, int width,
+                                          int height) {
+  if (!proc) {
+    return 0;
+  }
+  if (!ensure_gtk()) {
+    clap_set_last_error("GTK4 initialisation timed out");
+    return 0;
+  }
+
+  if (proc->editor_native_window) {
+    return clap_focus_editor_linux(proc) ? proc->editor_handle : 0;
+  }
+
+  OpenTask task;
+  task.proc = proc;
+  task.window_id = window_id;
+  task.title = title;
+  task.width = width;
+  task.height = height;
+
+  g_idle_add(idle_open_editor, &task);
+
+  std::unique_lock<std::mutex> lk(task.done_mutex);
+  task.done_cv.wait(lk, [&] { return task.done; });
+  return task.result;
+}
+
+void clap_close_editor_linux(SphereDauxClapProcessor *proc) {
+  if (!proc || !proc->editor_native_window || !s_gtk_ready) {
+    return;
+  }
+
+  CloseTask task;
+  task.proc = proc;
+
+  g_idle_add(idle_close_editor, &task);
+
+  std::unique_lock<std::mutex> lk(task.done_mutex);
+  task.done_cv.wait(lk, [&] { return task.done; });
+}
+
+int clap_focus_editor_linux(SphereDauxClapProcessor *proc) {
+  if (!proc || !s_gtk_ready || !proc->editor_native_window) {
+    return 0;
+  }
+  g_idle_add(
+      [](gpointer ud) -> gboolean {
+        gtk_window_present(GTK_WINDOW(static_cast<GtkWidget *>(ud)));
+        return G_SOURCE_REMOVE;
+      },
+      proc->editor_native_window);
+  return 1;
+}
+
+// ── C API ────────────────────────────────────────────────────────────────────
+//
+// embed_*/view_* stay stubbed exactly as clap_editor_stub.cpp reports them:
+// nothing calls the GPUI-embedded or host-owned-view tiers on Linux today
+// (VST3 doesn't use them here either — see editor_linux.cpp), so implementing
+// them would be speculative.
+
+extern "C" {
+
+unsigned long long sphere_daux_clap_open_editor(SphereDauxClapProcessor *p,
+                                                const char *window_id,
+                                                const char *title, int width,
+                                                int height) {
+  return clap_open_editor_linux(p, window_id, title, width, height);
+}
+
+void sphere_daux_clap_close_editor(SphereDauxClapProcessor *p) {
+  clap_close_editor_linux(p);
+}
+
+int sphere_daux_clap_focus_editor(SphereDauxClapProcessor *p) {
+  return clap_focus_editor_linux(p);
+}
+
+unsigned long long
+sphere_daux_clap_editor_native_window(SphereDauxClapProcessor *p) {
+  if (!p) {
+    return 0;
+  }
+  return static_cast<unsigned long long>(
+      reinterpret_cast<std::uintptr_t>(p->editor_native_window));
+}
+
+unsigned long long sphere_daux_clap_embed_editor(SphereDauxClapProcessor *,
+                                                 unsigned long long, int, int,
+                                                 int, int) {
+  clap_set_last_error("CLAP embedded editor is not supported on this platform");
+  return 0;
+}
+
+void sphere_daux_clap_embed_set_bounds(SphereDauxClapProcessor *, int, int,
+                                       int, int) {}
+
+void sphere_daux_clap_embed_refresh(SphereDauxClapProcessor *) {}
+
+unsigned long long
+sphere_daux_clap_embed_attach_hwnd(SphereDauxClapProcessor *) {
+  return 0;
+}
+
+void sphere_daux_clap_embed_detach(SphereDauxClapProcessor *) {}
+
+int sphere_daux_clap_embed_is_valid(SphereDauxClapProcessor *) { return 0; }
+
+int sphere_daux_clap_embed_has_visible_ui(SphereDauxClapProcessor *) {
+  return 0;
+}
+
+// ── Host-owned view host ────────────────────────────────────────────────────
+
+int sphere_daux_clap_view_attach(SphereDauxClapProcessor *, unsigned long long,
+                                 int, int, int *, int *) {
+  clap_set_last_error("CLAP host-owned view is not supported on this platform");
+  return 0;
+}
+
+void sphere_daux_clap_view_detach(SphereDauxClapProcessor *) {}
+
+int sphere_daux_clap_view_is_attached(SphereDauxClapProcessor *) { return 0; }
+
+int sphere_daux_clap_view_set_size(SphereDauxClapProcessor *, int, int) {
+  return 0;
+}
+
+int sphere_daux_clap_view_get_size(SphereDauxClapProcessor *, int *, int *) {
+  return 0;
+}
+
+int sphere_daux_clap_view_can_resize(SphereDauxClapProcessor *) { return 0; }
+
+int sphere_daux_clap_view_constrain(SphereDauxClapProcessor *, int *, int *) {
+  return 0;
+}
+
+int sphere_daux_clap_view_take_resize_request(SphereDauxClapProcessor *, int *,
+                                              int *) {
+  return 0;
+}
+
+} // extern "C"

--- a/crates/SphereDirectAudioEngine/clapbridge/src/clap_processor.cpp
+++ b/crates/SphereDirectAudioEngine/clapbridge/src/clap_processor.cpp
@@ -254,6 +254,18 @@ const clap_host_gui_t kHostGui{host_gui_resize_hints_changed,
                                host_gui_request_resize, host_gui_request_show,
                                host_gui_request_hide, host_gui_closed};
 
+#if defined(__linux__)
+// clap.posix-fd-support / clap.timer-support: only meaningful where a plug-in
+// GUI needs the host to drive its event loop (Linux — see
+// clap_editor_linux.cpp). Windows/Cocoa editors have their own native message
+// pump and never query these.
+const clap_host_posix_fd_support_t kHostPosixFdSupport{
+    clap_host_register_fd_linux, clap_host_modify_fd_linux,
+    clap_host_unregister_fd_linux};
+const clap_host_timer_support_t kHostTimerSupport{
+    clap_host_register_timer_linux, clap_host_unregister_timer_linux};
+#endif
+
 const void *CLAP_ABI host_get_extension(const clap_host_t *,
                                         const char *extension_id) {
   if (!extension_id) {
@@ -271,6 +283,12 @@ const void *CLAP_ABI host_get_extension(const clap_host_t *,
     return &kHostState;
   if (std::strcmp(extension_id, CLAP_EXT_GUI) == 0)
     return &kHostGui;
+#if defined(__linux__)
+  if (std::strcmp(extension_id, CLAP_EXT_POSIX_FD_SUPPORT) == 0)
+    return &kHostPosixFdSupport;
+  if (std::strcmp(extension_id, CLAP_EXT_TIMER_SUPPORT) == 0)
+    return &kHostTimerSupport;
+#endif
   // Everything else is genuinely unsupported. Returning null is the contract.
   return nullptr;
 }

--- a/crates/SphereDirectAudioEngine/src/backend/cpal_backend.rs
+++ b/crates/SphereDirectAudioEngine/src/backend/cpal_backend.rs
@@ -176,16 +176,31 @@ pub(crate) fn open_on_host(
             config.mmcss_priority,
         ) {
             Ok(stream) => {
-                // `callback_frames` is what the chosen candidate predicts the
-                // callback block will be: on ALSA the period cpal derives from
-                // the ring it was handed (see `period_candidates`), elsewhere
-                // the requested size itself. cpal exposes no way to read back
-                // what the device really negotiated, so the prediction is the
-                // only answer available; `BufferSize::Default` means we never
-                // asked, so report 0 rather than guess.
-                let buf_size = match stream_config.buffer_size {
+                // `callback_frames` is what the chosen candidate *predicts* the
+                // callback block will be (on ALSA, derived from the ring — see
+                // `period_candidates`; elsewhere, the requested size itself).
+                // The ALSA backend can report what it actually negotiated via
+                // `negotiated_buffer()` (reads back `snd_pcm_hw_params`), which
+                // is the real figure when it disagrees with the prediction —
+                // dmix/PipeWire's ALSA plugin can round `_near` calls away from
+                // what was asked for. `BufferSize::Default` means we never
+                // asked, so report 0 rather than guess when no negotiated value
+                // is available either.
+                let predicted = match stream_config.buffer_size {
                     BufferSize::Fixed(_) => *callback_frames,
                     BufferSize::Default => 0,
+                };
+                let buf_size = match stream.negotiated_buffer() {
+                    Some(negotiated) => {
+                        if negotiated.period_frames != predicted && predicted != 0 {
+                            eprintln!(
+                                "[DAUx cpal] {label}: negotiated period {} frames (requested {predicted})",
+                                negotiated.period_frames
+                            );
+                        }
+                        negotiated.period_frames
+                    }
+                    None => predicted,
                 };
                 return Ok(CpalStreamHandle {
                     stream,
@@ -242,20 +257,36 @@ pub(crate) fn period_candidates(period: u32) -> Vec<(&'static str, u32, u32)> {
     const MAX_RING: u32 = crate::plugin_bridge::MAX_BRIDGE_BLOCK_FRAMES as u32;
     let periods = (MAX_RING / period.max(1)).clamp(1, ALSA_PERIODS_PER_BUFFER);
     let ring = period.saturating_mul(periods);
-    vec![
+    let mut candidates = vec![
         // Preferred: as many periods as fit, so the callback block == the
         // requested period and the rest absorbs scheduling jitter.
         ("requested (ALSA multi-period ring)", ring, period),
-        // `set_buffer_size` is an *exact* match on ALSA, and dmix / the
-        // PipeWire ALSA plugin routinely refuse the larger ring. Retry with the
-        // bare value — worse headroom, but far better than surrendering to the
-        // device default (25 ms period / 100 ms ring) as the next step would.
-        (
-            "requested (ALSA bare ring)",
-            period,
-            (period / ALSA_PERIODS_PER_BUFFER).max(1),
-        ),
-    ]
+    ];
+    // `set_buffer_size` is an *exact* match on ALSA, and dmix / the PipeWire
+    // ALSA plugin routinely refuse the larger ring above. Jumping straight
+    // from a 4-period ring to the single-period "bare ring" below quarters
+    // the callback size (`period` -> `period/4`) — worse headroom on exactly
+    // the systems most likely to reject the preferred candidate. Try a
+    // 2-period ring first: still rejectable on the same exact-match grounds,
+    // but only halves the callback instead of quartering it.
+    //
+    // Only worth trying when it's actually smaller than the preferred ring
+    // above (`periods > 2`); otherwise it would just repeat the same value.
+    if periods > 2 {
+        candidates.push((
+            "requested (ALSA 2-period ring)",
+            period.saturating_mul(2),
+            (period / 2).max(1),
+        ));
+    }
+    // Last resort before surrendering to the device default (25 ms period /
+    // 100 ms ring): the bare requested value as the whole ring.
+    candidates.push((
+        "requested (ALSA bare ring)",
+        period,
+        (period / ALSA_PERIODS_PER_BUFFER).max(1),
+    ));
+    candidates
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -461,6 +492,15 @@ where
                         eprintln!("[DAUx cpal] Stream error: {err}");
                         err_shared.device_lost.store(true, Ordering::Relaxed);
                     }
+                    // The vendored ALSA backend detects the driver-level xrun
+                    // itself (recovering via `snd_pcm_prepare`/`try_recover`)
+                    // and reports it here instead of swallowing it — this is
+                    // the only place a real ALSA underrun becomes visible to
+                    // the UI, distinct from `glitch_counter`'s broader
+                    // "something clipped a block" signal.
+                    cpal::StreamError::Underrun => {
+                        err_shared.device_xruns.fetch_add(1, Ordering::Relaxed);
+                    }
                     _ => eprintln!("[DAUx cpal] Stream error: {err}"),
                 }
             },
@@ -526,13 +566,23 @@ mod rt_priority {
 
     /// Spawn the helper that promotes the audio thread once it announces its
     /// tid. Returns immediately; the helper exits after a single attempt.
+    ///
+    /// The RealtimeKit D-Bus connection is opened here, before the helper
+    /// blocks waiting for the announce — not inside `rtkit::promote` — so the
+    /// (single-digit-to-tens-of-ms) connect handshake happens during stream
+    /// setup instead of racing the audio thread's first few callbacks. On a
+    /// stock desktop (`RLIMIT_RTPRIO` 0) RealtimeKit is the only promotion
+    /// route, and until it completes the callback thread is plain
+    /// `SCHED_OTHER`, preemptable by GPUI's own `SCHED_FIFO` compositor
+    /// thread — exactly the window this closes.
     pub fn spawn_promoter() -> Announcer {
         let (tx, rx) = bounded(1);
         let spawned = std::thread::Builder::new()
             .name("daux-rt-promote".into())
             .spawn(move || {
+                let prewarmed_bus = rtkit::connect_system_bus();
                 if let Ok(tid) = rx.recv_timeout(ANNOUNCE_TIMEOUT) {
-                    let _ = promote(tid);
+                    let _ = promote(tid, prewarmed_bus);
                 }
             });
         if let Err(e) = &spawned {
@@ -554,14 +604,14 @@ mod rt_priority {
         Unchanged,
     }
 
-    fn promote(tid: libc::pid_t) -> Outcome {
+    fn promote(tid: libc::pid_t, prewarmed_bus: Option<zbus::blocking::Connection>) -> Outcome {
         if let Some(priority) = try_sched_fifo(tid) {
             eprintln!("[DAUx] audio thread promoted to SCHED_FIFO priority {priority}");
             return Outcome::Fifo(priority);
         }
         // Expected on a stock desktop: RLIMIT_RTPRIO is 0 there, so the direct
         // syscall above is always refused and RealtimeKit is the only route.
-        match rtkit::promote(tid) {
+        match rtkit::promote(tid, prewarmed_bus) {
             Ok(priority) => {
                 eprintln!(
                     "[DAUx] audio thread promoted to SCHED_RR priority {priority} \
@@ -630,9 +680,24 @@ mod rt_priority {
         /// the daemon advertises no maximum of its own.
         const FALLBACK_RTTIME_US: u64 = 200_000;
 
-        pub fn promote(tid: libc::pid_t) -> Result<i32, String> {
-            let conn = zbus::blocking::Connection::system()
-                .map_err(|e| format!("system bus unavailable: {e}"))?;
+        /// Opened by `spawn_promoter` before it waits for the tid announce, so
+        /// the handshake is off the promotion critical path. Falls back to a
+        /// fresh connection in `promote` if this failed (daemon/bus not up
+        /// yet at helper-thread start) — same behavior as before, just no
+        /// longer the common case.
+        pub fn connect_system_bus() -> Option<zbus::blocking::Connection> {
+            zbus::blocking::Connection::system().ok()
+        }
+
+        pub fn promote(
+            tid: libc::pid_t,
+            prewarmed_bus: Option<zbus::blocking::Connection>,
+        ) -> Result<i32, String> {
+            let conn = match prewarmed_bus {
+                Some(conn) => conn,
+                None => zbus::blocking::Connection::system()
+                    .map_err(|e| format!("system bus unavailable: {e}"))?,
+            };
             let proxy = zbus::blocking::Proxy::new(&conn, SERVICE, PATH, SERVICE)
                 .map_err(|e| format!("proxy setup failed: {e}"))?;
 
@@ -713,7 +778,7 @@ mod rt_priority {
             });
             let tid = ready_rx.recv().expect("worker should report its tid");
 
-            let outcome = super::promote(tid);
+            let outcome = super::promote(tid, super::rtkit::connect_system_bus());
             // SAFETY: `tid` names the still-parked worker thread.
             let policy = unsafe { libc::sched_getscheduler(tid) };
 
@@ -837,8 +902,38 @@ mod buffer_size_tests {
     #[test]
     fn alsa_falls_back_before_surrendering_to_the_device_default() {
         let candidates = period_candidates(256);
-        assert_eq!(candidates.len(), 2, "a retry must exist");
-        assert_eq!(candidates[1].1, 256, "retry asks for the bare value");
+        assert_eq!(
+            candidates.len(),
+            3,
+            "a 2-period and a bare retry must exist"
+        );
+        assert_eq!(candidates[2].1, 256, "final retry asks for the bare value");
+    }
+
+    /// The fallback between the preferred 4-period ring and the bare ring
+    /// must not jump straight from a full-size callback to a quarter-size
+    /// one: a 2-period ring (half-size callback) belongs in between.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn middle_candidate_only_halves_the_callback() {
+        let candidates = period_candidates(256);
+        let (_, mid_fixed, mid_callback) = candidates[1];
+        assert_eq!(mid_fixed, 512, "2-period ring holds two 256-frame periods");
+        assert_eq!(mid_callback, 128, "callback halves instead of quartering");
+
+        // When the preferred ring already has 2 or fewer periods (large
+        // requests), the 2-period middle candidate would duplicate it, so it
+        // must be omitted rather than repeated.
+        assert_eq!(
+            period_candidates(1024).len(),
+            2,
+            "no middle candidate when the preferred ring already has 2 periods"
+        );
+        assert_eq!(
+            period_candidates(2048).len(),
+            2,
+            "no middle candidate when the preferred ring already has 1 period"
+        );
     }
 
     /// Small periods must not report a zero-frame callback block, which would


### PR DESCRIPTION
## Summary
- ALSA: restore `device_xruns`/`negotiated_buffer()` diagnostics dropped by an earlier formatting commit, close the RealtimeKit D-Bus promotion race by pre-connecting before the audio thread's first-callback announce, and add a 2-period ring fallback candidate so a rejected preferred ring doesn't collapse straight from a full-size callback to a quarter-size one.
- CLAP: add `clap_editor_linux.cpp` (GTK4 + X11/XEmbed), mirroring `vst3bridge/src/editor_linux.cpp`'s architecture, plus host-side `clap.posix-fd-support`/`clap.timer-support` so GUI-bearing CLAP plugins open on Linux the same way VST3 already does.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p sphere_directaudioengine`
- [x] `cargo test -p sphere_directaudioengine` (buffer_size_tests + rt_priority tests, 8/8 pass)
- [ ] Manual: open a real GUI-bearing CLAP plugin on Linux and confirm the editor window opens/resizes/closes
- [ ] Manual: confirm `device_xruns` reports real counts and fewer dropouts at 128/256-frame buffers on real hardware